### PR TITLE
Fixed Python unit tests

### DIFF
--- a/libraries/botframework-connector/tests/test_attachments.py
+++ b/libraries/botframework-connector/tests/test_attachments.py
@@ -18,7 +18,7 @@ from microsoft.botbuilder.schema import *
 from microsoft.botframework.connector import ConnectorClient
 from microsoft.botframework.connector.auth import MicrosoftTokenAuthentication
 
-from authentication_stub import MicrosoftTokenAuthenticationStub
+from .authentication_stub import MicrosoftTokenAuthenticationStub
 
 SERVICE_URL = 'https://slack.botframework.com'
 CHANNEL_ID = 'slack'
@@ -116,4 +116,4 @@ class AttachmentsTest(ReplayableTest):
             attachment_id = response.id
             attachment_view = connector.attachments.get_attachment(attachment_id, 'invalid')
 
-        assert ('Not Found' in str(excinfo.value))
+        assert ('not found' in str(excinfo.value))

--- a/libraries/botframework-connector/tests/test_conversations.py
+++ b/libraries/botframework-connector/tests/test_conversations.py
@@ -15,7 +15,7 @@ from microsoft.botbuilder.schema import *
 from microsoft.botframework.connector import ConnectorClient
 from microsoft.botframework.connector.auth import MicrosoftTokenAuthentication
 
-from authentication_stub import MicrosoftTokenAuthenticationStub
+from .authentication_stub import MicrosoftTokenAuthenticationStub
 
 SERVICE_URL = 'https://slack.botframework.com'
 CHANNEL_ID = 'slack'


### PR DESCRIPTION
Fixes failing unit tests:
-  Fixed importing `MicrosoftTokenAuthenticationStub` using relative module reference `from .authentication_stub`
- Updated assert for `test_attachments_get_attachment_view_with_invalid_view_id_fails`