### PR TITLE
add typing and microsoft.botbuilder.schema references to activity_adapter.py

### DIFF
--- a/libraries/botbuilder/microsoft/botbuilder/activity_adapter.py
+++ b/libraries/botbuilder/microsoft/botbuilder/activity_adapter.py
@@ -2,6 +2,8 @@
 # Licensed under the MIT License.
 
 from abc import ABC, abstractmethod
+from typing import List
+from microsoft.botbuilder.schema import Activity
 
 
 class ActivityAdapter(ABC):


### PR DESCRIPTION
Causes runtime errors without these two imports.