### PR TITLE
update botframework-connector tests to reference new namespaced packages

### DIFF
--- a/libraries/botframework-connector/tests/test_attachments.py
+++ b/libraries/botframework-connector/tests/test_attachments.py
@@ -14,9 +14,9 @@ import pytest
 from azure_devtools.scenario_tests import ReplayableTest
 
 import msrest
-from microsoft.botbuilder.schema import *
-from microsoft.botframework.connector import ConnectorClient
-from microsoft.botframework.connector.auth import MicrosoftAppCredentials
+from botbuilder.schema import *
+from botframework.connector import ConnectorClient
+from botframework.connector.auth import MicrosoftAppCredentials
 
 from .authentication_stub import MicrosoftTokenAuthenticationStub
 

--- a/libraries/botframework-connector/tests/test_auth.py
+++ b/libraries/botframework-connector/tests/test_auth.py
@@ -1,10 +1,10 @@
 import pytest
 
-from microsoft.botbuilder.schema import Activity
-from microsoft.botframework.connector.auth import JwtTokenValidation
-from microsoft.botframework.connector.auth import SimpleCredentialProvider
-from microsoft.botframework.connector.auth import EmulatorValidation
-from microsoft.botframework.connector.auth import ChannelValidation
+from botbuilder.schema import Activity
+from botframework.connector.auth import JwtTokenValidation
+from botframework.connector.auth import SimpleCredentialProvider
+from botframework.connector.auth import EmulatorValidation
+from botframework.connector.auth import ChannelValidation
 
 import asyncio
 

--- a/libraries/botframework-connector/tests/test_conversations.py
+++ b/libraries/botframework-connector/tests/test_conversations.py
@@ -11,9 +11,9 @@
 import pytest
 from azure_devtools.scenario_tests import ReplayableTest
 
-from microsoft.botbuilder.schema import *
-from microsoft.botframework.connector import ConnectorClient
-from microsoft.botframework.connector.auth import MicrosoftAppCredentials
+from botbuilder.schema import *
+from botframework.connector import ConnectorClient
+from botframework.connector.auth import MicrosoftAppCredentials
 
 from .authentication_stub import MicrosoftTokenAuthenticationStub
 
@@ -141,7 +141,7 @@ class ConversationTest(ReplayableTest):
             title='A static image',
             text='JPEG image',
             images=[
-                CardImage(url='https://docs.microsoft.com/en-us/bot-framework/media/designing-bots/core/dialogs-screens.png')
+                CardImage(url='https://docs.com/en-us/bot-framework/media/designing-bots/core/dialogs-screens.png')
             ])
 
         card2 = HeroCard(
@@ -158,8 +158,8 @@ class ConversationTest(ReplayableTest):
             from_property=ChannelAccount(id=BOT_ID),
             attachment_layout=AttachmentLayoutTypes.list,
             attachments=[
-                Attachment(content_type='application/vnd.microsoft.card.hero', content=card1),
-                Attachment(content_type='application/vnd.microsoft.card.hero', content=card2),
+                Attachment(content_type='application/vnd.card.hero', content=card1),
+                Attachment(content_type='application/vnd.card.hero', content=card2),
             ])
 
         connector = ConnectorClient(self.credentials, base_url=SERVICE_URL)


### PR DESCRIPTION
Removed `microsoft.` from `microsoft.botbuilder.schema` so that the imports properly work.

To run these tests, users must do the following:

1. enter `pip install -r requirements.txt`
2. enter `pytest` which will then run the tests. There should be 28 tests run.