### PR TITLE
Azure CosmosDbStorage Middleware

### DIFF
--- a/.cache/v/cache/lastfailed
+++ b/.cache/v/cache/lastfailed
@@ -1,4 +1,5 @@
 {
+  "libraries/botbuilder-azure/tests/test_cosmos_storage.py": true,
   "libraries/botframework-connector/tests/test_attachments.py": true,
   "libraries/botframework-connector/tests/test_attachments_async.py": true,
   "libraries/botframework-connector/tests/test_conversations.py": true,

--- a/.cache/v/cache/lastfailed
+++ b/.cache/v/cache/lastfailed
@@ -1,0 +1,6 @@
+{
+  "libraries/botframework-connector/tests/test_attachments.py": true,
+  "libraries/botframework-connector/tests/test_attachments_async.py": true,
+  "libraries/botframework-connector/tests/test_conversations.py": true,
+  "libraries/botframework-connector/tests/test_conversations_async.py": true
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "3.6"
 
 install:
+  - pip install -e ./libraries/botbuilder-azure
   - pip install -e ./libraries/botbuilder-schema
   - pip install -e ./libraries/botframework-connector
   - pip install -e ./libraries/botbuilder-core

--- a/libraries/botbuilder-azure/.cache/v/cache/lastfailed
+++ b/libraries/botbuilder-azure/.cache/v/cache/lastfailed
@@ -1,0 +1,4 @@
+{
+  "tests/test_cosmos_storage.py::TestCosmosDbStorage::()::test_cosmos_storage_write_should_overwrite_cached_value_with_valid_newer_e_tag": true,
+  "tests/test_cosmos_storage.py::TestCosmosDbStorage::()::test_cosmos_storage_write_should_raise_a_key_error_with_older_e_tag": true
+}

--- a/libraries/botbuilder-azure/.cache/v/cache/lastfailed
+++ b/libraries/botbuilder-azure/.cache/v/cache/lastfailed
@@ -1,4 +1,5 @@
 {
+  "tests/test_cosmos_storage.py": true,
   "tests/test_cosmos_storage.py::TestCosmosDbStorage::()::test_cosmos_storage_write_should_overwrite_cached_value_with_valid_newer_e_tag": true,
   "tests/test_cosmos_storage.py::TestCosmosDbStorage::()::test_cosmos_storage_write_should_raise_a_key_error_with_older_e_tag": true
 }

--- a/libraries/botbuilder-azure/botbuilder/azure/__init__.py
+++ b/libraries/botbuilder-azure/botbuilder/azure/__init__.py
@@ -1,0 +1,12 @@
+# coding=utf-8
+# --------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+
+from .about import __version__
+from .cosmosdb_storage import CosmosDbStorage
+
+__all__ = ['CosmosDbStorage',
+           '__version__']

--- a/libraries/botbuilder-azure/botbuilder/azure/__init__.py
+++ b/libraries/botbuilder-azure/botbuilder/azure/__init__.py
@@ -6,7 +6,8 @@
 # --------------------------------------------------------------------------
 
 from .about import __version__
-from .cosmosdb_storage import CosmosDbStorage
+from .cosmosdb_storage import CosmosDbStorage, CosmosDbConfig
 
 __all__ = ['CosmosDbStorage',
+           'CosmosDbConfig',
            '__version__']

--- a/libraries/botbuilder-azure/botbuilder/azure/about.py
+++ b/libraries/botbuilder-azure/botbuilder/azure/about.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 __title__ = 'botbuilder-azure'
-__version__ = '0.1'
+__version__ = '4.0.0.a6'
 __uri__ = 'https://www.github.com/Microsoft/botbuilder-python'
 __author__ = 'Microsoft'
 __description__ = 'Microsoft Bot Framework Bot Builder'

--- a/libraries/botbuilder-azure/botbuilder/azure/about.py
+++ b/libraries/botbuilder-azure/botbuilder/azure/about.py
@@ -1,0 +1,10 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+__title__ = 'botbuilder-azure'
+__version__ = '0.1'
+__uri__ = 'https://www.github.com/Microsoft/botbuilder-python'
+__author__ = 'Microsoft'
+__description__ = 'Microsoft Bot Framework Bot Builder'
+__summary__ = 'Microsoft Bot Framework Bot Builder SDK for Python.'
+__license__ = 'MIT'

--- a/libraries/botbuilder-azure/botbuilder/azure/cosmosdb_storage.py
+++ b/libraries/botbuilder-azure/botbuilder/azure/cosmosdb_storage.py
@@ -1,0 +1,149 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+from typing import Dict, List
+from copy import deepcopy
+import json
+from botbuilder.core.storage import Storage, StoreItem
+import azure.cosmos.cosmos_client as cosmos_client
+
+
+class CosmosDbStorage(Storage):
+    def __init__(self, config, dictionary=None):
+        super(CosmosDbStorage, self).__init__()
+        self.config = config
+        self.client = cosmos_client.CosmosClient(self.config['ENDPOINT'], {'masterKey': self.config['MASTERKEY']})
+        self.db = None
+        self.container = None
+
+    async def delete(self, keys: List[str]):
+        try:
+            #check if the database and container exists and if not create
+            if not self.container_exists:
+                self.create_db_and_container()
+            #call the function for each key
+            map(self.__delete_key, keys)
+        except TypeError as e:
+            raise e
+
+    async def __delete_key(self, key_to_delete):
+        print(f'try to delete: {self.document_link(self.sanitize_key(key_to_delete))}')
+        await self.client.DeleteItem(self.document_link(self.sanitize_key(key_to_delete)))
+
+    async def read(self, keys: List[str]):
+        try:
+            #check if the database and container exists and if not create
+            if not self.container_exists:
+                self.create_db_and_container()
+            #create a comma seperated list of keys
+            parameters = ",".join(map(self.sanitize_key, keys))
+            #create the query 
+            query = {
+                'query': f'SELECT c.id, c.realId, c.document, c._etag FROM c WHERE c.id in (@ids)',
+                "parameters": [
+                        { "name":"@ids", "value": parameters }
+                    ]
+                }
+            options = { 'enableCrossPartitionQuery': True }
+            #run the query and store the results as a list
+            results = list(self.client.QueryItems(self.container_link, query, options))
+            #return a dict with a key and a StoreItem
+            return {r.get('realId'): self.__create_si_from_result(r) for r in results}
+        except TypeError as e:
+            raise e
+
+    def __create_si_from_result(self, result):
+        #get the document item from the result and turn into a dict
+        doc = eval(result.get('document'))
+        #readd the e_tag from Cosmos
+        doc['e_tag'] = result.get('_etag')
+        #create and return the StoreItem 
+        return StoreItem(**doc)
+
+    async def write(self, changes: Dict[str, StoreItem]):
+        try:
+            #check if the database and container exists and if not create
+            if not self.container_exists:
+                self.create_db_and_container()
+                # iterate over the changes
+            for (key, change) in changes.items():
+                #store the e_tag
+                e_tag = change.e_tag
+                #create a copy of the change and delete the e_tag since CosmosDB handles that
+                change_copy = deepcopy(change)
+                del change_copy.e_tag
+                #create the new document
+                doc = {'id': self.sanitize_key(key), 'realId': key, 'document': str(change_copy)}
+                #if it's a new document, then the e_tag will be * so do an insert
+                if (e_tag == '*'):
+                    self.client.UpsertItem(database_or_Container_link=self.container_link, 
+                                document=doc, 
+                                options={'disableAutomaticIdGeneration': True}
+                                )
+                #otherwise let cosmosdb decide if its the same and replace if necessary
+                elif(len(e_tag) > 0):
+                    access_condition = { 'type': 'IfMatch', 'condition': e_tag }
+                    self.client.ReplaceItem(document_link=self.document_link(self.sanitize_key(key)), 
+                                new_document=doc, 
+                                options={'accessCondition': access_condition}
+                                )
+                #error when there is no e_tag
+                else:
+                    raise KeyError('cosmosdb_storage.wite(): etag missing')
+        except Exception as e:
+            raise e
+
+    def document_link(self, id):
+        return self.container_link + '/docs/' + id
+
+    @property
+    def container_link(self):
+        return self.database_link + '/colls/' +  self.container
+
+    @property
+    def database_link(self):
+        return 'dbs/' + self.db
+
+    @property
+    def container_exists(self):
+        return self.db and self.container
+
+    def create_db_and_container(self):
+        db_id = self.config['DOCUMENTDB_DATABASE']
+        container_name = self.config['DOCUMENTDB_CONTAINER']
+        self.db = self.get_or_create_database(self.client, db_id)
+        self.container = self.get_or_create_container(self.client, container_name)
+
+    def get_or_create_database(self, doc_client, id):
+        dbs = list(doc_client.QueryDatabases({
+            "query": "SELECT * FROM r WHERE r.id=@id",
+            "parameters": [
+                { "name":"@id", "value": id }
+            ]
+        }))
+        if len(dbs) > 0:
+            return dbs[0]['id']
+        else:
+            res = doc_client.CreateDatabase({ 'id': id })
+            return res['id']
+
+    def get_or_create_container(self, doc_client, container):        
+        containers = list(doc_client.QueryContainers(
+            self.database_link,
+            {
+                "query": "SELECT * FROM r WHERE r.id=@id",
+                "parameters": [
+                    { "name":"@id", "value": container }
+                ]
+            }
+        ))
+        if len(containers) > 0:
+            return containers[0]['id']
+        else:
+            # Create a container
+            res = doc_client.CreateContainer(self.database_link, { 'id': container })
+            return res['id']
+
+    def sanitize_key(self, key):
+        bad_chars = ['\\', '?', '/', '#', '\t', '\n', '\r']
+        return ''.join(map(lambda x: '*'+str(ord(x)) if x in bad_chars else x, key))

--- a/libraries/botbuilder-azure/botbuilder/azure/cosmosdb_storage.py
+++ b/libraries/botbuilder-azure/botbuilder/azure/cosmosdb_storage.py
@@ -1,149 +1,301 @@
+"""CosmosDB Middleware for Python Bot Framework.
+
+This is middleware to store items in CosmosDB.
+Part of the Azure Bot Framework in Python.
+"""
+
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
 from typing import Dict, List
-from copy import deepcopy
 import json
 from botbuilder.core.storage import Storage, StoreItem
 import azure.cosmos.cosmos_client as cosmos_client
+import azure.cosmos.errors as cosmos_errors
+
+
+class CosmosDbConfig():
+    """The class for CosmosDB configuration for the Azure Bot Framework."""
+
+    def __init__(self, **kwargs):
+        """Create the Config object.
+
+        :param endpoint:
+        :param masterkey:
+        :param database:
+        :param container:
+        :param filename:
+        :return CosmosDbConfig:
+        """
+        self.__config_file = kwargs.pop('filename', None)
+        if self.__config_file:
+            kwargs = json.load(open(self.__config_file))
+        self.endpoint = kwargs.pop('endpoint')
+        self.masterkey = kwargs.pop('masterkey')
+        self.database = kwargs.pop('database', 'bot_db')
+        self.container = kwargs.pop('container', 'bot_container')
 
 
 class CosmosDbStorage(Storage):
-    def __init__(self, config, dictionary=None):
+    """The class for CosmosDB middleware for the Azure Bot Framework."""
+
+    def __init__(self, config: CosmosDbConfig):
+        """Create the storage object.
+
+        :param config:
+        """
         super(CosmosDbStorage, self).__init__()
         self.config = config
-        self.client = cosmos_client.CosmosClient(self.config['ENDPOINT'], {'masterKey': self.config['MASTERKEY']})
+        self.client = cosmos_client.CosmosClient(
+            self.config.endpoint,
+            {'masterKey': self.config.masterkey}
+            )
+        # these are set by the functions that check 
+        # the presence of the db and container or creates them
         self.db = None
         self.container = None
 
-    async def delete(self, keys: List[str]):
-        try:
-            #check if the database and container exists and if not create
-            if not self.container_exists:
-                self.create_db_and_container()
-            #call the function for each key
-            map(self.__delete_key, keys)
-        except TypeError as e:
-            raise e
+    async def read(self, keys: List[str]) -> dict:
+        """Read storeitems from storage.
 
-    async def __delete_key(self, key_to_delete):
-        print(f'try to delete: {self.document_link(self.sanitize_key(key_to_delete))}')
-        await self.client.DeleteItem(self.document_link(self.sanitize_key(key_to_delete)))
-
-    async def read(self, keys: List[str]):
+        :param keys:
+        :return dict:
+        """
         try:
-            #check if the database and container exists and if not create
-            if not self.container_exists:
-                self.create_db_and_container()
-            #create a comma seperated list of keys
-            parameters = ",".join(map(self.sanitize_key, keys))
-            #create the query 
-            query = {
-                'query': f'SELECT c.id, c.realId, c.document, c._etag FROM c WHERE c.id in (@ids)',
-                "parameters": [
-                        { "name":"@ids", "value": parameters }
+            # check if the database and container exists and if not create
+            if not self.__container_exists:
+                self.__create_db_and_container()
+            if len(keys) > 0:
+                # create the parameters object
+                parameters = [
+                    {'name': f'@id{i}', 'value': f'{self.__sanitize_key(key)}'}
+                    for i, key in enumerate(keys)
                     ]
-                }
-            options = { 'enableCrossPartitionQuery': True }
-            #run the query and store the results as a list
-            results = list(self.client.QueryItems(self.container_link, query, options))
-            #return a dict with a key and a StoreItem
-            return {r.get('realId'): self.__create_si_from_result(r) for r in results}
+                # get the names of the params
+                parameter_sequence = ','.join(param.get('name')
+                                              for param in parameters)
+                # create the query
+                query = {
+                    "query":
+                    f"SELECT c.id, c.realId, c.document, c._etag \
+FROM c WHERE c.id in ({parameter_sequence})",
+                    "parameters": parameters
+                    }
+                options = {'enableCrossPartitionQuery': True}
+                # run the query and store the results as a list
+                results = list(
+                    self.client.QueryItems(
+                        self.__container_link, query, options)
+                    )
+                # return a dict with a key and a StoreItem
+                return {
+                    r.get('realId'): self.__create_si(r) for r in results
+                    }
+            else:
+                raise Exception('cosmosdb_storage.read(): \
+provide at least one key')
         except TypeError as e:
             raise e
-
-    def __create_si_from_result(self, result):
-        #get the document item from the result and turn into a dict
-        doc = eval(result.get('document'))
-        #readd the e_tag from Cosmos
-        doc['e_tag'] = result.get('_etag')
-        #create and return the StoreItem 
-        return StoreItem(**doc)
 
     async def write(self, changes: Dict[str, StoreItem]):
+        """Save storeitems to storage.
+
+        :param changes:
+        :return:
+        """
         try:
-            #check if the database and container exists and if not create
-            if not self.container_exists:
-                self.create_db_and_container()
+            # check if the database and container exists and if not create
+            if not self.__container_exists:
+                self.__create_db_and_container()
                 # iterate over the changes
             for (key, change) in changes.items():
-                #store the e_tag
+                # store the e_tag
                 e_tag = change.e_tag
-                #create a copy of the change and delete the e_tag since CosmosDB handles that
-                change_copy = deepcopy(change)
-                del change_copy.e_tag
-                #create the new document
-                doc = {'id': self.sanitize_key(key), 'realId': key, 'document': str(change_copy)}
-                #if it's a new document, then the e_tag will be * so do an insert
-                if (e_tag == '*'):
-                    self.client.UpsertItem(database_or_Container_link=self.container_link, 
-                                document=doc, 
-                                options={'disableAutomaticIdGeneration': True}
-                                )
-                #otherwise let cosmosdb decide if its the same and replace if necessary
+                # create the new document
+                doc = {'id': self.__sanitize_key(key),
+                       'realId': key,
+                       'document': self.__create_dict(change)
+                       }
+                # the e_tag will be * for new docs so do an insert
+                if (e_tag == '*' or not e_tag):
+                    self.client.UpsertItem(
+                        database_or_Container_link=self.__container_link,
+                        document=doc,
+                        options={'disableAutomaticIdGeneration': True}
+                        )
+                # if we have an etag, do opt. concurrency replace
                 elif(len(e_tag) > 0):
-                    access_condition = { 'type': 'IfMatch', 'condition': e_tag }
-                    self.client.ReplaceItem(document_link=self.document_link(self.sanitize_key(key)), 
-                                new_document=doc, 
-                                options={'accessCondition': access_condition}
-                                )
-                #error when there is no e_tag
+                    access_condition = {'type': 'IfMatch', 'condition': e_tag}
+                    self.client.ReplaceItem(
+                        document_link=self.__item_link(
+                            self.__sanitize_key(key)),
+                        new_document=doc,
+                        options={'accessCondition': access_condition}
+                        )
+                # error when there is no e_tag
                 else:
-                    raise KeyError('cosmosdb_storage.wite(): etag missing')
+                    raise Exception('cosmosdb_storage.write(): etag missing')
         except Exception as e:
             raise e
 
-    def document_link(self, id):
-        return self.container_link + '/docs/' + id
+    async def delete(self, keys: List[str]):
+        """Remove storeitems from storage.
+
+        :param keys:
+        :return:
+        """
+        try:
+            # check if the database and container exists and if not create
+            if not self.__container_exists:
+                self.__create_db_and_container()
+            # call the function for each key
+            for k in keys:
+                self.client.DeleteItem(
+                    document_link=self.__item_link(self.__sanitize_key(k)))
+                # print(res)
+        except cosmos_errors.HTTPFailure as h:
+            # print(h.status_code)
+            if h.status_code != 404:
+                raise h
+        except TypeError as e:
+            raise e
+
+    def __create_si(self, result) -> StoreItem:
+        """Create a StoreItem from a result out of CosmosDB.
+
+        :param result:
+        :return StoreItem:
+        """
+        # get the document item from the result and turn into a dict
+        doc = result.get('document')
+        # readd the e_tag from Cosmos
+        doc['e_tag'] = result.get('_etag')
+        # create and return the StoreItem
+        return StoreItem(**doc)
+
+    def __create_dict(self, si: StoreItem) -> Dict:
+        """Return the dict of a StoreItem.
+
+        This eliminates non_magic attributes and the e_tag.
+
+        :param si:
+        :return dict:
+        """
+        # read the content
+        non_magic_attr = ([attr for attr in dir(si)
+                          if not attr.startswith('_') or attr.__eq__('e_tag')])
+        # loop through attributes and write and return a dict
+        return ({attr: getattr(si, attr)
+                for attr in non_magic_attr})
+
+    def __sanitize_key(self, key) -> str:
+        """Return the sanitized key.
+
+        Replace characters that are not allowed in keys in Cosmos.
+
+        :param key:
+        :return str:
+        """
+        # forbidden characters
+        bad_chars = ['\\', '?', '/', '#', '\t', '\n', '\r']
+        # replace those with with '*' and the
+        # Unicode code point of the character and return the new string
+        return ''.join(
+            map(
+                lambda x: '*'+str(ord(x)) if x in bad_chars else x, key
+                )
+            )
+
+    def __item_link(self, id) -> str:
+        """Return the item link of a item in the container.
+
+        :param id:
+        :return str:
+        """
+        return self.__container_link + '/docs/' + id
 
     @property
-    def container_link(self):
-        return self.database_link + '/colls/' +  self.container
+    def __container_link(self) -> str:
+        """Return the container link in the database.
+
+        :param:
+        :return str:
+        """
+        return self.__database_link + '/colls/' + self.container
 
     @property
-    def database_link(self):
+    def __database_link(self) -> str:
+        """Return the database link.
+
+        :return str:
+        """
         return 'dbs/' + self.db
 
     @property
-    def container_exists(self):
+    def __container_exists(self) -> bool:
+        """Return whether the database and container have been created.
+
+        :return bool:
+        """
         return self.db and self.container
 
-    def create_db_and_container(self):
-        db_id = self.config['DOCUMENTDB_DATABASE']
-        container_name = self.config['DOCUMENTDB_CONTAINER']
-        self.db = self.get_or_create_database(self.client, db_id)
-        self.container = self.get_or_create_container(self.client, container_name)
+    def __create_db_and_container(self):
+        """Call the get or create methods."""
+        db_id = self.config.database
+        container_name = self.config.container
+        self.db = self.__get_or_create_database(self.client, db_id)
+        self.container = self.__get_or_create_container(
+            self.client, container_name
+            )
 
-    def get_or_create_database(self, doc_client, id):
+    def __get_or_create_database(self, doc_client, id) -> str:
+        """Return the database link.
+
+        Check if the database exists or create the db.
+
+        :param doc_client:
+        :param id:
+        :return str:
+        """
+        # query CosmosDB for a database with that name/id
         dbs = list(doc_client.QueryDatabases({
             "query": "SELECT * FROM r WHERE r.id=@id",
             "parameters": [
-                { "name":"@id", "value": id }
+                {"name": "@id", "value": id}
             ]
         }))
+        # if there are results, return the first (db names are unique)
         if len(dbs) > 0:
             return dbs[0]['id']
         else:
-            res = doc_client.CreateDatabase({ 'id': id })
+            # create the database if it didn't exist
+            res = doc_client.CreateDatabase({'id': id})
             return res['id']
 
-    def get_or_create_container(self, doc_client, container):        
+    def __get_or_create_container(self, doc_client, container) -> str:
+        """Return the container link.
+
+        Check if the container exists or create the container.
+
+        :param doc_client:
+        :param container:
+        :return str:
+        """
+        # query CosmosDB for a container in the database with that name
         containers = list(doc_client.QueryContainers(
-            self.database_link,
+            self.__database_link,
             {
                 "query": "SELECT * FROM r WHERE r.id=@id",
                 "parameters": [
-                    { "name":"@id", "value": container }
+                    {"name": "@id", "value": container}
                 ]
             }
         ))
+        # if there are results, return the first (container names are unique)
         if len(containers) > 0:
             return containers[0]['id']
         else:
-            # Create a container
-            res = doc_client.CreateContainer(self.database_link, { 'id': container })
+            # Create a container if it didn't exist
+            res = doc_client.CreateContainer(
+                self.__database_link, {'id': container})
             return res['id']
-
-    def sanitize_key(self, key):
-        bad_chars = ['\\', '?', '/', '#', '\t', '\n', '\r']
-        return ''.join(map(lambda x: '*'+str(ord(x)) if x in bad_chars else x, key))

--- a/libraries/botbuilder-azure/setup.py
+++ b/libraries/botbuilder-azure/setup.py
@@ -6,7 +6,7 @@ import os
 
 NAME = "botbuilder-azure"
 VERSION = "0.1"
-REQUIRES = ['azure.cosmos==3.0.0',
+REQUIRES = ['azure-cosmos==3.0.0',
             'botbuilder-schema>=4.0.0.a6',
             'botframework-connector>=4.0.0.a6']
 

--- a/libraries/botbuilder-azure/setup.py
+++ b/libraries/botbuilder-azure/setup.py
@@ -1,11 +1,9 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-from setuptools import setup
 import os
+from setuptools import setup
 
-NAME = "botbuilder-azure"
-VERSION = "0.1"
 REQUIRES = ['azure-cosmos==3.0.0',
             'botbuilder-schema>=4.0.0.a6',
             'botframework-connector>=4.0.0.a6']

--- a/libraries/botbuilder-azure/setup.py
+++ b/libraries/botbuilder-azure/setup.py
@@ -1,0 +1,40 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+from setuptools import setup
+import os
+
+NAME = "botbuilder-azure"
+VERSION = "0.1"
+REQUIRES = ['azure.cosmos==3.0.0',
+            'botbuilder-schema>=4.0.0.a6',
+            'botframework-connector>=4.0.0.a6']
+
+root = os.path.abspath(os.path.dirname(__file__))
+
+with open(os.path.join(root, 'botbuilder', 'azure', 'about.py')) as f:
+    package_info = {}
+    info = f.read()
+    exec(info, package_info)
+
+setup(
+    name=package_info['__title__'],
+    version=package_info['__version__'],
+    url=package_info['__uri__'],
+    author=package_info['__author__'],
+    description=package_info['__description__'],
+    keywords=['BotBuilderAzure', 'bots', 'ai',
+              'botframework', 'botbuilder', 'azure'],
+    long_description=package_info['__summary__'],
+    license=package_info['__license__'],
+    packages=['botbuilder.azure'],
+    install_requires=REQUIRES,
+    classifiers=[
+        'Programming Language :: Python :: 3.6',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: MIT License',
+        'Operating System :: OS Independent',
+        'Development Status :: 3 - Alpha',
+        'Topic :: Scientific/Engineering :: Artificial Intelligence',
+    ]
+)

--- a/libraries/botbuilder-azure/tests/test_cosmos_storage.py
+++ b/libraries/botbuilder-azure/tests/test_cosmos_storage.py
@@ -12,7 +12,7 @@ cosmos_db_config = CosmosDbConfig(
     database='test-db',
     container='bot-storage'
 )
-
+emulator_running = False
 
 async def reset():
     storage = CosmosDbStorage(cosmos_db_config)
@@ -37,167 +37,167 @@ class TestCosmosDbStorage:
         except Exception as e:
             assert e
 
-    # @pytest.mark.asyncio
-    # async def test_cosmos_storage_init_should_work_with_just_endpoint_and_key(self):
-    #     storage = CosmosDbStorage(CosmosDbConfig(endpoint=cosmos_db_config.endpoint, masterkey=cosmos_db_config.masterkey))
-    #     await storage.write({'user': SimpleStoreItem()})
-    #     data = await storage.read(['user'])
-    #     assert 'user' in data
-    #     assert data['user'].counter == 1
-    #     assert len(data.keys()) == 1
+    @pytest.mark.skipif(not emulator_running, reason='Needs the emulator to run.')
+    async def test_cosmos_storage_init_should_work_with_just_endpoint_and_key(self):
+        storage = CosmosDbStorage(CosmosDbConfig(endpoint=cosmos_db_config.endpoint, masterkey=cosmos_db_config.masterkey))
+        await storage.write({'user': SimpleStoreItem()})
+        data = await storage.read(['user'])
+        assert 'user' in data
+        assert data['user'].counter == 1
+        assert len(data.keys()) == 1
 
-    # @pytest.mark.asyncio
-    # async def test_cosmos_storage_read_should_return_data_with_valid_key(self):
-    #     await reset()
-    #     storage = CosmosDbStorage(cosmos_db_config)
-    #     await storage.write({'user': SimpleStoreItem()})
+    @pytest.mark.skipif(not emulator_running, reason='Needs the emulator to run.')
+    async def test_cosmos_storage_read_should_return_data_with_valid_key(self):
+        await reset()
+        storage = CosmosDbStorage(cosmos_db_config)
+        await storage.write({'user': SimpleStoreItem()})
 
-    #     data = await storage.read(['user'])
-    #     assert 'user' in data
-    #     assert data['user'].counter == 1
-    #     assert len(data.keys()) == 1
+        data = await storage.read(['user'])
+        assert 'user' in data
+        assert data['user'].counter == 1
+        assert len(data.keys()) == 1
 
-    # @pytest.mark.asyncio
-    # async def test_cosmos_storage_read_update_should_return_new_etag(self):
-    #     await reset()
-    #     storage = CosmosDbStorage(cosmos_db_config)
-    #     await storage.write({'test': SimpleStoreItem(counter=1)})
-    #     data_result = await storage.read(['test'])
-    #     data_result['test'].counter = 2
-    #     await storage.write(data_result)
-    #     data_updated = await storage.read(['test'])
-    #     assert data_updated['test'].counter == 2
-    #     assert data_updated['test'].e_tag != data_result['test'].e_tag
+    @pytest.mark.skipif(not emulator_running, reason='Needs the emulator to run.')
+    async def test_cosmos_storage_read_update_should_return_new_etag(self):
+        await reset()
+        storage = CosmosDbStorage(cosmos_db_config)
+        await storage.write({'test': SimpleStoreItem(counter=1)})
+        data_result = await storage.read(['test'])
+        data_result['test'].counter = 2
+        await storage.write(data_result)
+        data_updated = await storage.read(['test'])
+        assert data_updated['test'].counter == 2
+        assert data_updated['test'].e_tag != data_result['test'].e_tag
 
-    # @pytest.mark.asyncio
-    # async def test_cosmos_storage_read_with_invalid_key_should_return_empty_dict(self):
-    #     await reset()
-    #     storage = CosmosDbStorage(cosmos_db_config)
-    #     data = await storage.read(['test'])
+    @pytest.mark.skipif(not emulator_running, reason='Needs the emulator to run.')
+    async def test_cosmos_storage_read_with_invalid_key_should_return_empty_dict(self):
+        await reset()
+        storage = CosmosDbStorage(cosmos_db_config)
+        data = await storage.read(['test'])
 
-    #     assert type(data) == dict
-    #     assert len(data.keys()) == 0
+        assert type(data) == dict
+        assert len(data.keys()) == 0
 
-    # @pytest.mark.asyncio
-    # async def test_cosmos_storage_read_no_key_should_throw(self):
-    #     try:
-    #         await reset()
-    #         storage = CosmosDbStorage(cosmos_db_config)
-    #         await storage.read([])
-    #     except Exception as e:
-    #         assert e
+    @pytest.mark.skipif(not emulator_running, reason='Needs the emulator to run.')
+    async def test_cosmos_storage_read_no_key_should_throw(self):
+        try:
+            await reset()
+            storage = CosmosDbStorage(cosmos_db_config)
+            await storage.read([])
+        except Exception as e:
+            assert e
 
-    # @pytest.mark.asyncio
-    # async def test_cosmos_storage_write_should_add_new_value(self):
-    #     await reset()
-    #     storage = CosmosDbStorage(cosmos_db_config)
-    #     await storage.write({'user': SimpleStoreItem(counter=1)})
+    @pytest.mark.skipif(not emulator_running, reason='Needs the emulator to run.')
+    async def test_cosmos_storage_write_should_add_new_value(self):
+        await reset()
+        storage = CosmosDbStorage(cosmos_db_config)
+        await storage.write({'user': SimpleStoreItem(counter=1)})
 
-    #     data = await storage.read(['user'])
-    #     assert 'user' in data
-    #     assert data['user'].counter == 1
+        data = await storage.read(['user'])
+        assert 'user' in data
+        assert data['user'].counter == 1
 
-    # @pytest.mark.asyncio
-    # async def test_cosmos_storage_write_should_overwrite_when_new_e_tag_is_an_asterisk(self):
-    #     await reset()
-    #     storage = CosmosDbStorage(cosmos_db_config)
-    #     await storage.write({'user': SimpleStoreItem()})
+    @pytest.mark.skipif(not emulator_running, reason='Needs the emulator to run.')
+    async def test_cosmos_storage_write_should_overwrite_when_new_e_tag_is_an_asterisk(self):
+        await reset()
+        storage = CosmosDbStorage(cosmos_db_config)
+        await storage.write({'user': SimpleStoreItem()})
 
-    #     await storage.write({'user': SimpleStoreItem(counter=10, e_tag='*')})
-    #     data = await storage.read(['user'])
-    #     assert data['user'].counter == 10
+        await storage.write({'user': SimpleStoreItem(counter=10, e_tag='*')})
+        data = await storage.read(['user'])
+        assert data['user'].counter == 10
 
-    # @pytest.mark.asyncio
-    # async def test_cosmos_storage_write_batch_operation(self):
-    #     await reset()
-    #     storage = CosmosDbStorage(cosmos_db_config)
-    #     await storage.write(
-    #         {'batch1': SimpleStoreItem(counter=1),
-    #         'batch2': SimpleStoreItem(counter=1),
-    #         'batch3': SimpleStoreItem(counter=1)}
-    #         )
-    #     data = await storage.read(['batch1', 'batch2', 'batch3'])
-    #     assert len(data.keys()) == 3
-    #     assert data['batch1']
-    #     assert data['batch2']
-    #     assert data['batch3']
-    #     assert data['batch1'].counter == 1
-    #     assert data['batch2'].counter == 1
-    #     assert data['batch3'].counter == 1
-    #     assert data['batch1'].e_tag
-    #     assert data['batch2'].e_tag
-    #     assert data['batch3'].e_tag
-    #     await storage.delete(['batch1', 'batch2', 'batch3'])
-    #     data = await storage.read(['batch1', 'batch2', 'batch3'])
-    #     assert len(data.keys()) == 0
+    @pytest.mark.skipif(not emulator_running, reason='Needs the emulator to run.')
+    async def test_cosmos_storage_write_batch_operation(self):
+        await reset()
+        storage = CosmosDbStorage(cosmos_db_config)
+        await storage.write(
+            {'batch1': SimpleStoreItem(counter=1),
+            'batch2': SimpleStoreItem(counter=1),
+            'batch3': SimpleStoreItem(counter=1)}
+            )
+        data = await storage.read(['batch1', 'batch2', 'batch3'])
+        assert len(data.keys()) == 3
+        assert data['batch1']
+        assert data['batch2']
+        assert data['batch3']
+        assert data['batch1'].counter == 1
+        assert data['batch2'].counter == 1
+        assert data['batch3'].counter == 1
+        assert data['batch1'].e_tag
+        assert data['batch2'].e_tag
+        assert data['batch3'].e_tag
+        await storage.delete(['batch1', 'batch2', 'batch3'])
+        data = await storage.read(['batch1', 'batch2', 'batch3'])
+        assert len(data.keys()) == 0
 
-    # @pytest.mark.asyncio
-    # async def test_cosmos_storage_write_crazy_keys_work(self):
-    #     await reset()
-    #     storage = CosmosDbStorage(cosmos_db_config)
-    #     crazy_key = '!@#$%^&*()_+??><":QASD~`'
-    #     await storage.write({crazy_key: SimpleStoreItem(counter=1)})
-    #     data = await storage.read([crazy_key])
-    #     assert len(data.keys()) == 1
-    #     assert data[crazy_key]
-    #     assert data[crazy_key].counter == 1
-    #     assert data[crazy_key].e_tag
+    @pytest.mark.skipif(not emulator_running, reason='Needs the emulator to run.')
+    async def test_cosmos_storage_write_crazy_keys_work(self):
+        await reset()
+        storage = CosmosDbStorage(cosmos_db_config)
+        crazy_key = '!@#$%^&*()_+??><":QASD~`'
+        await storage.write({crazy_key: SimpleStoreItem(counter=1)})
+        data = await storage.read([crazy_key])
+        assert len(data.keys()) == 1
+        assert data[crazy_key]
+        assert data[crazy_key].counter == 1
+        assert data[crazy_key].e_tag
 
-    # @pytest.mark.asyncio
-    # async def test_cosmos_storage_delete_should_delete_according_cached_data(self):
-    #     await reset()
-    #     storage = CosmosDbStorage(cosmos_db_config)
-    #     await storage.write({'test': SimpleStoreItem()})
-    #     try:
-    #         await storage.delete(['test'])
-    #     except Exception as e:
-    #         raise e
-    #     else:
-    #         data = await storage.read(['test'])
+    @pytest.mark.skipif(not emulator_running, reason='Needs the emulator to run.')
+    async def test_cosmos_storage_delete_should_delete_according_cached_data(self):
+        await reset()
+        storage = CosmosDbStorage(cosmos_db_config)
+        await storage.write({'test': SimpleStoreItem()})
+        try:
+            await storage.delete(['test'])
+        except Exception as e:
+            raise e
+        else:
+            data = await storage.read(['test'])
 
-    #         assert type(data) == dict
-    #         assert len(data.keys()) == 0
+            assert type(data) == dict
+            assert len(data.keys()) == 0
 
-    # @pytest.mark.asyncio
-    # async def test_cosmos_storage_delete_should_delete_multiple_values_when_given_multiple_valid_keys(self):
-    #     await reset()
-    #     storage = CosmosDbStorage(cosmos_db_config)
-    #     await storage.write({'test': SimpleStoreItem(), 'test2': SimpleStoreItem(2)})
+    @pytest.mark.skipif(not emulator_running, reason='Needs the emulator to run.')
+    async def test_cosmos_storage_delete_should_delete_multiple_values_when_given_multiple_valid_keys(self):
+        await reset()
+        storage = CosmosDbStorage(cosmos_db_config)
+        await storage.write({'test': SimpleStoreItem(), 'test2': SimpleStoreItem(2)})
 
-    #     await storage.delete(['test', 'test2'])
-    #     data = await storage.read(['test', 'test2'])
-    #     assert len(data.keys()) == 0
+        await storage.delete(['test', 'test2'])
+        data = await storage.read(['test', 'test2'])
+        assert len(data.keys()) == 0
 
-    # @pytest.mark.asyncio
-    # async def test_cosmos_storage_delete_should_delete_values_when_given_multiple_valid_keys_and_ignore_other_data(self):
-    #     await reset()
-    #     storage = CosmosDbStorage(cosmos_db_config)
-    #     await storage.write({'test': SimpleStoreItem(),
-    #                              'test2': SimpleStoreItem(counter=2),
-    #                              'test3': SimpleStoreItem(counter=3)})
+    @pytest.mark.skipif(not emulator_running, reason='Needs the emulator to run.')
+    async def test_cosmos_storage_delete_should_delete_values_when_given_multiple_valid_keys_and_ignore_other_data(self):
+        await reset()
+        storage = CosmosDbStorage(cosmos_db_config)
+        await storage.write({'test': SimpleStoreItem(),
+                                 'test2': SimpleStoreItem(counter=2),
+                                 'test3': SimpleStoreItem(counter=3)})
 
-    #     await storage.delete(['test', 'test2'])
-    #     data = await storage.read(['test', 'test2', 'test3'])
-    #     assert len(data.keys()) == 1
+        await storage.delete(['test', 'test2'])
+        data = await storage.read(['test', 'test2', 'test3'])
+        assert len(data.keys()) == 1
 
-    # @pytest.mark.asyncio
-    # async def test_cosmos_storage_delete_invalid_key_should_do_nothing_and_not_affect_cached_data(self):
-    #     await reset()
-    #     storage = CosmosDbStorage(cosmos_db_config)
-    #     await storage.write({'test': SimpleStoreItem()})
+    @pytest.mark.skipif(not emulator_running, reason='Needs the emulator to run.')
+    async def test_cosmos_storage_delete_invalid_key_should_do_nothing_and_not_affect_cached_data(self):
+        await reset()
+        storage = CosmosDbStorage(cosmos_db_config)
+        await storage.write({'test': SimpleStoreItem()})
 
-    #     await storage.delete(['foo'])
-    #     data = await storage.read(['test'])
-    #     assert len(data.keys()) == 1
-    #     data = await storage.read(['foo'])
-    #     assert len(data.keys()) == 0
+        await storage.delete(['foo'])
+        data = await storage.read(['test'])
+        assert len(data.keys()) == 1
+        data = await storage.read(['foo'])
+        assert len(data.keys()) == 0
 
-    # @pytest.mark.asyncio
-    # async def test_cosmos_storage_delete_invalid_keys_should_do_nothing_and_not_affect_cached_data(self):
-    #     await reset()
-    #     storage = CosmosDbStorage(cosmos_db_config)
-    #     await storage.write({'test': SimpleStoreItem()})
+    @pytest.mark.skipif(not emulator_running, reason='Needs the emulator to run.')
+    async def test_cosmos_storage_delete_invalid_keys_should_do_nothing_and_not_affect_cached_data(self):
+        await reset()
+        storage = CosmosDbStorage(cosmos_db_config)
+        await storage.write({'test': SimpleStoreItem()})
 
-    #     await storage.delete(['foo', 'bar'])
-    #     data = await storage.read(['test'])
-    #     assert len(data.keys()) == 1
+        await storage.delete(['foo', 'bar'])
+        data = await storage.read(['test'])
+        assert len(data.keys()) == 1

--- a/libraries/botbuilder-azure/tests/test_cosmos_storage.py
+++ b/libraries/botbuilder-azure/tests/test_cosmos_storage.py
@@ -37,167 +37,167 @@ class TestCosmosDbStorage:
         except Exception as e:
             assert e
 
-    @pytest.mark.asyncio
-    async def test_cosmos_storage_init_should_work_with_just_endpoint_and_key(self):
-        storage = CosmosDbStorage(CosmosDbConfig(endpoint=cosmos_db_config.endpoint, masterkey=cosmos_db_config.masterkey))
-        await storage.write({'user': SimpleStoreItem()})
-        data = await storage.read(['user'])
-        assert 'user' in data
-        assert data['user'].counter == 1
-        assert len(data.keys()) == 1
+    # @pytest.mark.asyncio
+    # async def test_cosmos_storage_init_should_work_with_just_endpoint_and_key(self):
+    #     storage = CosmosDbStorage(CosmosDbConfig(endpoint=cosmos_db_config.endpoint, masterkey=cosmos_db_config.masterkey))
+    #     await storage.write({'user': SimpleStoreItem()})
+    #     data = await storage.read(['user'])
+    #     assert 'user' in data
+    #     assert data['user'].counter == 1
+    #     assert len(data.keys()) == 1
 
-    @pytest.mark.asyncio
-    async def test_cosmos_storage_read_should_return_data_with_valid_key(self):
-        await reset()
-        storage = CosmosDbStorage(cosmos_db_config)
-        await storage.write({'user': SimpleStoreItem()})
+    # @pytest.mark.asyncio
+    # async def test_cosmos_storage_read_should_return_data_with_valid_key(self):
+    #     await reset()
+    #     storage = CosmosDbStorage(cosmos_db_config)
+    #     await storage.write({'user': SimpleStoreItem()})
 
-        data = await storage.read(['user'])
-        assert 'user' in data
-        assert data['user'].counter == 1
-        assert len(data.keys()) == 1
+    #     data = await storage.read(['user'])
+    #     assert 'user' in data
+    #     assert data['user'].counter == 1
+    #     assert len(data.keys()) == 1
 
-    @pytest.mark.asyncio
-    async def test_cosmos_storage_read_update_should_return_new_etag(self):
-        await reset()
-        storage = CosmosDbStorage(cosmos_db_config)
-        await storage.write({'test': SimpleStoreItem(counter=1)})
-        data_result = await storage.read(['test'])
-        data_result['test'].counter = 2
-        await storage.write(data_result)
-        data_updated = await storage.read(['test'])
-        assert data_updated['test'].counter == 2
-        assert data_updated['test'].e_tag != data_result['test'].e_tag
+    # @pytest.mark.asyncio
+    # async def test_cosmos_storage_read_update_should_return_new_etag(self):
+    #     await reset()
+    #     storage = CosmosDbStorage(cosmos_db_config)
+    #     await storage.write({'test': SimpleStoreItem(counter=1)})
+    #     data_result = await storage.read(['test'])
+    #     data_result['test'].counter = 2
+    #     await storage.write(data_result)
+    #     data_updated = await storage.read(['test'])
+    #     assert data_updated['test'].counter == 2
+    #     assert data_updated['test'].e_tag != data_result['test'].e_tag
 
-    @pytest.mark.asyncio
-    async def test_cosmos_storage_read_with_invalid_key_should_return_empty_dict(self):
-        await reset()
-        storage = CosmosDbStorage(cosmos_db_config)
-        data = await storage.read(['test'])
+    # @pytest.mark.asyncio
+    # async def test_cosmos_storage_read_with_invalid_key_should_return_empty_dict(self):
+    #     await reset()
+    #     storage = CosmosDbStorage(cosmos_db_config)
+    #     data = await storage.read(['test'])
 
-        assert type(data) == dict
-        assert len(data.keys()) == 0
+    #     assert type(data) == dict
+    #     assert len(data.keys()) == 0
 
-    @pytest.mark.asyncio
-    async def test_cosmos_storage_read_no_key_should_throw(self):
-        try:
-            await reset()
-            storage = CosmosDbStorage(cosmos_db_config)
-            await storage.read([])
-        except Exception as e:
-            assert e
+    # @pytest.mark.asyncio
+    # async def test_cosmos_storage_read_no_key_should_throw(self):
+    #     try:
+    #         await reset()
+    #         storage = CosmosDbStorage(cosmos_db_config)
+    #         await storage.read([])
+    #     except Exception as e:
+    #         assert e
 
-    @pytest.mark.asyncio
-    async def test_cosmos_storage_write_should_add_new_value(self):
-        await reset()
-        storage = CosmosDbStorage(cosmos_db_config)
-        await storage.write({'user': SimpleStoreItem(counter=1)})
+    # @pytest.mark.asyncio
+    # async def test_cosmos_storage_write_should_add_new_value(self):
+    #     await reset()
+    #     storage = CosmosDbStorage(cosmos_db_config)
+    #     await storage.write({'user': SimpleStoreItem(counter=1)})
 
-        data = await storage.read(['user'])
-        assert 'user' in data
-        assert data['user'].counter == 1
+    #     data = await storage.read(['user'])
+    #     assert 'user' in data
+    #     assert data['user'].counter == 1
 
-    @pytest.mark.asyncio
-    async def test_cosmos_storage_write_should_overwrite_when_new_e_tag_is_an_asterisk(self):
-        await reset()
-        storage = CosmosDbStorage(cosmos_db_config)
-        await storage.write({'user': SimpleStoreItem()})
+    # @pytest.mark.asyncio
+    # async def test_cosmos_storage_write_should_overwrite_when_new_e_tag_is_an_asterisk(self):
+    #     await reset()
+    #     storage = CosmosDbStorage(cosmos_db_config)
+    #     await storage.write({'user': SimpleStoreItem()})
 
-        await storage.write({'user': SimpleStoreItem(counter=10, e_tag='*')})
-        data = await storage.read(['user'])
-        assert data['user'].counter == 10
+    #     await storage.write({'user': SimpleStoreItem(counter=10, e_tag='*')})
+    #     data = await storage.read(['user'])
+    #     assert data['user'].counter == 10
 
-    @pytest.mark.asyncio
-    async def test_cosmos_storage_write_batch_operation(self):
-        await reset()
-        storage = CosmosDbStorage(cosmos_db_config)
-        await storage.write(
-            {'batch1': SimpleStoreItem(counter=1),
-            'batch2': SimpleStoreItem(counter=1),
-            'batch3': SimpleStoreItem(counter=1)}
-            )
-        data = await storage.read(['batch1', 'batch2', 'batch3'])
-        assert len(data.keys()) == 3
-        assert data['batch1']
-        assert data['batch2']
-        assert data['batch3']
-        assert data['batch1'].counter == 1
-        assert data['batch2'].counter == 1
-        assert data['batch3'].counter == 1
-        assert data['batch1'].e_tag
-        assert data['batch2'].e_tag
-        assert data['batch3'].e_tag
-        await storage.delete(['batch1', 'batch2', 'batch3'])
-        data = await storage.read(['batch1', 'batch2', 'batch3'])
-        assert len(data.keys()) == 0
+    # @pytest.mark.asyncio
+    # async def test_cosmos_storage_write_batch_operation(self):
+    #     await reset()
+    #     storage = CosmosDbStorage(cosmos_db_config)
+    #     await storage.write(
+    #         {'batch1': SimpleStoreItem(counter=1),
+    #         'batch2': SimpleStoreItem(counter=1),
+    #         'batch3': SimpleStoreItem(counter=1)}
+    #         )
+    #     data = await storage.read(['batch1', 'batch2', 'batch3'])
+    #     assert len(data.keys()) == 3
+    #     assert data['batch1']
+    #     assert data['batch2']
+    #     assert data['batch3']
+    #     assert data['batch1'].counter == 1
+    #     assert data['batch2'].counter == 1
+    #     assert data['batch3'].counter == 1
+    #     assert data['batch1'].e_tag
+    #     assert data['batch2'].e_tag
+    #     assert data['batch3'].e_tag
+    #     await storage.delete(['batch1', 'batch2', 'batch3'])
+    #     data = await storage.read(['batch1', 'batch2', 'batch3'])
+    #     assert len(data.keys()) == 0
 
-    @pytest.mark.asyncio
-    async def test_cosmos_storage_write_crazy_keys_work(self):
-        await reset()
-        storage = CosmosDbStorage(cosmos_db_config)
-        crazy_key = '!@#$%^&*()_+??><":QASD~`'
-        await storage.write({crazy_key: SimpleStoreItem(counter=1)})
-        data = await storage.read([crazy_key])
-        assert len(data.keys()) == 1
-        assert data[crazy_key]
-        assert data[crazy_key].counter == 1
-        assert data[crazy_key].e_tag
+    # @pytest.mark.asyncio
+    # async def test_cosmos_storage_write_crazy_keys_work(self):
+    #     await reset()
+    #     storage = CosmosDbStorage(cosmos_db_config)
+    #     crazy_key = '!@#$%^&*()_+??><":QASD~`'
+    #     await storage.write({crazy_key: SimpleStoreItem(counter=1)})
+    #     data = await storage.read([crazy_key])
+    #     assert len(data.keys()) == 1
+    #     assert data[crazy_key]
+    #     assert data[crazy_key].counter == 1
+    #     assert data[crazy_key].e_tag
 
-    @pytest.mark.asyncio
-    async def test_cosmos_storage_delete_should_delete_according_cached_data(self):
-        await reset()
-        storage = CosmosDbStorage(cosmos_db_config)
-        await storage.write({'test': SimpleStoreItem()})
-        try:
-            await storage.delete(['test'])
-        except Exception as e:
-            raise e
-        else:
-            data = await storage.read(['test'])
+    # @pytest.mark.asyncio
+    # async def test_cosmos_storage_delete_should_delete_according_cached_data(self):
+    #     await reset()
+    #     storage = CosmosDbStorage(cosmos_db_config)
+    #     await storage.write({'test': SimpleStoreItem()})
+    #     try:
+    #         await storage.delete(['test'])
+    #     except Exception as e:
+    #         raise e
+    #     else:
+    #         data = await storage.read(['test'])
 
-            assert type(data) == dict
-            assert len(data.keys()) == 0
+    #         assert type(data) == dict
+    #         assert len(data.keys()) == 0
 
-    @pytest.mark.asyncio
-    async def test_cosmos_storage_delete_should_delete_multiple_values_when_given_multiple_valid_keys(self):
-        await reset()
-        storage = CosmosDbStorage(cosmos_db_config)
-        await storage.write({'test': SimpleStoreItem(), 'test2': SimpleStoreItem(2)})
+    # @pytest.mark.asyncio
+    # async def test_cosmos_storage_delete_should_delete_multiple_values_when_given_multiple_valid_keys(self):
+    #     await reset()
+    #     storage = CosmosDbStorage(cosmos_db_config)
+    #     await storage.write({'test': SimpleStoreItem(), 'test2': SimpleStoreItem(2)})
 
-        await storage.delete(['test', 'test2'])
-        data = await storage.read(['test', 'test2'])
-        assert len(data.keys()) == 0
+    #     await storage.delete(['test', 'test2'])
+    #     data = await storage.read(['test', 'test2'])
+    #     assert len(data.keys()) == 0
 
-    @pytest.mark.asyncio
-    async def test_cosmos_storage_delete_should_delete_values_when_given_multiple_valid_keys_and_ignore_other_data(self):
-        await reset()
-        storage = CosmosDbStorage(cosmos_db_config)
-        await storage.write({'test': SimpleStoreItem(),
-                                 'test2': SimpleStoreItem(counter=2),
-                                 'test3': SimpleStoreItem(counter=3)})
+    # @pytest.mark.asyncio
+    # async def test_cosmos_storage_delete_should_delete_values_when_given_multiple_valid_keys_and_ignore_other_data(self):
+    #     await reset()
+    #     storage = CosmosDbStorage(cosmos_db_config)
+    #     await storage.write({'test': SimpleStoreItem(),
+    #                              'test2': SimpleStoreItem(counter=2),
+    #                              'test3': SimpleStoreItem(counter=3)})
 
-        await storage.delete(['test', 'test2'])
-        data = await storage.read(['test', 'test2', 'test3'])
-        assert len(data.keys()) == 1
+    #     await storage.delete(['test', 'test2'])
+    #     data = await storage.read(['test', 'test2', 'test3'])
+    #     assert len(data.keys()) == 1
 
-    @pytest.mark.asyncio
-    async def test_cosmos_storage_delete_invalid_key_should_do_nothing_and_not_affect_cached_data(self):
-        await reset()
-        storage = CosmosDbStorage(cosmos_db_config)
-        await storage.write({'test': SimpleStoreItem()})
+    # @pytest.mark.asyncio
+    # async def test_cosmos_storage_delete_invalid_key_should_do_nothing_and_not_affect_cached_data(self):
+    #     await reset()
+    #     storage = CosmosDbStorage(cosmos_db_config)
+    #     await storage.write({'test': SimpleStoreItem()})
 
-        await storage.delete(['foo'])
-        data = await storage.read(['test'])
-        assert len(data.keys()) == 1
-        data = await storage.read(['foo'])
-        assert len(data.keys()) == 0
+    #     await storage.delete(['foo'])
+    #     data = await storage.read(['test'])
+    #     assert len(data.keys()) == 1
+    #     data = await storage.read(['foo'])
+    #     assert len(data.keys()) == 0
 
-    @pytest.mark.asyncio
-    async def test_cosmos_storage_delete_invalid_keys_should_do_nothing_and_not_affect_cached_data(self):
-        await reset()
-        storage = CosmosDbStorage(cosmos_db_config)
-        await storage.write({'test': SimpleStoreItem()})
+    # @pytest.mark.asyncio
+    # async def test_cosmos_storage_delete_invalid_keys_should_do_nothing_and_not_affect_cached_data(self):
+    #     await reset()
+    #     storage = CosmosDbStorage(cosmos_db_config)
+    #     await storage.write({'test': SimpleStoreItem()})
 
-        await storage.delete(['foo', 'bar'])
-        data = await storage.read(['test'])
-        assert len(data.keys()) == 1
+    #     await storage.delete(['foo', 'bar'])
+    #     data = await storage.read(['test'])
+    #     assert len(data.keys()) == 1

--- a/libraries/botbuilder-azure/tests/test_cosmos_storage.py
+++ b/libraries/botbuilder-azure/tests/test_cosmos_storage.py
@@ -1,0 +1,203 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+import pytest
+from botbuilder.core import StoreItem
+from botbuilder.azure import (CosmosDbStorage, CosmosDbConfig)
+
+# local cosmosdb emulator instance cosmos_db_config
+cosmos_db_config = CosmosDbConfig(
+    endpoint='https://localhost:8081',
+    masterkey='<key for emulator>',
+    database='test-db',
+    container='bot-storage'
+)
+
+
+async def reset():
+    storage = CosmosDbStorage(cosmos_db_config)
+    storage.client.DeleteDatabase(
+        database_link='dbs/' + cosmos_db_config.database,
+        ignore_errors=True)
+
+
+class SimpleStoreItem(StoreItem):
+    def __init__(self, counter=1, e_tag='*'):
+        super(SimpleStoreItem, self).__init__()
+        self.counter = counter
+        self.e_tag = e_tag
+
+
+class TestCosmosDbStorage:
+
+    @pytest.mark.asyncio
+    async def test_cosmos_storage_init_should_error_without_cosmos_db_config(self):
+        try:
+            CosmosDbStorage(CosmosDbConfig())
+        except Exception as e:
+            assert e
+
+    @pytest.mark.asyncio
+    async def test_cosmos_storage_init_should_work_with_just_endpoint_and_key(self):
+        storage = CosmosDbStorage(CosmosDbConfig(endpoint=cosmos_db_config.endpoint, masterkey=cosmos_db_config.masterkey))
+        await storage.write({'user': SimpleStoreItem()})
+        data = await storage.read(['user'])
+        assert 'user' in data
+        assert data['user'].counter == 1
+        assert len(data.keys()) == 1
+
+    @pytest.mark.asyncio
+    async def test_cosmos_storage_read_should_return_data_with_valid_key(self):
+        await reset()
+        storage = CosmosDbStorage(cosmos_db_config)
+        await storage.write({'user': SimpleStoreItem()})
+
+        data = await storage.read(['user'])
+        assert 'user' in data
+        assert data['user'].counter == 1
+        assert len(data.keys()) == 1
+
+    @pytest.mark.asyncio
+    async def test_cosmos_storage_read_update_should_return_new_etag(self):
+        await reset()
+        storage = CosmosDbStorage(cosmos_db_config)
+        await storage.write({'test': SimpleStoreItem(counter=1)})
+        data_result = await storage.read(['test'])
+        data_result['test'].counter = 2
+        await storage.write(data_result)
+        data_updated = await storage.read(['test'])
+        assert data_updated['test'].counter == 2
+        assert data_updated['test'].e_tag != data_result['test'].e_tag
+
+    @pytest.mark.asyncio
+    async def test_cosmos_storage_read_with_invalid_key_should_return_empty_dict(self):
+        await reset()
+        storage = CosmosDbStorage(cosmos_db_config)
+        data = await storage.read(['test'])
+
+        assert type(data) == dict
+        assert len(data.keys()) == 0
+
+    @pytest.mark.asyncio
+    async def test_cosmos_storage_read_no_key_should_throw(self):
+        try:
+            await reset()
+            storage = CosmosDbStorage(cosmos_db_config)
+            await storage.read([])
+        except Exception as e:
+            assert e
+
+    @pytest.mark.asyncio
+    async def test_cosmos_storage_write_should_add_new_value(self):
+        await reset()
+        storage = CosmosDbStorage(cosmos_db_config)
+        await storage.write({'user': SimpleStoreItem(counter=1)})
+
+        data = await storage.read(['user'])
+        assert 'user' in data
+        assert data['user'].counter == 1
+
+    @pytest.mark.asyncio
+    async def test_cosmos_storage_write_should_overwrite_when_new_e_tag_is_an_asterisk(self):
+        await reset()
+        storage = CosmosDbStorage(cosmos_db_config)
+        await storage.write({'user': SimpleStoreItem()})
+
+        await storage.write({'user': SimpleStoreItem(counter=10, e_tag='*')})
+        data = await storage.read(['user'])
+        assert data['user'].counter == 10
+
+    @pytest.mark.asyncio
+    async def test_cosmos_storage_write_batch_operation(self):
+        await reset()
+        storage = CosmosDbStorage(cosmos_db_config)
+        await storage.write(
+            {'batch1': SimpleStoreItem(counter=1),
+            'batch2': SimpleStoreItem(counter=1),
+            'batch3': SimpleStoreItem(counter=1)}
+            )
+        data = await storage.read(['batch1', 'batch2', 'batch3'])
+        assert len(data.keys()) == 3
+        assert data['batch1']
+        assert data['batch2']
+        assert data['batch3']
+        assert data['batch1'].counter == 1
+        assert data['batch2'].counter == 1
+        assert data['batch3'].counter == 1
+        assert data['batch1'].e_tag
+        assert data['batch2'].e_tag
+        assert data['batch3'].e_tag
+        await storage.delete(['batch1', 'batch2', 'batch3'])
+        data = await storage.read(['batch1', 'batch2', 'batch3'])
+        assert len(data.keys()) == 0
+
+    @pytest.mark.asyncio
+    async def test_cosmos_storage_write_crazy_keys_work(self):
+        await reset()
+        storage = CosmosDbStorage(cosmos_db_config)
+        crazy_key = '!@#$%^&*()_+??><":QASD~`'
+        await storage.write({crazy_key: SimpleStoreItem(counter=1)})
+        data = await storage.read([crazy_key])
+        assert len(data.keys()) == 1
+        assert data[crazy_key]
+        assert data[crazy_key].counter == 1
+        assert data[crazy_key].e_tag
+
+    @pytest.mark.asyncio
+    async def test_cosmos_storage_delete_should_delete_according_cached_data(self):
+        await reset()
+        storage = CosmosDbStorage(cosmos_db_config)
+        await storage.write({'test': SimpleStoreItem()})
+        try:
+            await storage.delete(['test'])
+        except Exception as e:
+            raise e
+        else:
+            data = await storage.read(['test'])
+
+            assert type(data) == dict
+            assert len(data.keys()) == 0
+
+    @pytest.mark.asyncio
+    async def test_cosmos_storage_delete_should_delete_multiple_values_when_given_multiple_valid_keys(self):
+        await reset()
+        storage = CosmosDbStorage(cosmos_db_config)
+        await storage.write({'test': SimpleStoreItem(), 'test2': SimpleStoreItem(2)})
+
+        await storage.delete(['test', 'test2'])
+        data = await storage.read(['test', 'test2'])
+        assert len(data.keys()) == 0
+
+    @pytest.mark.asyncio
+    async def test_cosmos_storage_delete_should_delete_values_when_given_multiple_valid_keys_and_ignore_other_data(self):
+        await reset()
+        storage = CosmosDbStorage(cosmos_db_config)
+        await storage.write({'test': SimpleStoreItem(),
+                                 'test2': SimpleStoreItem(counter=2),
+                                 'test3': SimpleStoreItem(counter=3)})
+
+        await storage.delete(['test', 'test2'])
+        data = await storage.read(['test', 'test2', 'test3'])
+        assert len(data.keys()) == 1
+
+    @pytest.mark.asyncio
+    async def test_cosmos_storage_delete_invalid_key_should_do_nothing_and_not_affect_cached_data(self):
+        await reset()
+        storage = CosmosDbStorage(cosmos_db_config)
+        await storage.write({'test': SimpleStoreItem()})
+
+        await storage.delete(['foo'])
+        data = await storage.read(['test'])
+        assert len(data.keys()) == 1
+        data = await storage.read(['foo'])
+        assert len(data.keys()) == 0
+
+    @pytest.mark.asyncio
+    async def test_cosmos_storage_delete_invalid_keys_should_do_nothing_and_not_affect_cached_data(self):
+        await reset()
+        storage = CosmosDbStorage(cosmos_db_config)
+        await storage.write({'test': SimpleStoreItem()})
+
+        await storage.delete(['foo', 'bar'])
+        data = await storage.read(['test'])
+        assert len(data.keys()) == 1

--- a/libraries/botbuilder-azure/tests/test_cosmos_storage.py
+++ b/libraries/botbuilder-azure/tests/test_cosmos_storage.py
@@ -8,7 +8,7 @@ from botbuilder.azure import (CosmosDbStorage, CosmosDbConfig)
 # local cosmosdb emulator instance cosmos_db_config
 cosmos_db_config = CosmosDbConfig(
     endpoint='https://localhost:8081',
-    masterkey='<key for emulator>',
+    masterkey='C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==',
     database='test-db',
     container='bot-storage'
 )

--- a/samples/EchoBot-with-CosmosState/EchoBot-with-CosmosState.bot
+++ b/samples/EchoBot-with-CosmosState/EchoBot-with-CosmosState.bot
@@ -1,7 +1,6 @@
 {
     "name": "EchoBot-with-CosmosState",
     "description": "Simple echo bot with state in CosmosDB.",
-    "path": "C:\\Work\\bots\\botbuilder-python\\samples\\Auth-Bot\\EchoBot-with-CosmosState.bot",
     "secretKey": "",
     "services": [
         {

--- a/samples/EchoBot-with-CosmosState/EchoBot-with-CosmosState.bot
+++ b/samples/EchoBot-with-CosmosState/EchoBot-with-CosmosState.bot
@@ -1,0 +1,16 @@
+{
+    "name": "EchoBot-with-CosmosState",
+    "description": "Simple echo bot with state in CosmosDB.",
+    "path": "C:\\Work\\bots\\botbuilder-python\\samples\\Auth-Bot\\EchoBot-with-CosmosState.bot",
+    "secretKey": "",
+    "services": [
+        {
+            "appId": "",
+            "id": "http://localhost:9000",
+            "type": "endpoint",
+            "appPassword": "",
+            "endpoint": "http://localhost:9000",
+            "name": "EchoBot-with-CosmosState"
+        }
+    ]
+}

--- a/samples/EchoBot-with-CosmosState/README.md
+++ b/samples/EchoBot-with-CosmosState/README.md
@@ -1,0 +1,41 @@
+# EchoBot with State
+
+## To try this sample
+- Clone the repository
+```bash
+git clone https://github.com/Microsoft/botbuilder-python.git
+```
+
+
+### Visual studio code
+- Activate your desired virtual environment
+- Open `botbuilder-python\samples\EchoBot-with-State` folder
+- Bring up a terminal, navigate to `botbuilder-python\samples\EchoBot-with-State` folder
+- In the terminal, type `pip install -r requirements.txt`
+- In the terminal, type `python main.py`
+
+## Testing the bot using Bot Framework Emulator
+[Microsoft Bot Framework Emulator](https://github.com/microsoft/botframework-emulator) is a desktop application that allows bot developers to test and debug their bots on localhost or running remotely through a tunnel.
+
+- Install the Bot Framework emulator from [here](https://github.com/Microsoft/BotFramework-Emulator/releases)
+
+### Connect to bot using Bot Framework Emulator **V4**
+- Launch Bot Framework Emulator
+- File -> Open bot and navigate to samples\EchoBot-with-State folder
+- Select EchoBot-with-State.bot file
+
+### Connect to bot using Bot Framework Emulator **V3**
+- Launch Bot Framework Emulator
+- Paste this URL in the emulator window - http://localhost:9000
+
+
+## Bot State
+
+A key to good bot design is to track the context of a conversation, so that your bot remembers things like the answers to previous questions. Depending on what your bot is used for, you may even need to keep track of state or store information for longer than the lifetime of the conversation. A bot's state is information it remembers in order to respond appropriately to incoming messages. The Bot Builder SDK provides classes for storing and retrieving state data as an object associated with a user or a conversation.
+
+# Further reading
+
+- [Azure Bot Service Introduction](https://docs.microsoft.com/en-us/azure/bot-service/bot-service-overview-introduction?view=azure-bot-service-4.0)
+- [Bot State](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-storage-concept?view=azure-bot-service-4.0)
+- [Write directly to storage](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-howto-v4-storage?view=azure-bot-service-4.0&tabs=csharpechorproperty%2Ccsetagoverwrite%2Ccsetag)
+- [Managing conversation and user state](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-howto-v4-state?view=azure-bot-service-4.0)

--- a/samples/EchoBot-with-CosmosState/README.md
+++ b/samples/EchoBot-with-CosmosState/README.md
@@ -9,8 +9,8 @@ git clone https://github.com/Microsoft/botbuilder-python.git
 
 ### Visual studio code
 - Activate your desired virtual environment
-- Open `botbuilder-python\samples\EchoBot-with-State` folder
-- Bring up a terminal, navigate to `botbuilder-python\samples\EchoBot-with-CosmosState` folder
+- Open `botbuilder-python/samples/EchoBot-with-CosmosState` folder
+- Bring up a terminal, navigate to `botbuilder-python/samples/EchoBot-with-CosmosState` folder
 - In the terminal, type `pip install -r requirements.txt`
 - In the terminal, type `python main.py`
 

--- a/samples/EchoBot-with-CosmosState/README.md
+++ b/samples/EchoBot-with-CosmosState/README.md
@@ -10,9 +10,14 @@ git clone https://github.com/Microsoft/botbuilder-python.git
 ### Visual studio code
 - Activate your desired virtual environment
 - Open `botbuilder-python\samples\EchoBot-with-State` folder
-- Bring up a terminal, navigate to `botbuilder-python\samples\EchoBot-with-State` folder
+- Bring up a terminal, navigate to `botbuilder-python\samples\EchoBot-with-CosmosState` folder
 - In the terminal, type `pip install -r requirements.txt`
 - In the terminal, type `python main.py`
+
+### CosmosDB account and configuration
+- Create a CosmosDB account, according to this [guide](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-howto-v4-storage?view=azure-bot-service-4.0&tabs=csharp#using-cosmos-db)
+- Copy the sample_credentials_file.json to credentials_real.json
+- Fill in your CosmosDB credentials and the names for the database and container
 
 ## Testing the bot using Bot Framework Emulator
 [Microsoft Bot Framework Emulator](https://github.com/microsoft/botframework-emulator) is a desktop application that allows bot developers to test and debug their bots on localhost or running remotely through a tunnel.
@@ -21,8 +26,8 @@ git clone https://github.com/Microsoft/botbuilder-python.git
 
 ### Connect to bot using Bot Framework Emulator **V4**
 - Launch Bot Framework Emulator
-- File -> Open bot and navigate to samples\EchoBot-with-State folder
-- Select EchoBot-with-State.bot file
+- File -> Open bot and navigate to samples\EchoBot-with-CosmosState folder
+- Select EchoBot-with-CosmosState.bot file
 
 ### Connect to bot using Bot Framework Emulator **V3**
 - Launch Bot Framework Emulator

--- a/samples/EchoBot-with-CosmosState/main.py
+++ b/samples/EchoBot-with-CosmosState/main.py
@@ -16,7 +16,7 @@ APP_PASSWORD = ''
 PORT = 9000
 SETTINGS = BotFrameworkAdapterSettings(APP_ID, APP_PASSWORD)
 ADAPTER = BotFrameworkAdapter(SETTINGS)
-CONFIG_FILE = 'samples\\EchoBot-with-CosmosState\\credentials_real.json'
+CONFIG_FILE = 'sample_credentials_file.json'
 
 # Create CosmosStorage and ConversationState
 cosmos = CosmosDbStorage(CosmosDbConfig(filename=CONFIG_FILE))

--- a/samples/EchoBot-with-CosmosState/main.py
+++ b/samples/EchoBot-with-CosmosState/main.py
@@ -1,0 +1,105 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+"""
+This sample shows how to create a simple EchoBot with state in CosmosDB.
+"""
+
+
+from aiohttp import web
+import json
+from botbuilder.schema import (Activity, ActivityTypes)
+from botbuilder.core import (BotFrameworkAdapter, BotFrameworkAdapterSettings, TurnContext,
+                             ConversationState, MemoryStorage, UserState)
+
+from botbuilder.azure import (CosmosDbStorage)
+
+APP_ID = ''
+APP_PASSWORD = ''
+PORT = 9000
+SETTINGS = BotFrameworkAdapterSettings(APP_ID, APP_PASSWORD)
+ADAPTER = BotFrameworkAdapter(SETTINGS)
+CONFIG_FILE = 'samples\\EchoBot-with-CosmosState\\credentials_real.json'
+
+# Create MemoryStorage, UserState and ConversationState
+
+config = json.load(open(CONFIG_FILE))
+cosmos = CosmosDbStorage(config)
+# Commented out user_state because it's not being used.
+# user_state = UserState(memory)
+conversation_state = ConversationState(cosmos)
+
+# Register both State middleware on the adapter.
+# Commented out user_state because it's not being used.
+# ADAPTER.use(user_state)
+ADAPTER.use(conversation_state)
+
+
+async def create_reply_activity(request_activity, text) -> Activity:
+    return Activity(
+        type=ActivityTypes.message,
+        channel_id=request_activity.channel_id,
+        conversation=request_activity.conversation,
+        recipient=request_activity.from_property,
+        from_property=request_activity.recipient,
+        text=text,
+        service_url=request_activity.service_url)
+
+
+async def handle_message(context: TurnContext) -> web.Response:
+    # Access the state for the conversation between the user and the bot.
+    state = await conversation_state.get(context)
+    previous = None
+    if hasattr(state, 'previous_text'): 
+        previous = state.previous_text
+    if hasattr(state, 'counter'):
+        state.counter = int(state.counter) + 1
+    else:
+        state.counter = 1
+    state.previous_text = context.activity.text
+    if previous:
+        response_text = f'{state.counter}: You said {context.activity.text}. Earlier you said {previous}'
+    else:
+        response_text = f'{state.counter}: You said {context.activity.text}.'
+    response = await create_reply_activity(context.activity, response_text)
+    await context.send_activity(response)
+    return web.Response(status=202)
+
+
+async def handle_conversation_update(context: TurnContext) -> web.Response:
+    if context.activity.members_added[0].id != context.activity.recipient.id:
+        response = await create_reply_activity(context.activity, 'Welcome to the Echo Adapter Bot!')
+        await context.send_activity(response)
+    return web.Response(status=200)
+
+
+async def unhandled_activity() -> web.Response:
+    return web.Response(status=404)
+
+
+async def request_handler(context: TurnContext) -> web.Response:
+    if context.activity.type == 'message':
+        return await handle_message(context)
+    elif context.activity.type == 'conversationUpdate':
+        return await handle_conversation_update(context)
+    else:
+        return await unhandled_activity()
+
+
+async def messages(req: web.web_request) -> web.Response:
+    body = await req.json()
+    activity = Activity().deserialize(body)
+    auth_header = req.headers['Authorization'] if 'Authorization' in req.headers else ''
+    try:
+        return await ADAPTER.process_activity(activity, auth_header, request_handler)
+    except Exception as e:
+        raise e
+
+
+app = web.Application()
+app.router.add_post('/', messages)
+
+try:
+    web.run_app(app, host='localhost', port=PORT)
+except Exception as e:
+    raise e

--- a/samples/EchoBot-with-CosmosState/requirements.txt
+++ b/samples/EchoBot-with-CosmosState/requirements.txt
@@ -1,0 +1,3 @@
+git+https://github.com/Azure/msrest-for-python.git@a997e97cd926c1eedfe4e5a3a52a637313fbd4e4
+botbuilder-core>=4.0.0.a6
+aiohttp>=3.0.0

--- a/samples/EchoBot-with-CosmosState/requirements.txt
+++ b/samples/EchoBot-with-CosmosState/requirements.txt
@@ -1,3 +1,4 @@
 git+https://github.com/Azure/msrest-for-python.git@a997e97cd926c1eedfe4e5a3a52a637313fbd4e4
 botbuilder-core>=4.0.0.a6
 aiohttp>=3.0.0
+azure.cosmos>=3.0.0

--- a/samples/EchoBot-with-CosmosState/sample_credentials_file.json
+++ b/samples/EchoBot-with-CosmosState/sample_credentials_file.json
@@ -1,0 +1,6 @@
+{ 
+    "ENDPOINT": "",
+    "MASTERKEY": "",
+    "DOCUMENTDB_DATABASE": "",
+    "DOCUMENTDB_CONTAINER": ""
+}

--- a/samples/EchoBot-with-CosmosState/sample_credentials_file.json
+++ b/samples/EchoBot-with-CosmosState/sample_credentials_file.json
@@ -1,6 +1,6 @@
 { 
-    "ENDPOINT": "",
-    "MASTERKEY": "",
-    "DOCUMENTDB_DATABASE": "",
-    "DOCUMENTDB_CONTAINER": ""
+    "endpoint": "",
+    "masterkey": "",
+    "database": "",
+    "container": ""
 }


### PR DESCRIPTION
Hi all, 

I created a middleware package for talking with CosmosDB from the Python Bot Framework, I used a similar structure with a botbuilder-azure package. It includes a config object and a storage object, as well as tests for the integration. In the samples folder is a adaptation of the EchoBot that talks with Cosmos instead of memory storage. Automated testing will rely on CosmosDB emulator running, this is the same as with the Node version of the CosmosDB storage.

## Most important pieces:

- botbuilder-azure/botbuilder/azure/cosmosdb_storage.py - main code for using Cosmos as a middleware
- botbuilder-azure/tests/test_cosmos_storage.py - tests for the middleware
- samples/Echobot-with-CosmosState/* - sample that uses the middleware
