### PR TITLE
Fix waterfall test (add accessor set)

### DIFF
--- a/libraries/botbuilder-applicationinsights/tests/test_telemetry_waterfall.py
+++ b/libraries/botbuilder-applicationinsights/tests/test_telemetry_waterfall.py
@@ -23,6 +23,7 @@ from botbuilder.core import (
 from botbuilder.dialogs import (
                                 Dialog,
                                 DialogSet,
+                                DialogState,
                                 WaterfallDialog,
                                 WaterfallStepContext,
                                 DialogTurnResult,
@@ -45,7 +46,7 @@ class TelemetryWaterfallTests(aiounittest.AsyncTestCase):
         # assert
         self.assertEqual(type(dialog.telemetry_client), NullTelemetryClient)
 
-    @skip('Pending Telemetry mock')
+
     @patch('test_telemetry_waterfall.ApplicationInsightsTelemetryClient')
     async def test_execute_sequence_waterfall_steps(self, MockTelemetry):
         # arrange
@@ -56,7 +57,7 @@ class TelemetryWaterfallTests(aiounittest.AsyncTestCase):
         
         
         # Create a DialogState property, DialogSet and register the WaterfallDialog.
-        dialog_state = convo_state.create_property('dialogState')
+        dialog_state = convo_state.create_property('dialogState') 
         dialogs = DialogSet(dialog_state)
         async def step1(step) -> DialogTurnResult:
             await step.context.send_activity('bot responding.')
@@ -82,6 +83,8 @@ class TelemetryWaterfallTests(aiounittest.AsyncTestCase):
             else:
                 if results.status == DialogTurnStatus.Complete:
                     await turn_context.send_activity(results.result)
+            
+            await dialog_state.set(turn_context, DialogState(dc.stack))
             await convo_state.save_changes(turn_context)
             
         adapt = TestAdapter(exec_test)
@@ -100,7 +103,7 @@ class TelemetryWaterfallTests(aiounittest.AsyncTestCase):
                             ]
         self.assert_telemetry_calls(telemetry, telemetry_calls)
 
-    @skip('Pending Telemetry mock')     
+    
     @patch('test_telemetry_waterfall.ApplicationInsightsTelemetryClient')
     async def test_ensure_end_dialog_called(self, MockTelemetry):
         # arrange
@@ -134,6 +137,7 @@ class TelemetryWaterfallTests(aiounittest.AsyncTestCase):
             results = await dc.continue_dialog()
             if turn_context.responded == False:
                 await dc.begin_dialog("test", None)
+            await dialog_state.set(turn_context, DialogState(dc.stack))
             await convo_state.save_changes(turn_context)
             
         adapt = TestAdapter(exec_test)

--- a/libraries/botbuilder-applicationinsights/tests/test_telemetry_waterfall.py
+++ b/libraries/botbuilder-applicationinsights/tests/test_telemetry_waterfall.py
@@ -47,7 +47,7 @@ class TelemetryWaterfallTests(aiounittest.AsyncTestCase):
         self.assertEqual(type(dialog.telemetry_client), NullTelemetryClient)
 
 
-    @patch('test_telemetry_waterfall.ApplicationInsightsTelemetryClient')
+    @patch('botbuilder.applicationinsights.ApplicationInsightsTelemetryClient')
     async def test_execute_sequence_waterfall_steps(self, MockTelemetry):
         # arrange
 
@@ -104,7 +104,7 @@ class TelemetryWaterfallTests(aiounittest.AsyncTestCase):
         self.assert_telemetry_calls(telemetry, telemetry_calls)
 
     
-    @patch('test_telemetry_waterfall.ApplicationInsightsTelemetryClient')
+    @patch('botbuilder.applicationinsights.ApplicationInsightsTelemetryClient')
     async def test_ensure_end_dialog_called(self, MockTelemetry):
         # arrange
 


### PR DESCRIPTION
Fix waterfall test.  

The DialogState was not being set() (via accessor) before the storage save occurred.