### PR TITLE
Add tests for DateTimePrompt and NumberPrompt

### DIFF
--- a/libraries/botbuilder-dialogs/botbuilder/dialogs/prompts/datetime_prompt.py
+++ b/libraries/botbuilder-dialogs/botbuilder/dialogs/prompts/datetime_prompt.py
@@ -8,6 +8,7 @@ from .datetime_resolution import DateTimeResolution
 from .prompt import Prompt
 from .prompt_options import PromptOptions
 from .prompt_recognizer_result import PromptRecognizerResult
+from recognizers_date_time import recognize_datetime
 
 class DateTimePrompt(Prompt):
     def __init__(self, dialog_id: str, validator: object = None, default_locale: str = None):
@@ -34,10 +35,9 @@ class DateTimePrompt(Prompt):
         if turn_context.activity.type == ActivityTypes.message:
             # Recognize utterance
             message = turn_context.activity
-            # TODO: English contsant needs to be ported.
+            # TODO: English constant needs to be ported.
             culture = message.locale if message.locale != None else "English"
-            # TODO: Move this import to top of file when recognizers package is published
-            from recognizers_date_time import recognize_datetime
+
             results = recognize_datetime(message.text, culture)
             if len(results) > 0:
                 result.succeeded = True

--- a/libraries/botbuilder-dialogs/botbuilder/dialogs/prompts/number_prompt.py
+++ b/libraries/botbuilder-dialogs/botbuilder/dialogs/prompts/number_prompt.py
@@ -4,46 +4,43 @@
 from typing import Dict
 from botbuilder.core.turn_context import TurnContext
 from botbuilder.schema import (ActivityTypes, Activity)
-from .datetime_resolution import DateTimeResolution
 from .prompt import Prompt
 from .prompt_options import PromptOptions
 from .prompt_recognizer_result import PromptRecognizerResult
-
+from recognizers_number import recognize_number
 
 class NumberPrompt(Prompt):
     # TODO: PromptValidator
     def __init__(self, dialog_id: str, validator: object, default_locale: str):
         super(NumberPrompt, self).__init__(dialog_id, validator)
         self.default_locale = default_locale
-        
 
     async def on_prompt(self, turn_context: TurnContext, state: Dict[str, object], options: PromptOptions, is_retry: bool):
         if not turn_context:
             raise TypeError('NumberPrompt.on_prompt(): turn_context cannot be None.')
         if not options:
             raise TypeError('NumberPrompt.on_prompt(): options cannot be None.')
-        
+
         if is_retry == True and options.retry_prompt != None:
-            prompt = turn_context.send_activity(options.retry_prompt)  
+            prompt = turn_context.send_activity(options.retry_prompt)
         else:
             if options.prompt != None:
-                turn_context.send_activity(options.prompt)
-
+                await turn_context.send_activity(options.prompt)
 
     async def on_recognize(self, turn_context: TurnContext, state: Dict[str, object], options: PromptOptions) -> PromptRecognizerResult:
         if not turn_context:
             raise TypeError('NumberPrompt.on_recognize(): turn_context cannot be None.')
-        
+
         result = PromptRecognizerResult()
         if turn_context.activity.type == ActivityTypes.message:
             message = turn_context.activity
-            
+
             # TODO: Fix constant English with correct constant from text recognizer
             culture = turn_context.activity.locale if turn_context.activity.locale != None else 'English'
-            # TODO: Port ChoiceRecognizer
-            results = ChoiceRecognizer.recognize_number(message.text, culture)
-            if results.Count > 0:
+
+            results = recognize_number(message.text, culture)
+            if len(results) > 0:
                 result.succeeded = True
                 result.value = results[0].resolution["value"]
-        
+
         return result

--- a/libraries/botbuilder-dialogs/tests/test_dateTime_prompt.py
+++ b/libraries/botbuilder-dialogs/tests/test_dateTime_prompt.py
@@ -1,0 +1,53 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+import aiounittest
+from botbuilder.dialogs.prompts import (DateTimePrompt, PromptOptions)
+from botbuilder.core import MessageFactory
+from botbuilder.core import (ConversationState, MemoryStorage, TurnContext)
+from botbuilder.dialogs import (DialogSet, DialogTurnStatus)
+from botbuilder.core.adapters import (TestAdapter, TestFlow)
+
+
+class DatetimePromptTests(aiounittest.AsyncTestCase):
+
+    async def test_date_time_prompt(self):
+        # Create new ConversationState with MemoryStorage and register the state as middleware.
+        conver_state = ConversationState(MemoryStorage())
+
+        # Create a DialogState property
+        dialog_state = conver_state.create_property('dialogState')
+
+        #Create new DialogSet.
+        dialogs = DialogSet(dialog_state)
+
+        #Create and add DateTime prompt to DialogSet.
+        dateTimePrompt = DateTimePrompt('DateTimePrompt')
+
+        dialogs.add(dateTimePrompt)
+
+        # Initialize TestAdapter
+        async def exec_test(turn_context: TurnContext) -> None:
+            prompt_msg = 'What date would you like?'
+            dc = await dialogs.create_context(turn_context)
+
+            results = await dc.continue_dialog()
+            if results.status == DialogTurnStatus.Empty:
+
+                options = PromptOptions(
+                    prompt=MessageFactory.text(prompt_msg)
+                )
+                await dc.begin_dialog('DateTimePrompt', options)
+            else:
+                if results.status == DialogTurnStatus.Complete:
+                    resolution = results.result[0]
+                    reply = MessageFactory.text(f"Timex: '{resolution.timex}' Value: '{resolution.value}'")
+                    await turn_context.send_activity(reply)
+            await conver_state.save_changes(turn_context)
+
+        adapt = TestAdapter(exec_test)
+
+        tf = TestFlow(None, adapt)
+        tf2 = await tf.send('hello')
+        tf3 = await tf2.assert_reply('What date would you like?')
+        tf4 = await tf3.send('5th December 2018 at 9am')
+        tf5 = await tf4.assert_reply("Timex: '2018-12-05T09' Value: '2018-12-05 09:00:00'")

--- a/libraries/botbuilder-dialogs/tests/test_number_prompt.py
+++ b/libraries/botbuilder-dialogs/tests/test_number_prompt.py
@@ -1,10 +1,48 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 import aiounittest
-from botbuilder.dialogs.prompts import NumberPrompt
+from botbuilder.dialogs.prompts import NumberPrompt, PromptOptions
+from botbuilder.core import MemoryStorage, ConversationState, TurnContext, MessageFactory
+from botbuilder.core.adapters import TestAdapter, TestFlow
+from botbuilder.dialogs import DialogSet, DialogTurnStatus
 
 class NumberPromptTests(aiounittest.AsyncTestCase):
     def test_empty_should_fail(self):
         empty_id = ''
         self.assertRaises(TypeError, lambda:NumberPrompt(empty_id))
-    
+
+    async def test_number_prompt(self):
+        # Create new ConversationState with MemoryStorage and register the state as middleware.
+        conver_state = ConversationState(MemoryStorage())
+
+        # Create a DialogState property, DialogSet and register the WaterfallDialog.
+        dialog_state = conver_state.create_property('dialogState')
+
+        dialogs = DialogSet(dialog_state)
+
+        # Create and add number prompt to DialogSet.
+        numberPrompt = NumberPrompt('NumberPrompt', None, 'English')
+        dialogs.add(numberPrompt)
+
+        async def exec_test(turn_context: TurnContext) -> None:
+
+            dialogContext = await dialogs.create_context(turn_context)
+            results = await dialogContext.continue_dialog()
+
+            if results.status == DialogTurnStatus.Empty:
+                await dialogContext.begin_dialog('NumberPrompt', PromptOptions(prompt = MessageFactory.text('Enter quantity of cable')))
+            else:
+                if results.status == DialogTurnStatus.Complete:
+                    numberResult = results.result
+                    await turn_context.send_activity(MessageFactory.text(f"You asked me for '{numberResult}' meters of cable."))
+
+            await conver_state.save_changes(turn_context)
+
+        adapter = TestAdapter(exec_test)
+
+        test_flow = TestFlow(None, adapter)
+
+        test_flow2 = await test_flow.send('Hello')
+        test_flow3 = await test_flow2.assert_reply('Enter quantity of cable')
+        test_flow4 = await test_flow3.send('Give me twenty meters of cable')
+        test_flow5 = await test_flow4.assert_reply("You asked me for '20' meters of cable.")


### PR DESCRIPTION
## Proposed Changes

- Add a new test for **DateTimePrompt** using _Recognizers-Text.DateTime_.
![image](https://user-images.githubusercontent.com/44245136/57703476-8a2c9580-7636-11e9-90ae-5bbf73d9a784.png)
- Add a new test for **NumberPrompt** using _Recognizers-Text.Number_.
![image](https://user-images.githubusercontent.com/44245136/57703398-5fdad800-7636-11e9-85f6-b90f59013c8e.png)
- Minor fixes on **NumberPrompt** class to use _recognize_number_ method (replaced ChoiceRecognizer with NumberRecognizer for parity with DotNet implementation).


We ran all tests locally, also, we configured an Azure Pipeline to automatically run the tests.
![image](https://user-images.githubusercontent.com/44245136/57704716-db3d8900-7638-11e9-96cf-55a3467f3165.png)
_Note: It's necessary to update the Recognizers-Text-Number package with the fix made in PR# 1554 of Recognizers-Text_

## Steps to configure a Pipeline for CI:
1. Add a **_Use Python_** task. Configure it to use the latest version of python.
![image](https://user-images.githubusercontent.com/44245136/57706837-dd094b80-763c-11e9-9736-ac5b2a94862a.png)
2. Add a **_Command Line_** task to run all the test in the botbuilder-libraries.
![image](https://user-images.githubusercontent.com/44245136/57706957-278ac800-763d-11e9-93b4-ee9bacb3b37f.png)
The script used is:
```Powershell
pip install -e ./libraries/botbuilder-schema
pip install -e ./libraries/botframework-connector
pip install -e ./libraries/botbuilder-core 
pip install -e ./libraries/botbuilder-azure
pip install -r ./libraries/botframework-connector/tests/requirements.txt
pip install -e ./libraries/botbuilder-ai
pip install -e ./libraries/botbuilder-dialogs
pip install -e ./libraries/botbuilder-applicationinsights

cd libraries
	
pytest --tb=line
```
In this image we can see the tests ran successfully:
![image](https://user-images.githubusercontent.com/44245136/57707159-82242400-763d-11e9-852b-de501a0ead9c.png)