### PR TITLE
Telemetry emits correct EventData for "No Answer Found in KB" case

### DIFF
--- a/libraries/botbuilder-ai/botbuilder/ai/qna/qnamaker.py
+++ b/libraries/botbuilder-ai/botbuilder/ai/qna/qnamaker.py
@@ -305,9 +305,7 @@ class QnAMaker(QnAMakerTelemetryClient):
             json_res = await result.json()
 
         answers_within_threshold = [
-            { **answer,'score': answer['score']/100 } 
-            if answer['score']/100 > options.score_threshold 
-            else {**answer} for answer in json_res['answers'] 
+            { **answer,'score': answer['score']/100 } for answer in json_res['answers'] if answer['score']/100 > options.score_threshold
         ]
         sorted_answers = sorted(answers_within_threshold, key = lambda ans: ans['score'], reverse = True)
 

--- a/libraries/botbuilder-ai/tests/qna/test_data/NoAnswerFoundInKb.json
+++ b/libraries/botbuilder-ai/tests/qna/test_data/NoAnswerFoundInKb.json
@@ -1,0 +1,13 @@
+{
+    "answers": [
+        {
+            "questions": [],
+            "answer": "No good match found in KB.",
+            "score": 0,
+            "id": -1,
+            "source": null,
+            "metadata": []
+        }
+    ],
+    "debugInfo": null
+}

--- a/libraries/botbuilder-ai/tests/qna/test_qna.py
+++ b/libraries/botbuilder-ai/tests/qna/test_qna.py
@@ -291,6 +291,45 @@ class QnaApplicationTest(aiounittest.AsyncTestCase):
             self.assertEqual(expected_answer, results[0].answer[0])
             self.assertEqual('Editorial', results[0].source)
     
+    async def test_telemetry_returns_answer_when_no_answer_found_in_kb(self):
+        # Arrange
+        question: str = 'gibberish question'
+        response_json = QnaApplicationTest._get_json_for_file('NoAnswerFoundInKb.json')
+        telemetry_client = unittest.mock.create_autospec(BotTelemetryClient)
+        qna = QnAMaker(QnaApplicationTest.tests_endpoint, telemetry_client=telemetry_client, log_personal_information=True)
+        context = QnaApplicationTest._get_context(question, TestAdapter())
+
+        # Act
+        with patch('aiohttp.ClientSession.post', return_value = aiounittest.futurized(response_json)):
+            results = await qna.get_answers(context)
+
+            telemetry_args = telemetry_client.track_event.call_args_list[0][1]
+            telemetry_properties = telemetry_args['properties']
+            telemetry_metrics = telemetry_args['measurements']
+            number_of_args = len(telemetry_args)
+            first_answer = telemetry_args['properties'][QnATelemetryConstants.answer_property][0]
+            expected_answer = 'No good match found in KB.'
+
+            # Assert - Check Telemetry logged.
+            self.assertEqual(1, telemetry_client.track_event.call_count)
+            self.assertEqual(3, number_of_args)
+            self.assertEqual('QnaMessage', telemetry_args['name'])
+            self.assertTrue('answer' in telemetry_properties)
+            self.assertTrue('knowledgeBaseId' in telemetry_properties)
+            self.assertTrue('matchedQuestion' in telemetry_properties)
+            self.assertTrue('question' in telemetry_properties)
+            self.assertTrue('questionId' in telemetry_properties)
+            self.assertTrue('articleFound' in telemetry_properties)
+            self.assertEqual(expected_answer, first_answer)
+            self.assertTrue('score' in telemetry_metrics)
+            self.assertEqual(0, telemetry_metrics['score'][0])
+
+            # Assert - Validate we didn't break QnA functionality.
+            self.assertIsNotNone(results)
+            self.assertEqual(1, len(results))
+            self.assertEqual(expected_answer, results[0].answer[0])
+            self.assertEqual(None, results[0].source)
+    
     async def test_telemetry_pii(self):
         # Arrange
         question: str = 'how do I clean the stove?'


### PR DESCRIPTION
Fixes issue #179 

## Description
* When QnAMaker API returns "`No good match found in KB.`", it will be filtered properly now in `QnAMaker._format_qna_results()`.
* Added unit test for "No good match found in KB" case
