### PR TITLE
update .gitignore, remove asyncio from flask core-bot requirements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ __pycache__/
 
 # Virtual environment
 env*/
+venv*/
 
 # PTVS analysis
 .ptvs/

--- a/samples/python-flask/13.core-bot/main.py
+++ b/samples/python-flask/13.core-bot/main.py
@@ -64,9 +64,9 @@ def messages():
     auth_header = request.headers['Authorization'] if 'Authorization' in request.headers else ''
     
     async def aux_func(turn_context):
-        asyncio.ensure_future(bot.on_turn(turn_context))
+        asyncio.ensure_future(bot.on_turn(turn_context), loop=loop)
     try:
-        task = loop.create_task(ADAPTER.process_activity(activity, auth_header, aux_func))
+        task = asyncio.ensure_future(ADAPTER.process_activity(activity, auth_header, aux_func), loop=loop)
         loop.run_until_complete(task)
         return Response(status=201)
     except Exception as e:

--- a/samples/python-flask/13.core-bot/requirements.txt
+++ b/samples/python-flask/13.core-bot/requirements.txt
@@ -1,5 +1,4 @@
 Flask>=1.0.2
-asyncio>=3.4.3
 requests>=2.18.1
 botframework-connector>=4.4.0.b1
 botbuilder-schema>=4.4.0.b1


### PR DESCRIPTION
## Changes
- Adds `venv*/` to `.gitignore`
- Removes `asyncio` from flask core-bot's requirements.txt (this is a core module and `asyncio` on PyPI is only relevant for Python 3.3 which doesn't include `asyncio` in its stdlib.
- Minor cleanup in flask core-bot's `main.py`