### PR TITLE
ChoicePrompt properly uses ListStyle that's specified

### DIFF
--- a/libraries/botbuilder-dialogs/botbuilder/dialogs/prompts/choice_prompt.py
+++ b/libraries/botbuilder-dialogs/botbuilder/dialogs/prompts/choice_prompt.py
@@ -30,28 +30,28 @@ class ChoicePrompt(Prompt):
 
     _default_choice_options: Dict[str, ChoiceFactoryOptions] = {
         Culture.Spanish: ChoiceFactoryOptions(
-            inline_separator=", ", inline_or=" o ", include_numbers=True
+            inline_separator=", ", inline_or=" o ", inline_or_more=", o ", include_numbers=True
         ),
         Culture.Dutch: ChoiceFactoryOptions(
-            inline_separator=", ", inline_or=" of ", include_numbers=True
+            inline_separator=", ", inline_or=" of ", inline_or_more=", of ", include_numbers=True
         ),
         Culture.English: ChoiceFactoryOptions(
-            inline_separator=", ", inline_or=" or ", include_numbers=True
+            inline_separator=", ", inline_or=" or ", inline_or_more=", or ", include_numbers=True
         ),
         Culture.French: ChoiceFactoryOptions(
-            inline_separator=", ", inline_or=" ou ", include_numbers=True
+            inline_separator=", ", inline_or=" ou ", inline_or_more=", ou ", include_numbers=True
         ),
         "de-de": ChoiceFactoryOptions(
-            inline_separator=", ", inline_or=" oder ", include_numbers=True
+            inline_separator=", ", inline_or=" oder ", inline_or_more=", oder ", include_numbers=True
         ),
         Culture.Japanese: ChoiceFactoryOptions(
-            inline_separator="、 ", inline_or=" または ", include_numbers=True
+            inline_separator="、 ", inline_or=" または ", inline_or_more="、 または ", include_numbers=True
         ),
         Culture.Portuguese: ChoiceFactoryOptions(
-            inline_separator=", ", inline_or=" ou ", include_numbers=True
+            inline_separator=", ", inline_or=" ou ", inline_or_more=", ou ", include_numbers=True
         ),
         Culture.Chinese: ChoiceFactoryOptions(
-            inline_separator="， ", inline_or=" 要么 ", include_numbers=True
+            inline_separator="， ", inline_or=" 要么 ", inline_or_more="， 要么 ", include_numbers=True
         ),
     }
 

--- a/libraries/botbuilder-dialogs/botbuilder/dialogs/prompts/choice_prompt.py
+++ b/libraries/botbuilder-dialogs/botbuilder/dialogs/prompts/choice_prompt.py
@@ -30,28 +30,52 @@ class ChoicePrompt(Prompt):
 
     _default_choice_options: Dict[str, ChoiceFactoryOptions] = {
         Culture.Spanish: ChoiceFactoryOptions(
-            inline_separator=', ', inline_or=' o ', inline_or_more=', o ', include_numbers=True
+            inline_separator=", ",
+            inline_or=" o ",
+            inline_or_more=", o ",
+            include_numbers=True,
         ),
         Culture.Dutch: ChoiceFactoryOptions(
-            inline_separator=', ', inline_or=' of ', inline_or_more=', of ', include_numbers=True
+            inline_separator=", ",
+            inline_or=" of ",
+            inline_or_more=", of ",
+            include_numbers=True,
         ),
         Culture.English: ChoiceFactoryOptions(
-            inline_separator=', ', inline_or=' or ', inline_or_more=', or ', include_numbers=True
+            inline_separator=", ",
+            inline_or=" or ",
+            inline_or_more=", or ",
+            include_numbers=True,
         ),
         Culture.French: ChoiceFactoryOptions(
-            inline_separator=', ', inline_or=' ou ', inline_or_more=', ou ', include_numbers=True
+            inline_separator=", ",
+            inline_or=" ou ",
+            inline_or_more=", ou ",
+            include_numbers=True,
         ),
-        'de-de': ChoiceFactoryOptions(
-            inline_separator=', ', inline_or=' oder ', inline_or_more=', oder ', include_numbers=True
+        "de-de": ChoiceFactoryOptions(
+            inline_separator=", ",
+            inline_or=" oder ",
+            inline_or_more=", oder ",
+            include_numbers=True,
         ),
         Culture.Japanese: ChoiceFactoryOptions(
-            inline_separator='、 ', inline_or=' または ', inline_or_more='、 または ', include_numbers=True
+            inline_separator="、 ",
+            inline_or=" または ",
+            inline_or_more="、 または ",
+            include_numbers=True,
         ),
         Culture.Portuguese: ChoiceFactoryOptions(
-            inline_separator=', ', inline_or=' ou ', inline_or_more=', ou ', include_numbers=True
+            inline_separator=", ",
+            inline_or=" ou ",
+            inline_or_more=", ou ",
+            include_numbers=True,
         ),
         Culture.Chinese: ChoiceFactoryOptions(
-            inline_separator='， ', inline_or=' 要么 ', inline_or_more='， 要么 ', include_numbers=True
+            inline_separator="， ",
+            inline_or=" 要么 ",
+            inline_or_more="， 要么 ",
+            include_numbers=True,
         ),
     }
 
@@ -76,10 +100,10 @@ class ChoicePrompt(Prompt):
         is_retry: bool,
     ):
         if not turn_context:
-            raise TypeError('ChoicePrompt.on_prompt(): turn_context cannot be None.')
+            raise TypeError("ChoicePrompt.on_prompt(): turn_context cannot be None.")
 
         if not options:
-            raise TypeError('ChoicePrompt.on_prompt(): options cannot be None.')
+            raise TypeError("ChoicePrompt.on_prompt(): options cannot be None.")
 
         # Determine culture
         culture: Union[
@@ -116,7 +140,7 @@ class ChoicePrompt(Prompt):
         options: PromptOptions,
     ) -> PromptRecognizerResult:
         if not turn_context:
-            raise TypeError('ChoicePrompt.on_recognize(): turn_context cannot be None.')
+            raise TypeError("ChoicePrompt.on_recognize(): turn_context cannot be None.")
 
         choices: List[Choice] = options.choices if (options and options.choices) else []
         result: PromptRecognizerResult = PromptRecognizerResult()

--- a/libraries/botbuilder-dialogs/botbuilder/dialogs/prompts/choice_prompt.py
+++ b/libraries/botbuilder-dialogs/botbuilder/dialogs/prompts/choice_prompt.py
@@ -30,28 +30,28 @@ class ChoicePrompt(Prompt):
 
     _default_choice_options: Dict[str, ChoiceFactoryOptions] = {
         Culture.Spanish: ChoiceFactoryOptions(
-            inline_separator=", ", inline_or=" o ", inline_or_more=", o ", include_numbers=True
+            inline_separator=', ', inline_or=' o ', inline_or_more=', o ', include_numbers=True
         ),
         Culture.Dutch: ChoiceFactoryOptions(
-            inline_separator=", ", inline_or=" of ", inline_or_more=", of ", include_numbers=True
+            inline_separator=', ', inline_or=' of ', inline_or_more=', of ', include_numbers=True
         ),
         Culture.English: ChoiceFactoryOptions(
-            inline_separator=", ", inline_or=" or ", inline_or_more=", or ", include_numbers=True
+            inline_separator=', ', inline_or=' or ', inline_or_more=', or ', include_numbers=True
         ),
         Culture.French: ChoiceFactoryOptions(
-            inline_separator=", ", inline_or=" ou ", inline_or_more=", ou ", include_numbers=True
+            inline_separator=', ', inline_or=' ou ', inline_or_more=', ou ', include_numbers=True
         ),
-        "de-de": ChoiceFactoryOptions(
-            inline_separator=", ", inline_or=" oder ", inline_or_more=", oder ", include_numbers=True
+        'de-de': ChoiceFactoryOptions(
+            inline_separator=', ', inline_or=' oder ', inline_or_more=', oder ', include_numbers=True
         ),
         Culture.Japanese: ChoiceFactoryOptions(
-            inline_separator="、 ", inline_or=" または ", inline_or_more="、 または ", include_numbers=True
+            inline_separator='、 ', inline_or=' または ', inline_or_more='、 または ', include_numbers=True
         ),
         Culture.Portuguese: ChoiceFactoryOptions(
-            inline_separator=", ", inline_or=" ou ", inline_or_more=", ou ", include_numbers=True
+            inline_separator=', ', inline_or=' ou ', inline_or_more=', ou ', include_numbers=True
         ),
         Culture.Chinese: ChoiceFactoryOptions(
-            inline_separator="， ", inline_or=" 要么 ", inline_or_more="， 要么 ", include_numbers=True
+            inline_separator='， ', inline_or=' 要么 ', inline_or_more='， 要么 ', include_numbers=True
         ),
     }
 
@@ -76,10 +76,10 @@ class ChoicePrompt(Prompt):
         is_retry: bool,
     ):
         if not turn_context:
-            raise TypeError("ChoicePrompt.on_prompt(): turn_context cannot be None.")
+            raise TypeError('ChoicePrompt.on_prompt(): turn_context cannot be None.')
 
         if not options:
-            raise TypeError("ChoicePrompt.on_prompt(): options cannot be None.")
+            raise TypeError('ChoicePrompt.on_prompt(): options cannot be None.')
 
         # Determine culture
         culture: Union[
@@ -116,7 +116,7 @@ class ChoicePrompt(Prompt):
         options: PromptOptions,
     ) -> PromptRecognizerResult:
         if not turn_context:
-            raise TypeError("ChoicePrompt.on_recognize(): turn_context cannot be None.")
+            raise TypeError('ChoicePrompt.on_recognize(): turn_context cannot be None.')
 
         choices: List[Choice] = options.choices if (options and options.choices) else []
         result: PromptRecognizerResult = PromptRecognizerResult()

--- a/libraries/botbuilder-dialogs/botbuilder/dialogs/prompts/prompt.py
+++ b/libraries/botbuilder-dialogs/botbuilder/dialogs/prompts/prompt.py
@@ -12,7 +12,7 @@ from ..dialog_turn_result import DialogTurnResult
 from ..dialog_context import DialogContext
 from botbuilder.core.turn_context import TurnContext
 from botbuilder.schema import InputHints, ActivityTypes
-from botbuilder.dialogs.choices import ChoiceFactory
+from botbuilder.dialogs.choices import ChoiceFactory, ListStyle
 
 from abc import abstractmethod
 from botbuilder.schema import Activity
@@ -143,14 +143,13 @@ class Prompt(Dialog):
         pass
 
     # TODO: Fix choices to use Choice object when ported.
-    # TODO: Fix style to use ListStyle when ported.
     # TODO: Fix options to use ChoiceFactoryOptions object when ported.
     def append_choices(
         self,
         prompt: Activity,
         channel_id: str,
         choices: object,
-        style: object,
+        style: ListStyle,
         options: object = None,
     ) -> Activity:
         """

--- a/libraries/botbuilder-dialogs/botbuilder/dialogs/prompts/prompt.py
+++ b/libraries/botbuilder-dialogs/botbuilder/dialogs/prompts/prompt.py
@@ -22,9 +22,9 @@ from botbuilder.schema import Activity
 
 
 class Prompt(Dialog):
-    ATTEMPT_COUNT_KEY = 'AttemptCount'
-    persisted_options = 'options'
-    persisted_state = 'state'
+    ATTEMPT_COUNT_KEY = "AttemptCount"
+    persisted_options = "options"
+    persisted_state = "state"
 
     def __init__(self, dialog_id: str, validator: object = None):
         """Creates a new Prompt instance.
@@ -45,9 +45,9 @@ class Prompt(Dialog):
         self, dc: DialogContext, options: object
     ) -> DialogTurnResult:
         if not dc:
-            raise TypeError('Prompt(): dc cannot be None.')
+            raise TypeError("Prompt(): dc cannot be None.")
         if not isinstance(options, PromptOptions):
-            raise TypeError('Prompt(): Prompt options are required for Prompt dialogs.')
+            raise TypeError("Prompt(): Prompt options are required for Prompt dialogs.")
         # Ensure prompts have input hint set
         if options.prompt is not None and not options.prompt.input_hint:
             options.prompt.input_hint = InputHints.expecting_input
@@ -72,7 +72,7 @@ class Prompt(Dialog):
 
     async def continue_dialog(self, dc: DialogContext):
         if not dc:
-            raise TypeError('Prompt(): dc cannot be None.')
+            raise TypeError("Prompt(): dc cannot be None.")
 
         # Don't do anything for non-message activities
         if dc.context.activity.type != ActivityTypes.message:

--- a/libraries/botbuilder-dialogs/botbuilder/dialogs/prompts/prompt.py
+++ b/libraries/botbuilder-dialogs/botbuilder/dialogs/prompts/prompt.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 import copy
-from typing import Dict
+from typing import Dict, List
 from .prompt_options import PromptOptions
 from .prompt_validator_context import PromptValidatorContext
 from ..dialog_reason import DialogReason
@@ -12,7 +12,7 @@ from ..dialog_turn_result import DialogTurnResult
 from ..dialog_context import DialogContext
 from botbuilder.core.turn_context import TurnContext
 from botbuilder.schema import InputHints, ActivityTypes
-from botbuilder.dialogs.choices import ChoiceFactory, ListStyle
+from botbuilder.dialogs.choices import Choice, ChoiceFactory, ChoiceFactoryOptions, ListStyle
 
 from abc import abstractmethod
 from botbuilder.schema import Activity
@@ -142,15 +142,13 @@ class Prompt(Dialog):
     ):
         pass
 
-    # TODO: Fix choices to use Choice object when ported.
-    # TODO: Fix options to use ChoiceFactoryOptions object when ported.
     def append_choices(
         self,
         prompt: Activity,
         channel_id: str,
-        choices: object,
+        choices: List[Choice],
         style: ListStyle,
-        options: object = None,
+        options: ChoiceFactoryOptions = None,
     ) -> Activity:
         """
         Helper function to compose an output activity containing a set of choices.

--- a/libraries/botbuilder-dialogs/botbuilder/dialogs/prompts/prompt.py
+++ b/libraries/botbuilder-dialogs/botbuilder/dialogs/prompts/prompt.py
@@ -12,7 +12,12 @@ from ..dialog_turn_result import DialogTurnResult
 from ..dialog_context import DialogContext
 from botbuilder.core.turn_context import TurnContext
 from botbuilder.schema import InputHints, ActivityTypes
-from botbuilder.dialogs.choices import Choice, ChoiceFactory, ChoiceFactoryOptions, ListStyle
+from botbuilder.dialogs.choices import (
+    Choice,
+    ChoiceFactory,
+    ChoiceFactoryOptions,
+    ListStyle,
+)
 
 from abc import abstractmethod
 from botbuilder.schema import Activity
@@ -167,7 +172,7 @@ class Prompt(Dialog):
         options: (Optional) options to configure the underlying `ChoiceFactory` call.
         """
         # Get base prompt text (if any)
-        text = prompt.text if prompt != None and not prompt.text == False else ''
+        text = prompt.text if prompt != None and not prompt.text == False else ""
 
         # Create temporary msg
         # TODO: fix once ChoiceFactory complete
@@ -198,9 +203,9 @@ class Prompt(Dialog):
             2: inline,
             3: list_style,
             4: suggested_action,
-            5: hero_card
+            5: hero_card,
         }
- 
+
         msg = switcher.get(int(style.value), default)()
 
         # Update prompt with text, actions and attachments

--- a/libraries/botbuilder-dialogs/botbuilder/dialogs/prompts/prompt.py
+++ b/libraries/botbuilder-dialogs/botbuilder/dialogs/prompts/prompt.py
@@ -22,9 +22,9 @@ from botbuilder.schema import Activity
 
 
 class Prompt(Dialog):
-    ATTEMPT_COUNT_KEY = "AttemptCount"
-    persisted_options = "options"
-    persisted_state = "state"
+    ATTEMPT_COUNT_KEY = 'AttemptCount'
+    persisted_options = 'options'
+    persisted_state = 'state'
 
     def __init__(self, dialog_id: str, validator: object = None):
         """Creates a new Prompt instance.
@@ -45,9 +45,9 @@ class Prompt(Dialog):
         self, dc: DialogContext, options: object
     ) -> DialogTurnResult:
         if not dc:
-            raise TypeError("Prompt(): dc cannot be None.")
+            raise TypeError('Prompt(): dc cannot be None.')
         if not isinstance(options, PromptOptions):
-            raise TypeError("Prompt(): Prompt options are required for Prompt dialogs.")
+            raise TypeError('Prompt(): Prompt options are required for Prompt dialogs.')
         # Ensure prompts have input hint set
         if options.prompt is not None and not options.prompt.input_hint:
             options.prompt.input_hint = InputHints.expecting_input
@@ -72,7 +72,7 @@ class Prompt(Dialog):
 
     async def continue_dialog(self, dc: DialogContext):
         if not dc:
-            raise TypeError("Prompt(): dc cannot be None.")
+            raise TypeError('Prompt(): dc cannot be None.')
 
         # Don't do anything for non-message activities
         if dc.context.activity.type != ActivityTypes.message:
@@ -167,7 +167,7 @@ class Prompt(Dialog):
         options: (Optional) options to configure the underlying `ChoiceFactory` call.
         """
         # Get base prompt text (if any)
-        text = prompt.text if prompt != None and not prompt.text == False else ""
+        text = prompt.text if prompt != None and not prompt.text == False else ''
 
         # Create temporary msg
         # TODO: fix once ChoiceFactory complete

--- a/libraries/botbuilder-dialogs/botbuilder/dialogs/prompts/prompt.py
+++ b/libraries/botbuilder-dialogs/botbuilder/dialogs/prompts/prompt.py
@@ -187,23 +187,24 @@ class Prompt(Dialog):
             return ChoiceFactory.hero_card(choices, text)
 
         def list_style_none() -> Activity:
-            activity = Activity()
+            activity = Activity(type=ActivityTypes.message)
             activity.text = text
             return activity
 
         def default() -> Activity:
             return ChoiceFactory.for_channel(channel_id, choices, text, None, options)
 
+        # Maps to values in ListStyle Enum
         switcher = {
-            # ListStyle.inline
-            1: inline,
-            2: list_style,
-            3: suggested_action,
-            4: hero_card,
-            5: list_style_none,
-        }
-
-        msg = switcher.get(style, default)()
+            0: list_style_none,
+            1: default,
+            2: inline,
+            3: list_style,
+            4: suggested_action,
+            5: hero_card
+            }
+            
+        msg = switcher.get(int(style.value), default)()
 
         # Update prompt with text, actions and attachments
         if not prompt:

--- a/libraries/botbuilder-dialogs/botbuilder/dialogs/prompts/prompt.py
+++ b/libraries/botbuilder-dialogs/botbuilder/dialogs/prompts/prompt.py
@@ -199,8 +199,8 @@ class Prompt(Dialog):
             3: list_style,
             4: suggested_action,
             5: hero_card
-            }
-            
+        }
+ 
         msg = switcher.get(int(style.value), default)()
 
         # Update prompt with text, actions and attachments

--- a/libraries/botbuilder-dialogs/tests/test_choice_prompt.py
+++ b/libraries/botbuilder-dialogs/tests/test_choice_prompt.py
@@ -25,18 +25,18 @@ from botbuilder.dialogs.prompts import (
 from botbuilder.schema import Activity, ActivityTypes
 
 _color_choices: List[Choice] = [
-    Choice(value="red"),
-    Choice(value="green"),
-    Choice(value="blue"),
+    Choice(value='red'),
+    Choice(value='green'),
+    Choice(value='blue'),
 ]
 
-_answer_message: Activity = Activity(text="red", type=ActivityTypes.message)
-_invalid_message: Activity = Activity(text="purple", type=ActivityTypes.message)
+_answer_message: Activity = Activity(text='red', type=ActivityTypes.message)
+_invalid_message: Activity = Activity(text='purple', type=ActivityTypes.message)
 
 
 class ChoicePromptTest(aiounittest.AsyncTestCase):
     def test_choice_prompt_with_empty_id_should_fail(self):
-        empty_id = ""
+        empty_id = ''
 
         with self.assertRaises(TypeError):
             ChoicePrompt(empty_id)
@@ -56,11 +56,11 @@ class ChoicePromptTest(aiounittest.AsyncTestCase):
             if results.status == DialogTurnStatus.Empty:
                 options = PromptOptions(
                     prompt=Activity(
-                        type=ActivityTypes.message, text="Please choose a color."
+                        type=ActivityTypes.message, text='Please choose a color.'
                     ),
                     choices=_color_choices,
                 )
-                await dc.prompt("ChoicePrompt", options)
+                await dc.prompt('ChoicePrompt', options)
             elif results.status == DialogTurnStatus.Complete:
                 selected_choice = results.result
                 await turn_context.send_activity(selected_choice.value)
@@ -74,17 +74,17 @@ class ChoicePromptTest(aiounittest.AsyncTestCase):
         convo_state = ConversationState(MemoryStorage())
 
         # Create a DialogState property, DialogSet, and ChoicePrompt.
-        dialog_state = convo_state.create_property("dialogState")
+        dialog_state = convo_state.create_property('dialogState')
         dialogs = DialogSet(dialog_state)
-        choice_prompt = ChoicePrompt("ChoicePrompt")
+        choice_prompt = ChoicePrompt('ChoicePrompt')
         dialogs.add(choice_prompt)
 
-        step1 = await adapter.send("hello")
+        step1 = await adapter.send('hello')
         step2 = await step1.assert_reply(
-            "Please choose a color. (1) red, (2) green, or (3) blue"
+            'Please choose a color. (1) red, (2) green, or (3) blue'
         )
         step3 = await step2.send(_answer_message)
-        await step3.assert_reply("red")
+        await step3.assert_reply('red')
 
     async def test_should_call_ChoicePrompt_with_custom_validator(self):
         async def exec_test(turn_context: TurnContext):
@@ -95,11 +95,11 @@ class ChoicePromptTest(aiounittest.AsyncTestCase):
             if results.status == DialogTurnStatus.Empty:
                 options = PromptOptions(
                     prompt=Activity(
-                        type=ActivityTypes.message, text="Please choose a color."
+                        type=ActivityTypes.message, text='Please choose a color.'
                     ),
                     choices=_color_choices,
                 )
-                await dc.prompt("prompt", options)
+                await dc.prompt('prompt', options)
             elif results.status == DialogTurnStatus.Complete:
                 selected_choice = results.result
                 await turn_context.send_activity(selected_choice.value)
@@ -109,7 +109,7 @@ class ChoicePromptTest(aiounittest.AsyncTestCase):
         adapter = TestAdapter(exec_test)
 
         convo_state = ConversationState(MemoryStorage())
-        dialog_state = convo_state.create_property("dialogState")
+        dialog_state = convo_state.create_property('dialogState')
         dialogs = DialogSet(dialog_state)
 
         async def validator(prompt: PromptValidatorContext) -> bool:
@@ -117,20 +117,20 @@ class ChoicePromptTest(aiounittest.AsyncTestCase):
 
             return prompt.recognized.succeeded
 
-        choice_prompt = ChoicePrompt("prompt", validator)
+        choice_prompt = ChoicePrompt('prompt', validator)
 
         dialogs.add(choice_prompt)
 
-        step1 = await adapter.send("Hello")
+        step1 = await adapter.send('Hello')
         step2 = await step1.assert_reply(
-            "Please choose a color. (1) red, (2) green, or (3) blue"
+            'Please choose a color. (1) red, (2) green, or (3) blue'
         )
         step3 = await step2.send(_invalid_message)
         step4 = await step3.assert_reply(
-            "Please choose a color. (1) red, (2) green, or (3) blue"
+            'Please choose a color. (1) red, (2) green, or (3) blue'
         )
         step5 = await step4.send(_answer_message)
-        await step5.assert_reply("red")
+        await step5.assert_reply('red')
 
     async def test_should_send_custom_retry_prompt(self):
         async def exec_test(turn_context: TurnContext):
@@ -141,15 +141,15 @@ class ChoicePromptTest(aiounittest.AsyncTestCase):
             if results.status == DialogTurnStatus.Empty:
                 options = PromptOptions(
                     prompt=Activity(
-                        type=ActivityTypes.message, text="Please choose a color."
+                        type=ActivityTypes.message, text='Please choose a color.'
                     ),
                     retry_prompt=Activity(
                         type=ActivityTypes.message,
-                        text="Please choose red, blue, or green.",
+                        text='Please choose red, blue, or green.',
                     ),
                     choices=_color_choices,
                 )
-                await dc.prompt("prompt", options)
+                await dc.prompt('prompt', options)
             elif results.status == DialogTurnStatus.Complete:
                 selected_choice = results.result
                 await turn_context.send_activity(selected_choice.value)
@@ -159,21 +159,21 @@ class ChoicePromptTest(aiounittest.AsyncTestCase):
         adapter = TestAdapter(exec_test)
 
         convo_state = ConversationState(MemoryStorage())
-        dialog_state = convo_state.create_property("dialogState")
+        dialog_state = convo_state.create_property('dialogState')
         dialogs = DialogSet(dialog_state)
-        choice_prompt = ChoicePrompt("prompt")
+        choice_prompt = ChoicePrompt('prompt')
         dialogs.add(choice_prompt)
 
-        step1 = await adapter.send("Hello")
+        step1 = await adapter.send('Hello')
         step2 = await step1.assert_reply(
-            "Please choose a color. (1) red, (2) green, or (3) blue"
+            'Please choose a color. (1) red, (2) green, or (3) blue'
         )
         step3 = await step2.send(_invalid_message)
         step4 = await step3.assert_reply(
-            "Please choose red, blue, or green. (1) red, (2) green, or (3) blue"
+            'Please choose red, blue, or green. (1) red, (2) green, or (3) blue'
         )
         step5 = await step4.send(_answer_message)
-        await step5.assert_reply("red")
+        await step5.assert_reply('red')
 
     async def test_should_send_ignore_retry_prompt_if_validator_replies(self):
         async def exec_test(turn_context: TurnContext):
@@ -184,15 +184,15 @@ class ChoicePromptTest(aiounittest.AsyncTestCase):
             if results.status == DialogTurnStatus.Empty:
                 options = PromptOptions(
                     prompt=Activity(
-                        type=ActivityTypes.message, text="Please choose a color."
+                        type=ActivityTypes.message, text='Please choose a color.'
                     ),
                     retry_prompt=Activity(
                         type=ActivityTypes.message,
-                        text="Please choose red, blue, or green.",
+                        text='Please choose red, blue, or green.',
                     ),
                     choices=_color_choices,
                 )
-                await dc.prompt("prompt", options)
+                await dc.prompt('prompt', options)
             elif results.status == DialogTurnStatus.Complete:
                 selected_choice = results.result
                 await turn_context.send_activity(selected_choice.value)
@@ -202,29 +202,29 @@ class ChoicePromptTest(aiounittest.AsyncTestCase):
         adapter = TestAdapter(exec_test)
 
         convo_state = ConversationState(MemoryStorage())
-        dialog_state = convo_state.create_property("dialogState")
+        dialog_state = convo_state.create_property('dialogState')
         dialogs = DialogSet(dialog_state)
 
         async def validator(prompt: PromptValidatorContext) -> bool:
             assert prompt
 
             if not prompt.recognized.succeeded:
-                await prompt.context.send_activity("Bad input.")
+                await prompt.context.send_activity('Bad input.')
 
             return prompt.recognized.succeeded
 
-        choice_prompt = ChoicePrompt("prompt", validator)
+        choice_prompt = ChoicePrompt('prompt', validator)
 
         dialogs.add(choice_prompt)
 
-        step1 = await adapter.send("Hello")
+        step1 = await adapter.send('Hello')
         step2 = await step1.assert_reply(
-            "Please choose a color. (1) red, (2) green, or (3) blue"
+            'Please choose a color. (1) red, (2) green, or (3) blue'
         )
         step3 = await step2.send(_invalid_message)
-        step4 = await step3.assert_reply("Bad input.")
+        step4 = await step3.assert_reply('Bad input.')
         step5 = await step4.send(_answer_message)
-        await step5.assert_reply("red")
+        await step5.assert_reply('red')
 
     async def test_should_use_default_locale_when_rendering_choices(self):
         async def exec_test(turn_context: TurnContext):
@@ -235,11 +235,11 @@ class ChoicePromptTest(aiounittest.AsyncTestCase):
             if results.status == DialogTurnStatus.Empty:
                 options = PromptOptions(
                     prompt=Activity(
-                        type=ActivityTypes.message, text="Please choose a color."
+                        type=ActivityTypes.message, text='Please choose a color.'
                     ),
                     choices=_color_choices,
                 )
-                await dc.prompt("prompt", options)
+                await dc.prompt('prompt', options)
             elif results.status == DialogTurnStatus.Complete:
                 selected_choice = results.result
                 await turn_context.send_activity(selected_choice.value)
@@ -249,31 +249,31 @@ class ChoicePromptTest(aiounittest.AsyncTestCase):
         adapter = TestAdapter(exec_test)
 
         convo_state = ConversationState(MemoryStorage())
-        dialog_state = convo_state.create_property("dialogState")
+        dialog_state = convo_state.create_property('dialogState')
         dialogs = DialogSet(dialog_state)
 
         async def validator(prompt: PromptValidatorContext) -> bool:
             assert prompt
 
             if not prompt.recognized.succeeded:
-                await prompt.context.send_activity("Bad input.")
+                await prompt.context.send_activity('Bad input.')
 
             return prompt.recognized.succeeded
 
         choice_prompt = ChoicePrompt(
-            "prompt", validator, default_locale=Culture.Spanish
+            'prompt', validator, default_locale=Culture.Spanish
         )
 
         dialogs.add(choice_prompt)
 
-        step1 = await adapter.send(Activity(type=ActivityTypes.message, text="Hello"))
+        step1 = await adapter.send(Activity(type=ActivityTypes.message, text='Hello'))
         step2 = await step1.assert_reply(
-            "Please choose a color. (1) red, (2) green, o (3) blue"
+            'Please choose a color. (1) red, (2) green, o (3) blue'
         )
         step3 = await step2.send(_invalid_message)
-        step4 = await step3.assert_reply("Bad input.")
-        step5 = await step4.send(Activity(type=ActivityTypes.message, text="red"))
-        await step5.assert_reply("red")
+        step4 = await step3.assert_reply('Bad input.')
+        step5 = await step4.send(Activity(type=ActivityTypes.message, text='red'))
+        await step5.assert_reply('red')
 
     async def test_should_use_context_activity_locale_when_rendering_choices(self):
         async def exec_test(turn_context: TurnContext):
@@ -284,11 +284,11 @@ class ChoicePromptTest(aiounittest.AsyncTestCase):
             if results.status == DialogTurnStatus.Empty:
                 options = PromptOptions(
                     prompt=Activity(
-                        type=ActivityTypes.message, text="Please choose a color."
+                        type=ActivityTypes.message, text='Please choose a color.'
                     ),
                     choices=_color_choices,
                 )
-                await dc.prompt("prompt", options)
+                await dc.prompt('prompt', options)
             elif results.status == DialogTurnStatus.Complete:
                 selected_choice = results.result
                 await turn_context.send_activity(selected_choice.value)
@@ -298,28 +298,28 @@ class ChoicePromptTest(aiounittest.AsyncTestCase):
         adapter = TestAdapter(exec_test)
 
         convo_state = ConversationState(MemoryStorage())
-        dialog_state = convo_state.create_property("dialogState")
+        dialog_state = convo_state.create_property('dialogState')
         dialogs = DialogSet(dialog_state)
 
         async def validator(prompt: PromptValidatorContext) -> bool:
             assert prompt
 
             if not prompt.recognized.succeeded:
-                await prompt.context.send_activity("Bad input.")
+                await prompt.context.send_activity('Bad input.')
 
             return prompt.recognized.succeeded
 
-        choice_prompt = ChoicePrompt("prompt", validator)
+        choice_prompt = ChoicePrompt('prompt', validator)
         dialogs.add(choice_prompt)
 
         step1 = await adapter.send(
-            Activity(type=ActivityTypes.message, text="Hello", locale=Culture.Spanish)
+            Activity(type=ActivityTypes.message, text='Hello', locale=Culture.Spanish)
         )
         step2 = await step1.assert_reply(
             'Please choose a color. (1) red, (2) green, o (3) blue'
         )
         step3 = await step2.send(_answer_message)
-        await step3.assert_reply("red")
+        await step3.assert_reply('red')
 
     async def test_should_use_context_activity_locale_over_default_locale_when_rendering_choices(
         self
@@ -332,11 +332,11 @@ class ChoicePromptTest(aiounittest.AsyncTestCase):
             if results.status == DialogTurnStatus.Empty:
                 options = PromptOptions(
                     prompt=Activity(
-                        type=ActivityTypes.message, text="Please choose a color."
+                        type=ActivityTypes.message, text='Please choose a color.'
                     ),
                     choices=_color_choices,
                 )
-                await dc.prompt("prompt", options)
+                await dc.prompt('prompt', options)
             elif results.status == DialogTurnStatus.Complete:
                 selected_choice = results.result
                 await turn_context.send_activity(selected_choice.value)
@@ -346,30 +346,30 @@ class ChoicePromptTest(aiounittest.AsyncTestCase):
         adapter = TestAdapter(exec_test)
 
         convo_state = ConversationState(MemoryStorage())
-        dialog_state = convo_state.create_property("dialogState")
+        dialog_state = convo_state.create_property('dialogState')
         dialogs = DialogSet(dialog_state)
 
         async def validator(prompt: PromptValidatorContext) -> bool:
             assert prompt
 
             if not prompt.recognized.succeeded:
-                await prompt.context.send_activity("Bad input.")
+                await prompt.context.send_activity('Bad input.')
 
             return prompt.recognized.succeeded
 
         choice_prompt = ChoicePrompt(
-            "prompt", validator, default_locale=Culture.Spanish
+            'prompt', validator, default_locale=Culture.Spanish
         )
         dialogs.add(choice_prompt)
 
         step1 = await adapter.send(
-            Activity(type=ActivityTypes.message, text="Hello", locale=Culture.English)
+            Activity(type=ActivityTypes.message, text='Hello', locale=Culture.English)
         )
         step2 = await step1.assert_reply(
-            "Please choose a color. (1) red, (2) green, or (3) blue"
+            'Please choose a color. (1) red, (2) green, or (3) blue'
         )
         step3 = await step2.send(_answer_message)
-        await step3.assert_reply("red")
+        await step3.assert_reply('red')
 
     async def test_should_not_render_choices_if_list_style_none_is_specified(
         self
@@ -382,12 +382,12 @@ class ChoicePromptTest(aiounittest.AsyncTestCase):
             if results.status == DialogTurnStatus.Empty:
                 options = PromptOptions(
                     prompt=Activity(
-                        type=ActivityTypes.message, text="Please choose a color."
+                        type=ActivityTypes.message, text='Please choose a color.'
                     ),
                     choices=_color_choices,
                     style=ListStyle.none
                 )
-                await dc.prompt("prompt", options)
+                await dc.prompt('prompt', options)
             elif results.status == DialogTurnStatus.Complete:
                 selected_choice = results.result
                 await turn_context.send_activity(selected_choice.value)
@@ -397,17 +397,17 @@ class ChoicePromptTest(aiounittest.AsyncTestCase):
         adapter = TestAdapter(exec_test)
 
         convo_state = ConversationState(MemoryStorage())
-        dialog_state = convo_state.create_property("dialogState")
+        dialog_state = convo_state.create_property('dialogState')
         dialogs = DialogSet(dialog_state)
 
-        choice_prompt = ChoicePrompt("prompt")
+        choice_prompt = ChoicePrompt('prompt')
 
         dialogs.add(choice_prompt)
 
-        step1 = await adapter.send("Hello")
-        step2 = await step1.assert_reply("Please choose a color.")
+        step1 = await adapter.send('Hello')
+        step2 = await step1.assert_reply('Please choose a color.')
         step3 = await step2.send(_answer_message)
-        await step3.assert_reply("red")
+        await step3.assert_reply('red')
 
     async def test_should_create_prompt_with_inline_choices_when_specified(self):
         async def exec_test(turn_context: TurnContext):
@@ -418,11 +418,11 @@ class ChoicePromptTest(aiounittest.AsyncTestCase):
             if results.status == DialogTurnStatus.Empty:
                 options = PromptOptions(
                     prompt=Activity(
-                        type=ActivityTypes.message, text="Please choose a color."
+                        type=ActivityTypes.message, text='Please choose a color.'
                     ),
                     choices=_color_choices,
                 )
-                await dc.prompt("prompt", options)
+                await dc.prompt('prompt', options)
             elif results.status == DialogTurnStatus.Complete:
                 selected_choice = results.result
                 await turn_context.send_activity(selected_choice.value)
@@ -432,20 +432,20 @@ class ChoicePromptTest(aiounittest.AsyncTestCase):
         adapter = TestAdapter(exec_test)
 
         convo_state = ConversationState(MemoryStorage())
-        dialog_state = convo_state.create_property("dialogState")
+        dialog_state = convo_state.create_property('dialogState')
         dialogs = DialogSet(dialog_state)
 
-        choice_prompt = ChoicePrompt("prompt")
+        choice_prompt = ChoicePrompt('prompt')
         choice_prompt.style = ListStyle.in_line
 
         dialogs.add(choice_prompt)
 
-        step1 = await adapter.send("Hello")
+        step1 = await adapter.send('Hello')
         step2 = await step1.assert_reply(
-            "Please choose a color. (1) red, (2) green, or (3) blue"
+            'Please choose a color. (1) red, (2) green, or (3) blue'
         )
         step3 = await step2.send(_answer_message)
-        await step3.assert_reply("red")
+        await step3.assert_reply('red')
 
     async def test_should_create_prompt_with_list_choices_when_specified(self):
         async def exec_test(turn_context: TurnContext):
@@ -456,11 +456,11 @@ class ChoicePromptTest(aiounittest.AsyncTestCase):
             if results.status == DialogTurnStatus.Empty:
                 options = PromptOptions(
                     prompt=Activity(
-                        type=ActivityTypes.message, text="Please choose a color."
+                        type=ActivityTypes.message, text='Please choose a color.'
                     ),
                     choices=_color_choices,
                 )
-                await dc.prompt("prompt", options)
+                await dc.prompt('prompt', options)
             elif results.status == DialogTurnStatus.Complete:
                 selected_choice = results.result
                 await turn_context.send_activity(selected_choice.value)
@@ -470,18 +470,18 @@ class ChoicePromptTest(aiounittest.AsyncTestCase):
         adapter = TestAdapter(exec_test)
 
         convo_state = ConversationState(MemoryStorage())
-        dialog_state = convo_state.create_property("dialogState")
+        dialog_state = convo_state.create_property('dialogState')
         dialogs = DialogSet(dialog_state)
 
-        choice_prompt = ChoicePrompt("prompt")
+        choice_prompt = ChoicePrompt('prompt')
         choice_prompt.style = ListStyle.list_style
 
         dialogs.add(choice_prompt)
 
-        step1 = await adapter.send("Hello")
+        step1 = await adapter.send('Hello')
         step2 = await step1.assert_reply('Please choose a color.\n\n   1. red\n   2. green\n   3. blue')
         step3 = await step2.send(_answer_message)
-        await step3.assert_reply("red")
+        await step3.assert_reply('red')
 
     async def test_should_create_prompt_with_suggested_action_style_when_specified(self):
         async def exec_test(turn_context: TurnContext):
@@ -492,12 +492,12 @@ class ChoicePromptTest(aiounittest.AsyncTestCase):
             if results.status == DialogTurnStatus.Empty:
                 options = PromptOptions(
                     prompt=Activity(
-                        type=ActivityTypes.message, text="Please choose a color."
+                        type=ActivityTypes.message, text='Please choose a color.'
                     ),
                     choices=_color_choices,
                     style=ListStyle.suggested_action
                 )
-                await dc.prompt("prompt", options)
+                await dc.prompt('prompt', options)
             elif results.status == DialogTurnStatus.Complete:
                 selected_choice = results.result
                 await turn_context.send_activity(selected_choice.value)
@@ -507,17 +507,17 @@ class ChoicePromptTest(aiounittest.AsyncTestCase):
         adapter = TestAdapter(exec_test)
 
         convo_state = ConversationState(MemoryStorage())
-        dialog_state = convo_state.create_property("dialogState")
+        dialog_state = convo_state.create_property('dialogState')
         dialogs = DialogSet(dialog_state)
 
-        choice_prompt = ChoicePrompt("prompt")
+        choice_prompt = ChoicePrompt('prompt')
 
         dialogs.add(choice_prompt)
 
-        step1 = await adapter.send("Hello")
+        step1 = await adapter.send('Hello')
         step2 = await step1.assert_reply('Please choose a color.')
         step3 = await step2.send(_answer_message)
-        await step3.assert_reply("red")
+        await step3.assert_reply('red')
 
     async def test_should_create_prompt_with_auto_style_when_specified(self):
         async def exec_test(turn_context: TurnContext):
@@ -528,12 +528,12 @@ class ChoicePromptTest(aiounittest.AsyncTestCase):
             if results.status == DialogTurnStatus.Empty:
                 options = PromptOptions(
                     prompt=Activity(
-                        type=ActivityTypes.message, text="Please choose a color."
+                        type=ActivityTypes.message, text='Please choose a color.'
                     ),
                     choices=_color_choices,
                     style=ListStyle.auto
                 )
-                await dc.prompt("prompt", options)
+                await dc.prompt('prompt', options)
             elif results.status == DialogTurnStatus.Complete:
                 selected_choice = results.result
                 await turn_context.send_activity(selected_choice.value)
@@ -543,17 +543,17 @@ class ChoicePromptTest(aiounittest.AsyncTestCase):
         adapter = TestAdapter(exec_test)
 
         convo_state = ConversationState(MemoryStorage())
-        dialog_state = convo_state.create_property("dialogState")
+        dialog_state = convo_state.create_property('dialogState')
         dialogs = DialogSet(dialog_state)
 
-        choice_prompt = ChoicePrompt("prompt")
+        choice_prompt = ChoicePrompt('prompt')
 
         dialogs.add(choice_prompt)
 
-        step1 = await adapter.send("Hello")
+        step1 = await adapter.send('Hello')
         step2 = await step1.assert_reply('Please choose a color. (1) red, (2) green, or (3) blue')
         step3 = await step2.send(_answer_message)
-        await step3.assert_reply("red")
+        await step3.assert_reply('red')
 
     async def test_should_recognize_valid_number_choice(self):
         async def exec_test(turn_context: TurnContext):
@@ -564,11 +564,11 @@ class ChoicePromptTest(aiounittest.AsyncTestCase):
             if results.status == DialogTurnStatus.Empty:
                 options = PromptOptions(
                     prompt=Activity(
-                        type=ActivityTypes.message, text="Please choose a color."
+                        type=ActivityTypes.message, text='Please choose a color.'
                     ),
                     choices=_color_choices,
                 )
-                await dc.prompt("prompt", options)
+                await dc.prompt('prompt', options)
             elif results.status == DialogTurnStatus.Complete:
                 selected_choice = results.result
                 await turn_context.send_activity(selected_choice.value)
@@ -578,17 +578,17 @@ class ChoicePromptTest(aiounittest.AsyncTestCase):
         adapter = TestAdapter(exec_test)
 
         convo_state = ConversationState(MemoryStorage())
-        dialog_state = convo_state.create_property("dialogState")
+        dialog_state = convo_state.create_property('dialogState')
         dialogs = DialogSet(dialog_state)
 
-        choice_prompt = ChoicePrompt("prompt")
+        choice_prompt = ChoicePrompt('prompt')
 
         dialogs.add(choice_prompt)
 
-        step1 = await adapter.send("Hello")
+        step1 = await adapter.send('Hello')
         step2 = await step1.assert_reply(
-            "Please choose a color. (1) red, (2) green, or (3) blue"
+            'Please choose a color. (1) red, (2) green, or (3) blue'
         )
-        step3 = await step2.send("1")
-        await step3.assert_reply("red")
+        step3 = await step2.send('1')
+        await step3.assert_reply('red')
     

--- a/libraries/botbuilder-dialogs/tests/test_choice_prompt.py
+++ b/libraries/botbuilder-dialogs/tests/test_choice_prompt.py
@@ -267,11 +267,8 @@ class ChoicePromptTest(aiounittest.AsyncTestCase):
         dialogs.add(choice_prompt)
 
         step1 = await adapter.send(Activity(type=ActivityTypes.message, text="Hello"))
-        # TODO ChoiceFactory.inline() is broken, where it only uses hard-coded English locale.
-        # commented out the CORRECT assertion below, until .inline() is fixed to use proper locale
-        # step2 = await step1.assert_reply('Please choose a color. (1) red, (2) green, o (3) blue')
         step2 = await step1.assert_reply(
-            "Please choose a color. (1) red, (2) green, or (3) blue"
+            "Please choose a color. (1) red, (2) green, o (3) blue"
         )
         step3 = await step2.send(_invalid_message)
         step4 = await step3.assert_reply("Bad input.")
@@ -318,11 +315,8 @@ class ChoicePromptTest(aiounittest.AsyncTestCase):
         step1 = await adapter.send(
             Activity(type=ActivityTypes.message, text="Hello", locale=Culture.Spanish)
         )
-        # TODO ChoiceFactory.inline() is broken, where it only uses hard-coded English locale.
-        # commented out the CORRECT assertion below, until .inline() is fixed to use proper locale
-        # step2 = await step1.assert_reply('Please choose a color. (1) red, (2) green, o (3) blue')
         step2 = await step1.assert_reply(
-            "Please choose a color. (1) red, (2) green, or (3) blue"
+            'Please choose a color. (1) red, (2) green, o (3) blue'
         )
         step3 = await step2.send(_answer_message)
         await step3.assert_reply("red")

--- a/libraries/botbuilder-dialogs/tests/test_choice_prompt.py
+++ b/libraries/botbuilder-dialogs/tests/test_choice_prompt.py
@@ -25,18 +25,18 @@ from botbuilder.dialogs.prompts import (
 from botbuilder.schema import Activity, ActivityTypes
 
 _color_choices: List[Choice] = [
-    Choice(value='red'),
-    Choice(value='green'),
-    Choice(value='blue'),
+    Choice(value="red"),
+    Choice(value="green"),
+    Choice(value="blue"),
 ]
 
-_answer_message: Activity = Activity(text='red', type=ActivityTypes.message)
-_invalid_message: Activity = Activity(text='purple', type=ActivityTypes.message)
+_answer_message: Activity = Activity(text="red", type=ActivityTypes.message)
+_invalid_message: Activity = Activity(text="purple", type=ActivityTypes.message)
 
 
 class ChoicePromptTest(aiounittest.AsyncTestCase):
     def test_choice_prompt_with_empty_id_should_fail(self):
-        empty_id = ''
+        empty_id = ""
 
         with self.assertRaises(TypeError):
             ChoicePrompt(empty_id)
@@ -56,11 +56,11 @@ class ChoicePromptTest(aiounittest.AsyncTestCase):
             if results.status == DialogTurnStatus.Empty:
                 options = PromptOptions(
                     prompt=Activity(
-                        type=ActivityTypes.message, text='Please choose a color.'
+                        type=ActivityTypes.message, text="Please choose a color."
                     ),
                     choices=_color_choices,
                 )
-                await dc.prompt('ChoicePrompt', options)
+                await dc.prompt("ChoicePrompt", options)
             elif results.status == DialogTurnStatus.Complete:
                 selected_choice = results.result
                 await turn_context.send_activity(selected_choice.value)
@@ -74,17 +74,17 @@ class ChoicePromptTest(aiounittest.AsyncTestCase):
         convo_state = ConversationState(MemoryStorage())
 
         # Create a DialogState property, DialogSet, and ChoicePrompt.
-        dialog_state = convo_state.create_property('dialogState')
+        dialog_state = convo_state.create_property("dialogState")
         dialogs = DialogSet(dialog_state)
-        choice_prompt = ChoicePrompt('ChoicePrompt')
+        choice_prompt = ChoicePrompt("ChoicePrompt")
         dialogs.add(choice_prompt)
 
-        step1 = await adapter.send('hello')
+        step1 = await adapter.send("hello")
         step2 = await step1.assert_reply(
-            'Please choose a color. (1) red, (2) green, or (3) blue'
+            "Please choose a color. (1) red, (2) green, or (3) blue"
         )
         step3 = await step2.send(_answer_message)
-        await step3.assert_reply('red')
+        await step3.assert_reply("red")
 
     async def test_should_call_ChoicePrompt_with_custom_validator(self):
         async def exec_test(turn_context: TurnContext):
@@ -95,11 +95,11 @@ class ChoicePromptTest(aiounittest.AsyncTestCase):
             if results.status == DialogTurnStatus.Empty:
                 options = PromptOptions(
                     prompt=Activity(
-                        type=ActivityTypes.message, text='Please choose a color.'
+                        type=ActivityTypes.message, text="Please choose a color."
                     ),
                     choices=_color_choices,
                 )
-                await dc.prompt('prompt', options)
+                await dc.prompt("prompt", options)
             elif results.status == DialogTurnStatus.Complete:
                 selected_choice = results.result
                 await turn_context.send_activity(selected_choice.value)
@@ -109,7 +109,7 @@ class ChoicePromptTest(aiounittest.AsyncTestCase):
         adapter = TestAdapter(exec_test)
 
         convo_state = ConversationState(MemoryStorage())
-        dialog_state = convo_state.create_property('dialogState')
+        dialog_state = convo_state.create_property("dialogState")
         dialogs = DialogSet(dialog_state)
 
         async def validator(prompt: PromptValidatorContext) -> bool:
@@ -117,20 +117,20 @@ class ChoicePromptTest(aiounittest.AsyncTestCase):
 
             return prompt.recognized.succeeded
 
-        choice_prompt = ChoicePrompt('prompt', validator)
+        choice_prompt = ChoicePrompt("prompt", validator)
 
         dialogs.add(choice_prompt)
 
-        step1 = await adapter.send('Hello')
+        step1 = await adapter.send("Hello")
         step2 = await step1.assert_reply(
-            'Please choose a color. (1) red, (2) green, or (3) blue'
+            "Please choose a color. (1) red, (2) green, or (3) blue"
         )
         step3 = await step2.send(_invalid_message)
         step4 = await step3.assert_reply(
-            'Please choose a color. (1) red, (2) green, or (3) blue'
+            "Please choose a color. (1) red, (2) green, or (3) blue"
         )
         step5 = await step4.send(_answer_message)
-        await step5.assert_reply('red')
+        await step5.assert_reply("red")
 
     async def test_should_send_custom_retry_prompt(self):
         async def exec_test(turn_context: TurnContext):
@@ -141,15 +141,15 @@ class ChoicePromptTest(aiounittest.AsyncTestCase):
             if results.status == DialogTurnStatus.Empty:
                 options = PromptOptions(
                     prompt=Activity(
-                        type=ActivityTypes.message, text='Please choose a color.'
+                        type=ActivityTypes.message, text="Please choose a color."
                     ),
                     retry_prompt=Activity(
                         type=ActivityTypes.message,
-                        text='Please choose red, blue, or green.',
+                        text="Please choose red, blue, or green.",
                     ),
                     choices=_color_choices,
                 )
-                await dc.prompt('prompt', options)
+                await dc.prompt("prompt", options)
             elif results.status == DialogTurnStatus.Complete:
                 selected_choice = results.result
                 await turn_context.send_activity(selected_choice.value)
@@ -159,21 +159,21 @@ class ChoicePromptTest(aiounittest.AsyncTestCase):
         adapter = TestAdapter(exec_test)
 
         convo_state = ConversationState(MemoryStorage())
-        dialog_state = convo_state.create_property('dialogState')
+        dialog_state = convo_state.create_property("dialogState")
         dialogs = DialogSet(dialog_state)
-        choice_prompt = ChoicePrompt('prompt')
+        choice_prompt = ChoicePrompt("prompt")
         dialogs.add(choice_prompt)
 
-        step1 = await adapter.send('Hello')
+        step1 = await adapter.send("Hello")
         step2 = await step1.assert_reply(
-            'Please choose a color. (1) red, (2) green, or (3) blue'
+            "Please choose a color. (1) red, (2) green, or (3) blue"
         )
         step3 = await step2.send(_invalid_message)
         step4 = await step3.assert_reply(
-            'Please choose red, blue, or green. (1) red, (2) green, or (3) blue'
+            "Please choose red, blue, or green. (1) red, (2) green, or (3) blue"
         )
         step5 = await step4.send(_answer_message)
-        await step5.assert_reply('red')
+        await step5.assert_reply("red")
 
     async def test_should_send_ignore_retry_prompt_if_validator_replies(self):
         async def exec_test(turn_context: TurnContext):
@@ -184,15 +184,15 @@ class ChoicePromptTest(aiounittest.AsyncTestCase):
             if results.status == DialogTurnStatus.Empty:
                 options = PromptOptions(
                     prompt=Activity(
-                        type=ActivityTypes.message, text='Please choose a color.'
+                        type=ActivityTypes.message, text="Please choose a color."
                     ),
                     retry_prompt=Activity(
                         type=ActivityTypes.message,
-                        text='Please choose red, blue, or green.',
+                        text="Please choose red, blue, or green.",
                     ),
                     choices=_color_choices,
                 )
-                await dc.prompt('prompt', options)
+                await dc.prompt("prompt", options)
             elif results.status == DialogTurnStatus.Complete:
                 selected_choice = results.result
                 await turn_context.send_activity(selected_choice.value)
@@ -202,29 +202,29 @@ class ChoicePromptTest(aiounittest.AsyncTestCase):
         adapter = TestAdapter(exec_test)
 
         convo_state = ConversationState(MemoryStorage())
-        dialog_state = convo_state.create_property('dialogState')
+        dialog_state = convo_state.create_property("dialogState")
         dialogs = DialogSet(dialog_state)
 
         async def validator(prompt: PromptValidatorContext) -> bool:
             assert prompt
 
             if not prompt.recognized.succeeded:
-                await prompt.context.send_activity('Bad input.')
+                await prompt.context.send_activity("Bad input.")
 
             return prompt.recognized.succeeded
 
-        choice_prompt = ChoicePrompt('prompt', validator)
+        choice_prompt = ChoicePrompt("prompt", validator)
 
         dialogs.add(choice_prompt)
 
-        step1 = await adapter.send('Hello')
+        step1 = await adapter.send("Hello")
         step2 = await step1.assert_reply(
-            'Please choose a color. (1) red, (2) green, or (3) blue'
+            "Please choose a color. (1) red, (2) green, or (3) blue"
         )
         step3 = await step2.send(_invalid_message)
-        step4 = await step3.assert_reply('Bad input.')
+        step4 = await step3.assert_reply("Bad input.")
         step5 = await step4.send(_answer_message)
-        await step5.assert_reply('red')
+        await step5.assert_reply("red")
 
     async def test_should_use_default_locale_when_rendering_choices(self):
         async def exec_test(turn_context: TurnContext):
@@ -235,11 +235,11 @@ class ChoicePromptTest(aiounittest.AsyncTestCase):
             if results.status == DialogTurnStatus.Empty:
                 options = PromptOptions(
                     prompt=Activity(
-                        type=ActivityTypes.message, text='Please choose a color.'
+                        type=ActivityTypes.message, text="Please choose a color."
                     ),
                     choices=_color_choices,
                 )
-                await dc.prompt('prompt', options)
+                await dc.prompt("prompt", options)
             elif results.status == DialogTurnStatus.Complete:
                 selected_choice = results.result
                 await turn_context.send_activity(selected_choice.value)
@@ -249,31 +249,31 @@ class ChoicePromptTest(aiounittest.AsyncTestCase):
         adapter = TestAdapter(exec_test)
 
         convo_state = ConversationState(MemoryStorage())
-        dialog_state = convo_state.create_property('dialogState')
+        dialog_state = convo_state.create_property("dialogState")
         dialogs = DialogSet(dialog_state)
 
         async def validator(prompt: PromptValidatorContext) -> bool:
             assert prompt
 
             if not prompt.recognized.succeeded:
-                await prompt.context.send_activity('Bad input.')
+                await prompt.context.send_activity("Bad input.")
 
             return prompt.recognized.succeeded
 
         choice_prompt = ChoicePrompt(
-            'prompt', validator, default_locale=Culture.Spanish
+            "prompt", validator, default_locale=Culture.Spanish
         )
 
         dialogs.add(choice_prompt)
 
-        step1 = await adapter.send(Activity(type=ActivityTypes.message, text='Hello'))
+        step1 = await adapter.send(Activity(type=ActivityTypes.message, text="Hello"))
         step2 = await step1.assert_reply(
-            'Please choose a color. (1) red, (2) green, o (3) blue'
+            "Please choose a color. (1) red, (2) green, o (3) blue"
         )
         step3 = await step2.send(_invalid_message)
-        step4 = await step3.assert_reply('Bad input.')
-        step5 = await step4.send(Activity(type=ActivityTypes.message, text='red'))
-        await step5.assert_reply('red')
+        step4 = await step3.assert_reply("Bad input.")
+        step5 = await step4.send(Activity(type=ActivityTypes.message, text="red"))
+        await step5.assert_reply("red")
 
     async def test_should_use_context_activity_locale_when_rendering_choices(self):
         async def exec_test(turn_context: TurnContext):
@@ -284,11 +284,11 @@ class ChoicePromptTest(aiounittest.AsyncTestCase):
             if results.status == DialogTurnStatus.Empty:
                 options = PromptOptions(
                     prompt=Activity(
-                        type=ActivityTypes.message, text='Please choose a color.'
+                        type=ActivityTypes.message, text="Please choose a color."
                     ),
                     choices=_color_choices,
                 )
-                await dc.prompt('prompt', options)
+                await dc.prompt("prompt", options)
             elif results.status == DialogTurnStatus.Complete:
                 selected_choice = results.result
                 await turn_context.send_activity(selected_choice.value)
@@ -298,28 +298,28 @@ class ChoicePromptTest(aiounittest.AsyncTestCase):
         adapter = TestAdapter(exec_test)
 
         convo_state = ConversationState(MemoryStorage())
-        dialog_state = convo_state.create_property('dialogState')
+        dialog_state = convo_state.create_property("dialogState")
         dialogs = DialogSet(dialog_state)
 
         async def validator(prompt: PromptValidatorContext) -> bool:
             assert prompt
 
             if not prompt.recognized.succeeded:
-                await prompt.context.send_activity('Bad input.')
+                await prompt.context.send_activity("Bad input.")
 
             return prompt.recognized.succeeded
 
-        choice_prompt = ChoicePrompt('prompt', validator)
+        choice_prompt = ChoicePrompt("prompt", validator)
         dialogs.add(choice_prompt)
 
         step1 = await adapter.send(
-            Activity(type=ActivityTypes.message, text='Hello', locale=Culture.Spanish)
+            Activity(type=ActivityTypes.message, text="Hello", locale=Culture.Spanish)
         )
         step2 = await step1.assert_reply(
-            'Please choose a color. (1) red, (2) green, o (3) blue'
+            "Please choose a color. (1) red, (2) green, o (3) blue"
         )
         step3 = await step2.send(_answer_message)
-        await step3.assert_reply('red')
+        await step3.assert_reply("red")
 
     async def test_should_use_context_activity_locale_over_default_locale_when_rendering_choices(
         self
@@ -332,11 +332,11 @@ class ChoicePromptTest(aiounittest.AsyncTestCase):
             if results.status == DialogTurnStatus.Empty:
                 options = PromptOptions(
                     prompt=Activity(
-                        type=ActivityTypes.message, text='Please choose a color.'
+                        type=ActivityTypes.message, text="Please choose a color."
                     ),
                     choices=_color_choices,
                 )
-                await dc.prompt('prompt', options)
+                await dc.prompt("prompt", options)
             elif results.status == DialogTurnStatus.Complete:
                 selected_choice = results.result
                 await turn_context.send_activity(selected_choice.value)
@@ -346,34 +346,32 @@ class ChoicePromptTest(aiounittest.AsyncTestCase):
         adapter = TestAdapter(exec_test)
 
         convo_state = ConversationState(MemoryStorage())
-        dialog_state = convo_state.create_property('dialogState')
+        dialog_state = convo_state.create_property("dialogState")
         dialogs = DialogSet(dialog_state)
 
         async def validator(prompt: PromptValidatorContext) -> bool:
             assert prompt
 
             if not prompt.recognized.succeeded:
-                await prompt.context.send_activity('Bad input.')
+                await prompt.context.send_activity("Bad input.")
 
             return prompt.recognized.succeeded
 
         choice_prompt = ChoicePrompt(
-            'prompt', validator, default_locale=Culture.Spanish
+            "prompt", validator, default_locale=Culture.Spanish
         )
         dialogs.add(choice_prompt)
 
         step1 = await adapter.send(
-            Activity(type=ActivityTypes.message, text='Hello', locale=Culture.English)
+            Activity(type=ActivityTypes.message, text="Hello", locale=Culture.English)
         )
         step2 = await step1.assert_reply(
-            'Please choose a color. (1) red, (2) green, or (3) blue'
+            "Please choose a color. (1) red, (2) green, or (3) blue"
         )
         step3 = await step2.send(_answer_message)
-        await step3.assert_reply('red')
+        await step3.assert_reply("red")
 
-    async def test_should_not_render_choices_if_list_style_none_is_specified(
-        self
-    ):
+    async def test_should_not_render_choices_if_list_style_none_is_specified(self):
         async def exec_test(turn_context: TurnContext):
             dc = await dialogs.create_context(turn_context)
 
@@ -382,12 +380,12 @@ class ChoicePromptTest(aiounittest.AsyncTestCase):
             if results.status == DialogTurnStatus.Empty:
                 options = PromptOptions(
                     prompt=Activity(
-                        type=ActivityTypes.message, text='Please choose a color.'
+                        type=ActivityTypes.message, text="Please choose a color."
                     ),
                     choices=_color_choices,
-                    style=ListStyle.none
+                    style=ListStyle.none,
                 )
-                await dc.prompt('prompt', options)
+                await dc.prompt("prompt", options)
             elif results.status == DialogTurnStatus.Complete:
                 selected_choice = results.result
                 await turn_context.send_activity(selected_choice.value)
@@ -397,17 +395,17 @@ class ChoicePromptTest(aiounittest.AsyncTestCase):
         adapter = TestAdapter(exec_test)
 
         convo_state = ConversationState(MemoryStorage())
-        dialog_state = convo_state.create_property('dialogState')
+        dialog_state = convo_state.create_property("dialogState")
         dialogs = DialogSet(dialog_state)
 
-        choice_prompt = ChoicePrompt('prompt')
+        choice_prompt = ChoicePrompt("prompt")
 
         dialogs.add(choice_prompt)
 
-        step1 = await adapter.send('Hello')
-        step2 = await step1.assert_reply('Please choose a color.')
+        step1 = await adapter.send("Hello")
+        step2 = await step1.assert_reply("Please choose a color.")
         step3 = await step2.send(_answer_message)
-        await step3.assert_reply('red')
+        await step3.assert_reply("red")
 
     async def test_should_create_prompt_with_inline_choices_when_specified(self):
         async def exec_test(turn_context: TurnContext):
@@ -418,11 +416,11 @@ class ChoicePromptTest(aiounittest.AsyncTestCase):
             if results.status == DialogTurnStatus.Empty:
                 options = PromptOptions(
                     prompt=Activity(
-                        type=ActivityTypes.message, text='Please choose a color.'
+                        type=ActivityTypes.message, text="Please choose a color."
                     ),
                     choices=_color_choices,
                 )
-                await dc.prompt('prompt', options)
+                await dc.prompt("prompt", options)
             elif results.status == DialogTurnStatus.Complete:
                 selected_choice = results.result
                 await turn_context.send_activity(selected_choice.value)
@@ -432,20 +430,20 @@ class ChoicePromptTest(aiounittest.AsyncTestCase):
         adapter = TestAdapter(exec_test)
 
         convo_state = ConversationState(MemoryStorage())
-        dialog_state = convo_state.create_property('dialogState')
+        dialog_state = convo_state.create_property("dialogState")
         dialogs = DialogSet(dialog_state)
 
-        choice_prompt = ChoicePrompt('prompt')
+        choice_prompt = ChoicePrompt("prompt")
         choice_prompt.style = ListStyle.in_line
 
         dialogs.add(choice_prompt)
 
-        step1 = await adapter.send('Hello')
+        step1 = await adapter.send("Hello")
         step2 = await step1.assert_reply(
-            'Please choose a color. (1) red, (2) green, or (3) blue'
+            "Please choose a color. (1) red, (2) green, or (3) blue"
         )
         step3 = await step2.send(_answer_message)
-        await step3.assert_reply('red')
+        await step3.assert_reply("red")
 
     async def test_should_create_prompt_with_list_choices_when_specified(self):
         async def exec_test(turn_context: TurnContext):
@@ -456,11 +454,11 @@ class ChoicePromptTest(aiounittest.AsyncTestCase):
             if results.status == DialogTurnStatus.Empty:
                 options = PromptOptions(
                     prompt=Activity(
-                        type=ActivityTypes.message, text='Please choose a color.'
+                        type=ActivityTypes.message, text="Please choose a color."
                     ),
                     choices=_color_choices,
                 )
-                await dc.prompt('prompt', options)
+                await dc.prompt("prompt", options)
             elif results.status == DialogTurnStatus.Complete:
                 selected_choice = results.result
                 await turn_context.send_activity(selected_choice.value)
@@ -470,20 +468,24 @@ class ChoicePromptTest(aiounittest.AsyncTestCase):
         adapter = TestAdapter(exec_test)
 
         convo_state = ConversationState(MemoryStorage())
-        dialog_state = convo_state.create_property('dialogState')
+        dialog_state = convo_state.create_property("dialogState")
         dialogs = DialogSet(dialog_state)
 
-        choice_prompt = ChoicePrompt('prompt')
+        choice_prompt = ChoicePrompt("prompt")
         choice_prompt.style = ListStyle.list_style
 
         dialogs.add(choice_prompt)
 
-        step1 = await adapter.send('Hello')
-        step2 = await step1.assert_reply('Please choose a color.\n\n   1. red\n   2. green\n   3. blue')
+        step1 = await adapter.send("Hello")
+        step2 = await step1.assert_reply(
+            "Please choose a color.\n\n   1. red\n   2. green\n   3. blue"
+        )
         step3 = await step2.send(_answer_message)
-        await step3.assert_reply('red')
+        await step3.assert_reply("red")
 
-    async def test_should_create_prompt_with_suggested_action_style_when_specified(self):
+    async def test_should_create_prompt_with_suggested_action_style_when_specified(
+        self
+    ):
         async def exec_test(turn_context: TurnContext):
             dc = await dialogs.create_context(turn_context)
 
@@ -492,12 +494,12 @@ class ChoicePromptTest(aiounittest.AsyncTestCase):
             if results.status == DialogTurnStatus.Empty:
                 options = PromptOptions(
                     prompt=Activity(
-                        type=ActivityTypes.message, text='Please choose a color.'
+                        type=ActivityTypes.message, text="Please choose a color."
                     ),
                     choices=_color_choices,
-                    style=ListStyle.suggested_action
+                    style=ListStyle.suggested_action,
                 )
-                await dc.prompt('prompt', options)
+                await dc.prompt("prompt", options)
             elif results.status == DialogTurnStatus.Complete:
                 selected_choice = results.result
                 await turn_context.send_activity(selected_choice.value)
@@ -507,17 +509,17 @@ class ChoicePromptTest(aiounittest.AsyncTestCase):
         adapter = TestAdapter(exec_test)
 
         convo_state = ConversationState(MemoryStorage())
-        dialog_state = convo_state.create_property('dialogState')
+        dialog_state = convo_state.create_property("dialogState")
         dialogs = DialogSet(dialog_state)
 
-        choice_prompt = ChoicePrompt('prompt')
+        choice_prompt = ChoicePrompt("prompt")
 
         dialogs.add(choice_prompt)
 
-        step1 = await adapter.send('Hello')
-        step2 = await step1.assert_reply('Please choose a color.')
+        step1 = await adapter.send("Hello")
+        step2 = await step1.assert_reply("Please choose a color.")
         step3 = await step2.send(_answer_message)
-        await step3.assert_reply('red')
+        await step3.assert_reply("red")
 
     async def test_should_create_prompt_with_auto_style_when_specified(self):
         async def exec_test(turn_context: TurnContext):
@@ -528,12 +530,12 @@ class ChoicePromptTest(aiounittest.AsyncTestCase):
             if results.status == DialogTurnStatus.Empty:
                 options = PromptOptions(
                     prompt=Activity(
-                        type=ActivityTypes.message, text='Please choose a color.'
+                        type=ActivityTypes.message, text="Please choose a color."
                     ),
                     choices=_color_choices,
-                    style=ListStyle.auto
+                    style=ListStyle.auto,
                 )
-                await dc.prompt('prompt', options)
+                await dc.prompt("prompt", options)
             elif results.status == DialogTurnStatus.Complete:
                 selected_choice = results.result
                 await turn_context.send_activity(selected_choice.value)
@@ -543,17 +545,19 @@ class ChoicePromptTest(aiounittest.AsyncTestCase):
         adapter = TestAdapter(exec_test)
 
         convo_state = ConversationState(MemoryStorage())
-        dialog_state = convo_state.create_property('dialogState')
+        dialog_state = convo_state.create_property("dialogState")
         dialogs = DialogSet(dialog_state)
 
-        choice_prompt = ChoicePrompt('prompt')
+        choice_prompt = ChoicePrompt("prompt")
 
         dialogs.add(choice_prompt)
 
-        step1 = await adapter.send('Hello')
-        step2 = await step1.assert_reply('Please choose a color. (1) red, (2) green, or (3) blue')
+        step1 = await adapter.send("Hello")
+        step2 = await step1.assert_reply(
+            "Please choose a color. (1) red, (2) green, or (3) blue"
+        )
         step3 = await step2.send(_answer_message)
-        await step3.assert_reply('red')
+        await step3.assert_reply("red")
 
     async def test_should_recognize_valid_number_choice(self):
         async def exec_test(turn_context: TurnContext):
@@ -564,11 +568,11 @@ class ChoicePromptTest(aiounittest.AsyncTestCase):
             if results.status == DialogTurnStatus.Empty:
                 options = PromptOptions(
                     prompt=Activity(
-                        type=ActivityTypes.message, text='Please choose a color.'
+                        type=ActivityTypes.message, text="Please choose a color."
                     ),
                     choices=_color_choices,
                 )
-                await dc.prompt('prompt', options)
+                await dc.prompt("prompt", options)
             elif results.status == DialogTurnStatus.Complete:
                 selected_choice = results.result
                 await turn_context.send_activity(selected_choice.value)
@@ -578,17 +582,16 @@ class ChoicePromptTest(aiounittest.AsyncTestCase):
         adapter = TestAdapter(exec_test)
 
         convo_state = ConversationState(MemoryStorage())
-        dialog_state = convo_state.create_property('dialogState')
+        dialog_state = convo_state.create_property("dialogState")
         dialogs = DialogSet(dialog_state)
 
-        choice_prompt = ChoicePrompt('prompt')
+        choice_prompt = ChoicePrompt("prompt")
 
         dialogs.add(choice_prompt)
 
-        step1 = await adapter.send('Hello')
+        step1 = await adapter.send("Hello")
         step2 = await step1.assert_reply(
-            'Please choose a color. (1) red, (2) green, or (3) blue'
+            "Please choose a color. (1) red, (2) green, or (3) blue"
         )
-        step3 = await step2.send('1')
-        await step3.assert_reply('red')
-    
+        step3 = await step2.send("1")
+        await step3.assert_reply("red")


### PR DESCRIPTION
Fixes #239 , #240 

### Changes
* `ChoicePrompt._default_choice_options` now specifies **`inline_or_more`** for the `ChoiceFactoryOptions` in the appropriate culture

* `Prompt` was previously trying to use `Dict.get()` method, but with the enum class as the key instead of the _**value**_ that the enum equated to, making all styles go to "default" `ListStyle` previously, when key was not found (in this case `in_line` styling)
  * now properly uses enum value as key
* rearranged `switcher` variable to properly map in the same order as the values in `ListStyle` enum class, to apply correct styling
* `ListStyle.none` also now returns as an `ActivityType.message`, whereas before it was `None`
* updated unit tests to not only check for `in_line` styling