### PR TITLE
Fix Date Resolver in CoreBot

### DIFF
--- a/samples/13.core-bot/dialogs/date_resolver_dialog.py
+++ b/samples/13.core-bot/dialogs/date_resolver_dialog.py
@@ -56,7 +56,7 @@ class DateResolverDialog(CancelAndHelpDialog):
                 PromptOptions(prompt=prompt_msg, retry_prompt=reprompt_msg),
             )
         # We have a Date we just need to check it is unambiguous.
-        if "definite" in Timex(timex).types:
+        if "definite" not in Timex(timex).types:
             # This is essentially a "reprompt" of the data we were given up front.
             return await step_context.prompt(
                 DateTimePrompt.__name__, PromptOptions(prompt=reprompt_msg)

--- a/samples/13.core-bot/dialogs/main_dialog.py
+++ b/samples/13.core-bot/dialogs/main_dialog.py
@@ -1,17 +1,13 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-from datetime import datetime
-from typing import Dict
 from botbuilder.dialogs import (
     ComponentDialog,
-    DialogSet,
-    DialogTurnStatus,
     WaterfallDialog,
     WaterfallStepContext,
     DialogTurnResult,
 )
-from botbuilder.dialogs.prompts import TextPrompt, ConfirmPrompt, PromptOptions
+from botbuilder.dialogs.prompts import TextPrompt, PromptOptions
 from botbuilder.core import MessageFactory, TurnContext
 from botbuilder.schema import InputHints
 
@@ -76,9 +72,8 @@ class MainDialog(ComponentDialog):
             self._luis_recognizer, step_context.context
         )
 
-        # top_intent = cognitive_models_helper.top_intent(luis_result['intents'])
-
         if intent == Intent.BOOK_FLIGHT.value and luis_result:
+            # Show a warning for Origin and Destination if we can't resolve them.
             await MainDialog._show_warning_for_unsupported_cities(
                 step_context.context, luis_result
             )

--- a/samples/13.core-bot/helpers/luis_helper.py
+++ b/samples/13.core-bot/helpers/luis_helper.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 from enum import Enum
 from typing import Dict
-from botbuilder.ai.luis import LuisRecognizer, LuisApplication
+from botbuilder.ai.luis import LuisRecognizer
 from botbuilder.core import IntentScore, TopIntent, TurnContext
 
 from booking_details import BookingDetails
@@ -32,6 +32,9 @@ class LuisHelper:
     async def execute_luis_query(
         luis_recognizer: LuisRecognizer, turn_context: TurnContext
     ) -> (Intent, object):
+        """
+        Returns an object with preformatted LUIS results for the bot's dialogs to consume.
+        """
         result = None
         intent = None
 
@@ -78,13 +81,20 @@ class LuisHelper:
                             from_entities[0]["text"].capitalize()
                         )
 
-                # TODO: This value will be a TIMEX. And we are only interested in a Date so grab the first result and drop the Time part.
+                # This value will be a TIMEX. And we are only interested in a Date so grab the first result and drop the Time part.
                 # TIMEX is a format that represents DateTime expressions that include some ambiguity. e.g. missing a Year.
-                date_entities = recognizer_result.entities.get("$instance", {}).get(
-                    "datetime", []
-                )
-                if len(date_entities) > 0:
-                    result.travel_date = None  # TODO: Set when we get a timex format
+                date_entities = recognizer_result.entities.get("datetime", [])
+                if date_entities:
+                    timex = date_entities[0]["timex"]
+
+                    if timex:
+                        datetime = timex[0].split("T")[0]
+
+                        result.travel_date = datetime
+
+                else:
+                    result.travel_date = None
+
         except Exception as e:
             print(e)
 


### PR DESCRIPTION
Fixes #292 
___
### Changes

**Issue:**
* In [C#](https://github.com/microsoft/BotBuilder-Samples/blob/master/samples/csharp_dotnetcore/13.core-bot/Dialogs/DateResolverDialog.cs#L53) and [JS](https://github.com/microsoft/BotBuilder-Samples/blob/master/samples/javascript_nodejs/13.core-bot/dialogs/dateResolverDialog.js#L43) CoreBots, the logic to test for if the datetime entity parsed should check if it **is ambigous** still => then if it is ambigous, reprompt user for definitive datetime value

* However in Python its test incorrectly checks if the datetime **is definitive instead of ambigous**

This PR corrects the conditional logic for ambigous datetimes parsed from user when booking a flight.

### Specific Changes
* `LuisHelper` class parsed values for location entities (the `Origin` and `Destination` of the flight), however was missing parsing for datetime timex values that get returned from LUIS
    * Added timex parsing to `LuisHelper`
    * This is parity with [JS's timex parsing](https://github.com/microsoft/BotBuilder-Samples/blob/master/samples/javascript_nodejs/13.core-bot/dialogs/flightBookingRecognizer.js#L54)

* `DateResolverDialog` now correctly reprompts user if the date the user originally gave is ambiguous

### Screenshots

Expected behavior
![image](https://user-images.githubusercontent.com/35248895/63049761-498b2500-be8e-11e9-8145-eafd18c7e824.png)
 