### PR TITLE
Fixed retry prompting in NumberPrompt by adding await

### DIFF
--- a/libraries/botbuilder-dialogs/botbuilder/dialogs/prompts/number_prompt.py
+++ b/libraries/botbuilder-dialogs/botbuilder/dialogs/prompts/number_prompt.py
@@ -40,7 +40,7 @@ class NumberPrompt(Prompt):
             raise TypeError("NumberPrompt.on_prompt(): options cannot be None.")
 
         if is_retry and options.retry_prompt is not None:
-            turn_context.send_activity(options.retry_prompt)
+            await turn_context.send_activity(options.retry_prompt)
         elif options.prompt is not None:
             await turn_context.send_activity(options.prompt)
 

--- a/libraries/botbuilder-dialogs/tests/test_number_prompt.py
+++ b/libraries/botbuilder-dialogs/tests/test_number_prompt.py
@@ -267,7 +267,9 @@ class NumberPromptTests(aiounittest.AsyncTestCase):
         step1 = await adapter.send("hello")
         step2 = await step1.assert_reply("Enter a number.")
         step3 = await step2.send("150")
-        step4 = await step3.assert_reply("You must enter a positive number less than 100.")
+        step4 = await step3.assert_reply(
+            "You must enter a positive number less than 100."
+        )
         step5 = await step4.send("64")
         await step5.assert_reply("Bot received the number '64'.")
 

--- a/libraries/botbuilder-dialogs/tests/test_number_prompt.py
+++ b/libraries/botbuilder-dialogs/tests/test_number_prompt.py
@@ -125,9 +125,6 @@ class NumberPromptTests(aiounittest.AsyncTestCase):
         test_flow4 = await test_flow3.send("Give me twenty meters of cable")
         await test_flow4.assert_reply("You asked me for '20' meters of cable.")
 
-    # TODO: retry_prompt in NumberPrompt appears to be broken
-    # It when NumberPrompt fails to receive a number, it retries, prompting
-    # with the prompt and not retry prompt in options
     async def test_number_prompt_retry(self):
         async def exec_test(turn_context: TurnContext) -> None:
             dialog_context: DialogContext = await dialogs.create_context(turn_context)
@@ -161,14 +158,11 @@ class NumberPromptTests(aiounittest.AsyncTestCase):
         dialogs.add(number_prompt)
 
         step1 = await adapter.send("hello")
-        await step1.assert_reply("Enter a number.")
-        # TODO: something is breaking in the validators or retry prompt
-        # where it does not accept the 2nd answer after reprompting the user
-        # for another value
-        # step3 = await step2.send("hello")
-        # step4 = await step3.assert_reply("You must enter a number.")
-        # step5 = await step4.send("64")
-        # await step5.assert_reply("Bot received the number '64'.")
+        step2 = await step1.assert_reply("Enter a number.")
+        step3 = await step2.send("hello")
+        step4 = await step3.assert_reply("You must enter a number.")
+        step5 = await step4.send("64")
+        await step5.assert_reply("Bot received the number '64'.")
 
     async def test_number_uses_locale_specified_in_constructor(self):
         # Create new ConversationState with MemoryStorage and register the state as middleware.
@@ -272,13 +266,10 @@ class NumberPromptTests(aiounittest.AsyncTestCase):
 
         step1 = await adapter.send("hello")
         step2 = await step1.assert_reply("Enter a number.")
-        await step2.send("150")
-        # TODO: something is breaking in the validators or retry prompt
-        # where it does not accept the 2nd answer after reprompting the user
-        # for another value
-        # step4 = await step3.assert_reply("You must enter a positive number less than 100.")
-        # step5 = await step4.send("64")
-        # await step5.assert_reply("Bot received the number '64'.")
+        step3 = await step2.send("150")
+        step4 = await step3.assert_reply("You must enter a positive number less than 100.")
+        step5 = await step4.send("64")
+        await step5.assert_reply("Bot received the number '64'.")
 
     async def test_float_number_prompt(self):
         async def exec_test(turn_context: TurnContext) -> None:


### PR DESCRIPTION
Fixes #281 
___

### Changes
Originally retry prompts were not sending to the user when an invalid value was sent to a `NumberPrompt` (e.g. "Please enter a number" "hello" <-- invalid)

* This was happening simply because `NumberPrompt` was missing an "`await`" for sending an activity if it passed the condition of needing to send a retry prompt.

* Uncommented tests that were previously ported that were breaking for retry promps and validation

#### Screen shots

Expected Behavior (plugging a `NumberPrompt` into CoreBot real quickly)
![image](https://user-images.githubusercontent.com/35248895/63130467-68adb380-bf6f-11e9-896e-81646ce7f021.png)
