### PR TITLE
Sample 45 - Changed greeting to include instructions to type anything to see state

### DIFF
--- a/samples/45.state-management/bots/state_management_bot.py
+++ b/samples/45.state-management/bots/state_management_bot.py
@@ -59,7 +59,9 @@ class StateManagementBot(ActivityHandler):
                 user_profile.name = turn_context.activity.text
 
                 # Acknowledge that we got their name.
-                await turn_context.send_activity(f"Thanks { user_profile.name }.")
+                await turn_context.send_activity(
+                    f"Thanks { user_profile.name }. To see conversation data, type anything."
+                )
 
                 # Reset the flag to allow the bot to go though the cycle again.
                 conversation_data.prompted_for_user_name = False


### PR DESCRIPTION
Fixes #306 

___

Added "`To see conversation data, type anything.`" in `45.state-management/bots/state_management_bot.py` for parity with C# sample as the "golden standard" sample.