### PR TITLE
[Parity w/ Dotnet] create_conversation tentant_id/channel_data

### DIFF
--- a/libraries/botbuilder-core/botbuilder/core/bot_framework_adapter.py
+++ b/libraries/botbuilder-core/botbuilder/core/bot_framework_adapter.py
@@ -180,7 +180,8 @@ class BotFrameworkAdapter(BotAdapter, UserTokenProvider):
             request = TurnContext.apply_conversation_reference(
                 Activity(), reference, is_incoming=True
             )
-            request.conversation = ConversationAccount(id=resource_response.id)
+            request.conversation = ConversationAccount(id=resource_response.id, tenant_id=parameters.tenant_id)
+            request.channel_data = parameters.channel_data
             if resource_response.service_url:
                 request.service_url = resource_response.service_url
 

--- a/libraries/botbuilder-core/botbuilder/core/bot_framework_adapter.py
+++ b/libraries/botbuilder-core/botbuilder/core/bot_framework_adapter.py
@@ -180,7 +180,9 @@ class BotFrameworkAdapter(BotAdapter, UserTokenProvider):
             request = TurnContext.apply_conversation_reference(
                 Activity(), reference, is_incoming=True
             )
-            request.conversation = ConversationAccount(id=resource_response.id, tenant_id=parameters.tenant_id)
+            request.conversation = ConversationAccount(
+                id=resource_response.id, tenant_id=parameters.tenant_id
+            )
             request.channel_data = parameters.channel_data
             if resource_response.service_url:
                 request.service_url = resource_response.service_url

--- a/libraries/botbuilder-core/tests/test_bot_framework_adapter.py
+++ b/libraries/botbuilder-core/tests/test_bot_framework_adapter.py
@@ -264,6 +264,8 @@ class TestBotFrameworkAdapter(aiounittest.AsyncTestCase):
         reference.channel_data = {"tenant": {"id": tenant_id}}
         adapter = AdapterUnderTest()
 
+        called = False
+
         async def aux_func_assert_valid_conversation(context):
             self.assertIsNotNone(context, "context not passed")
             self.assertIsNotNone(context.activity, "context has no request")
@@ -280,5 +282,8 @@ class TestBotFrameworkAdapter(aiounittest.AsyncTestCase):
                 tenant_id,
                 "request has invalid tenant_id in channel_data",
             )
+            nonlocal called
+            called = True
 
         await adapter.create_conversation(reference, aux_func_assert_valid_conversation)
+        self.assertTrue(called, "bot logic not called.")

--- a/libraries/botbuilder-core/tests/test_bot_framework_adapter.py
+++ b/libraries/botbuilder-core/tests/test_bot_framework_adapter.py
@@ -4,8 +4,8 @@
 from copy import copy, deepcopy
 from unittest.mock import Mock
 import unittest
-import aiounittest
 import uuid
+import aiounittest
 
 from botbuilder.core import (
     BotFrameworkAdapter,

--- a/libraries/botbuilder-core/tests/test_bot_framework_adapter.py
+++ b/libraries/botbuilder-core/tests/test_bot_framework_adapter.py
@@ -261,35 +261,24 @@ class TestBotFrameworkAdapter(aiounittest.AsyncTestCase):
 
         reference = deepcopy(REFERENCE)
         reference.conversation.tenant_id = tenant_id
-        reference.channel_data = {
-            'tenant': {
-                'id': tenant_id
-            }
-        }
+        reference.channel_data = {"tenant": {"id": tenant_id}}
         adapter = AdapterUnderTest()
 
         async def aux_func_assert_valid_conversation(context):
+            self.assertIsNotNone(context, "context not passed")
+            self.assertIsNotNone(context.activity, "context has no request")
             self.assertIsNotNone(
-                context,
-                "context not passed"
-            )
-            self.assertIsNotNone(
-                context.activity,
-                "context has no request"
-            )
-            self.assertIsNotNone(
-                context.activity.conversation,
-                "request has invalid conversation"
+                context.activity.conversation, "request has invalid conversation"
             )
             self.assertEqual(
                 context.activity.conversation.tenant_id,
                 tenant_id,
-                "request has invalid tenant_id on conversation"
+                "request has invalid tenant_id on conversation",
             )
             self.assertEqual(
-                context.activity.channel_data['tenant']['id'],
+                context.activity.channel_data["tenant"]["id"],
                 tenant_id,
-                "request has invalid tenant_id in channel_data"
+                "request has invalid tenant_id in channel_data",
             )
 
         await adapter.create_conversation(reference, aux_func_assert_valid_conversation)


### PR DESCRIPTION
Parity:

* https://github.com/microsoft/botbuilder-dotnet/pull/2481
* https://github.com/microsoft/botbuilder-js/pull/1173

Keeps tentant_id & channel_data in create_conversation

**I'm not confident I wrote the test appropriately. It works, but I'm not sure I went about it the best way.** Let me know if you'd like something changed.

**Before Change**
![image](https://user-images.githubusercontent.com/40401643/65062075-2097fd00-d930-11e9-863b-5443c9214d23.png)


**After Change**
![image](https://user-images.githubusercontent.com/40401643/65062086-268dde00-d930-11e9-8d7d-82a91773316e.png)
