### PR TITLE
Fix UnsupportedMediaType in samples

### DIFF
--- a/samples/06.using-cards/app.py
+++ b/samples/06.using-cards/app.py
@@ -59,7 +59,7 @@ BOT = RichCardsBot(CONVERSATION_STATE, USER_STATE, DIALOG)
 @APP.route("/api/messages", methods=["POST"])
 def messages():
     """Main bot message handler."""
-    if request.headers["Content-Type"] == "application/json":
+    if "application/json" in request.headers["Content-Type"]:
         body = request.json
     else:
         return Response(status=415)

--- a/samples/13.core-bot/app.py
+++ b/samples/13.core-bot/app.py
@@ -46,7 +46,7 @@ BOT = DialogAndWelcomeBot(CONVERSATION_STATE, USER_STATE, DIALOG)
 @APP.route("/api/messages", methods=["POST"])
 def messages():
     """Main bot message handler."""
-    if request.headers["Content-Type"] == "application/json":
+    if "application/json" in request.headers["Content-Type"]:
         body = request.json
     else:
         return Response(status=415)

--- a/samples/21.corebot-app-insights/main.py
+++ b/samples/21.corebot-app-insights/main.py
@@ -62,7 +62,7 @@ BOT = DialogAndWelcomeBot(CONVERSATION_STATE, USER_STATE, DIALOG, TELEMETRY_CLIE
 @APP.route("/api/messages", methods=["POST"])
 def messages():
     """Main bot message handler."""
-    if request.headers["Content-Type"] == "application/json":
+    if "application/json" in request.headers["Content-Type"]:
         body = request.json
     else:
         return Response(status=415)

--- a/samples/45.state-management/app.py
+++ b/samples/45.state-management/app.py
@@ -57,7 +57,7 @@ BOT = StateManagementBot(CONVERSATION_STATE, USER_STATE)
 @APP.route("/api/messages", methods=["POST"])
 def messages():
     """Main bot message handler."""
-    if request.headers["Content-Type"] == "application/json":
+    if "application/json" in request.headers["Content-Type"]:
         body = request.json
     else:
         return Response(status=415)

--- a/samples/experimental/101.corebot-bert-bidaf/bot/main.py
+++ b/samples/experimental/101.corebot-bert-bidaf/bot/main.py
@@ -39,7 +39,7 @@ BOT = DialogAndWelcomeBot(CONVERSATION_STATE, USER_STATE, DIALOG)
 @APP.route("/api/messages", methods=["POST"])
 def messages():
     """Main bot message handler."""
-    if request.headers["Content-Type"] == "application/json":
+    if "application/json" in request.headers["Content-Type"]:
         body = request.json
     else:
         return Response(status=415)

--- a/samples/python_django/13.core-bot/bots/views.py
+++ b/samples/python_django/13.core-bot/bots/views.py
@@ -24,7 +24,7 @@ def home():
 
 def messages(request):
     """Main bot message handler."""
-    if request.headers["Content-Type"] == "application/json":
+    if "application/json" in request.headers["Content-Type"]:
         body = json.loads(request.body.decode("utf-8"))
     else:
         return HttpResponse(status=415)


### PR DESCRIPTION
Fixes: https://github.com/microsoft/botbuilder-python/issues/312

**Issue Summary**

`request.headers["Content-Type"]` sometimes comes in as 

```
application/json; charset=utf-8
````

...which causes the `415: UnsupportedMediaType` to throw.

**Changes**

In `app.py` for the samples, it implements this diff:

```diff
@app.route("/api/messages", methods=["POST"])
def messages():
    """Main bot message handler."""
-   if request.headers["Content-Type"] == "application/json":
+   if "application/json" in request.headers["Content-Type"]:
        body = request.json
    else:
        return Response(status=415)
```

