### PR TITLE
_dialog_stack to dialog_stack

### DIFF
--- a/libraries/botbuilder-dialogs/botbuilder/dialogs/dialog_state.py
+++ b/libraries/botbuilder-dialogs/botbuilder/dialogs/dialog_state.py
@@ -8,15 +8,11 @@ from .dialog_instance import DialogInstance
 class DialogState:
     def __init__(self, stack: List[DialogInstance] = None):
         if stack is None:
-            self._dialog_stack = []
+            self.dialog_stack = []
         else:
-            self._dialog_stack = stack
-
-    @property
-    def dialog_stack(self):
-        return self._dialog_stack
+            self.dialog_stack = stack
 
     def __str__(self):
-        if not self._dialog_stack:
+        if not self.dialog_stack:
             return "dialog stack empty!"
-        return " ".join(map(str, self._dialog_stack))
+        return " ".join(map(str, self.dialog_stack))


### PR DESCRIPTION
Prevents the following error:

```python
>       self._stack = state.dialog_stack
E       AttributeError: 'dict' object has no attribute 'dialog_stack'
```

dialog_context was errantly referencing `state.dialog_stack`, which didn't exist because dialog_state has it as `self._dialog_stack`. Since it should be public, this PR changes references of `_dialog_stack` to `dialog_stack` and removes the now-unnecessary `@property`

Note: As far as I can tell `dialog_stack` is only referenced in `dialog_context` and `dialog_state`, so this should cover all necessary changes.