### PR TITLE
Storage attr fix

### DIFF
--- a/libraries/botbuilder-azure/botbuilder/azure/blob_storage.py
+++ b/libraries/botbuilder-azure/botbuilder/azure/blob_storage.py
@@ -73,7 +73,11 @@ class BlobStorage(Storage):
         )
 
         for (name, item) in changes.items():
-            e_tag = item.e_tag if hasattr(item, "e_tag") else item.get("e_tag", None)
+            e_tag = None
+            if isinstance(item, dict):
+                e_tag = item.get("e_tag", None)
+            elif hasattr(item, "e_tag"):
+                e_tag = item.e_tag
             e_tag = None if e_tag == "*" else e_tag
             if e_tag == "":
                 raise Exception("blob_storage.write(): etag missing")

--- a/libraries/botbuilder-azure/botbuilder/azure/cosmosdb_partitioned_storage.py
+++ b/libraries/botbuilder-azure/botbuilder/azure/cosmosdb_partitioned_storage.py
@@ -150,7 +150,11 @@ class CosmosDbPartitionedStorage(Storage):
         await self.initialize()
 
         for (key, change) in changes.items():
-            e_tag = change.get("e_tag", None)
+            e_tag = None
+            if isinstance(change, dict):
+                e_tag = change.get("e_tag", None)
+            elif hasattr(change, "e_tag"):
+                e_tag = change.e_tag
             doc = {
                 "id": CosmosDbKeyEscape.sanitize_key(
                     key, self.config.key_suffix, self.config.compatibility_mode

--- a/libraries/botbuilder-azure/botbuilder/azure/cosmosdb_storage.py
+++ b/libraries/botbuilder-azure/botbuilder/azure/cosmosdb_storage.py
@@ -183,11 +183,11 @@ class CosmosDbStorage(Storage):
                 # iterate over the changes
             for (key, change) in changes.items():
                 # store the e_tag
-                e_tag = (
-                    change.e_tag
-                    if hasattr(change, "e_tag")
-                    else change.get("e_tag", None)
-                )
+                e_tag = None
+                if isinstance(change, dict):
+                    e_tag = change.get("e_tag", None)
+                elif hasattr(change, "e_tag"):
+                    e_tag = change.e_tag
                 # create the new document
                 doc = {
                     "id": CosmosDbKeyEscape.sanitize_key(key),

--- a/libraries/botbuilder-core/botbuilder/core/memory_storage.py
+++ b/libraries/botbuilder-core/botbuilder/core/memory_storage.py
@@ -48,19 +48,19 @@ class MemoryStorage(Storage):
                 # If it exists then we want to cache its original value from memory
                 if key in self.memory:
                     old_state = self.memory[key]
-                    if not isinstance(old_state, StoreItem):
+                    if isinstance(old_state, dict):
                         old_state_etag = old_state.get("e_tag", None)
-                    elif old_state.e_tag:
+                    elif hasattr(old_state, "e_tag"):
                         old_state_etag = old_state.e_tag
 
                 new_state = new_value
 
                 # Set ETag if applicable
-                new_value_etag = (
-                    new_value.e_tag
-                    if hasattr(new_value, "e_tag")
-                    else new_value.get("e_tag", None)
-                )
+                new_value_etag = None
+                if isinstance(new_value, dict):
+                    new_value_etag = new_value.get("e_tag", None)
+                elif hasattr(new_value, "e_tag"):
+                    new_value_etag = new_value.e_tag
                 if new_value_etag == "":
                     raise Exception("memory_storage.write(): etag missing")
                 if (

--- a/libraries/botbuilder-core/botbuilder/core/memory_storage.py
+++ b/libraries/botbuilder-core/botbuilder/core/memory_storage.py
@@ -62,7 +62,7 @@ class MemoryStorage(Storage):
                     else new_value.get("e_tag", None)
                 )
                 if new_value_etag == "":
-                    raise Exception("blob_storage.write(): etag missing")
+                    raise Exception("memory_storage.write(): etag missing")
                 if (
                     old_state_etag is not None
                     and new_value_etag is not None


### PR DESCRIPTION
Fixes instances where `item.get("e_tag")` fails due to item not being a dict, but having the "e_tag" attribute. Also changed a few instances where this was working fine to match the new "style" of this fix:

```python
e_tag = None
if isinstance(item, dict):
  e_tag = item.get("e_tag", None)
elif hasattr(item, "e_tag"):
  e_tag = item.e_tag
```

All current tests pass (with EMULATOR_RUNNING = True, of course)