### PR TITLE
mm-api-ref-docs-fixes

### DIFF
--- a/libraries/botbuilder-core/botbuilder/core/activity_handler.py
+++ b/libraries/botbuilder-core/botbuilder/core/activity_handler.py
@@ -7,13 +7,25 @@ from .turn_context import TurnContext
 
 
 class ActivityHandler:
+    """
+    Bot event activity handler.
+
+    .. remarks::
+    Provides an extensible class for handling incoming activities in an event-driven way.
+    You can register an arbitrary set of handlers for each event type. To register a handler
+    for an event, use the corresponding :meth:on_event. If multiple handlers are registered for
+    an event, they are run in the order in which they were registered.
+    This :class:`ActivityHandler` object emits a series of *events* as it processes an incoming activity.
+    A handler can stop the propagation of the event by not calling the continuation function.
+
+    """
+
     async def on_turn(self, turn_context: TurnContext):
         """
-        Called by the adapter (for example, :class:`BotFrameworkAdapter`) at runtime
-        in order to process an inbound :class:`botbuilder.schema.Activity`.
+        Called by the adapter at runtime in order to process an inbound :class:`botbuilder.schema.Activity`.
 
         :param turn_context: The context object for this turn
-        :type turn_context: :class:`TurnContext`
+        :type turn_context: :class:`botbuilder.core.TurnContext`
 
         :returns: A task that represents the work queued to execute
 
@@ -22,11 +34,10 @@ class ActivityHandler:
             process, which allows a derived class to provide type-specific logic in a controlled way.
             In a derived class, override this method to add logic that applies to all activity types.
 
-            .. note::
-                - Add logic to apply before the type-specific logic and before the call to the
-                  :meth:`ActivityHandler.on_turn()` method.
-                - Add logic to apply after the type-specific logic after the call to the
-                  :meth:`ActivityHandler.on_turn()` method.
+            Notice the following:
+
+            - Add logic to apply before the type-specific logic and before the call to :meth:`ActivityHandler.on_turn()`.
+            - Add logic to apply after the type-specific logic after the call to :meth:`ActivityHandler.on_turn()`.
         """
         if turn_context is None:
             raise TypeError("ActivityHandler.on_turn(): turn_context cannot be None.")
@@ -65,7 +76,7 @@ class ActivityHandler:
         such as the conversational logic.
 
         :param turn_context: The context object for this turn
-        :type turn_context: :class:`TurnContext`
+        :type turn_context: :class:`botbuilder.core.TurnContext`
 
         :returns: A task that represents the work queued to execute
 
@@ -75,20 +86,19 @@ class ActivityHandler:
     async def on_conversation_update_activity(self, turn_context: TurnContext):
         """
         Invoked when a conversation update activity is received from the channel when the base behavior of
-        :meth:`ActivityHandler.on_turn()` is used.
+        :meth:`on_turn()` is used.
 
         :param turn_context: The context object for this turn
-        :type turn_context: :class:`TurnContext`
+        :type turn_context: :class:`botbuilder.core.TurnContext`
 
         :returns: A task that represents the work queued to execute
 
-        .. note::
-            When the :meth:'ActivityHandler.on_turn()` method receives a conversation update activity, it calls this
-            method.
-            If the conversation update activity indicates that members other than the bot joined the conversation,
-            it calls the  :meth:`ActivityHandler.on_members_added_activity()` method.
+        .. remarks::
+            When the :meth:'on_turn()` method receives a conversation update activity, it calls this
+            method. If the conversation update activity indicates that members other than the bot joined the
+            conversation, it calls the  :meth:`on_members_added_activity()` method.
             If the conversation update activity indicates that members other than the bot left the conversation,
-            it calls the  :meth:`ActivityHandler.on_members_removed_activity()`  method.
+            it calls the  :meth:`on_members_removed_activity()`  method.
             In a derived class, override this method to add logic that applies to all conversation update activities.
             Add logic to apply before the member added or removed logic before the call to this base class method.
         """
@@ -115,18 +125,17 @@ class ActivityHandler:
         Override this method in a derived class to provide logic for when members other than the bot join
         the conversation. You can add your bot's welcome logic.
 
-        :param members_added: A list of all the members added to the conversation, as described by the
-        conversation update activity
+        :param members_added: A list of all the members added to the conversation
         :type members_added: :class:`typing.List`
         :param turn_context: The context object for this turn
-        :type turn_context: :class:`TurnContext`
+        :type turn_context: :class:`botbuilder.core.TurnContext`
 
         :returns: A task that represents the work queued to execute
 
-        .. note::
+        .. remarks::
             When the :meth:'ActivityHandler.on_conversation_update_activity()` method receives a conversation
-            update activity that indicates
-            one or more users other than the bot are joining the conversation, it calls this method.
+            update activity that indicates one or more users other than the bot are joining the conversation,
+            it calls this method.
         """
         return
 
@@ -137,15 +146,14 @@ class ActivityHandler:
         Override this method in a derived class to provide logic for when members other than the bot leave
         the conversation.  You can add your bot's good-bye logic.
 
-        :param members_added: A list of all the members removed from the conversation, as described by the
-        conversation update activity
+        :param members_added: A list of all the members removed from the conversation
         :type members_added: :class:`typing.List`
         :param turn_context: The context object for this turn
-        :type turn_context: :class:`TurnContext`
+        :type turn_context: :class:`botbuilder.core.TurnContext`
 
         :returns: A task that represents the work queued to execute
 
-        .. note::
+        .. remarks::
             When the :meth:'ActivityHandler.on_conversation_update_activity()` method receives a conversation
             update activity that indicates one or more users other than the bot are leaving the conversation,
             it calls this method.
@@ -156,25 +164,24 @@ class ActivityHandler:
     async def on_message_reaction_activity(self, turn_context: TurnContext):
         """
         Invoked when an event activity is received from the connector when the base behavior of
-        :meth:'ActivityHandler.on_turn()` is used.
+        :meth:'on_turn()` is used.
 
         :param turn_context: The context object for this turn
-        :type turn_context: :class:`TurnContext`
+        :type turn_context: :class:`botbuilder.core.TurnContext`
 
         :returns: A task that represents the work queued to execute
 
-        .. note::
+        .. remarks::
             Message reactions correspond to the user adding a 'like' or 'sad' etc. (often an emoji) to a previously
-            sent activity.
-            Message reactions are only supported by a few channels. The activity that the message reaction corresponds
-            to is indicated in the reply to Id property. The value of this property is the activity id of a previously
-            sent activity given back to the bot as the response from a send call.
-            When the :meth:'ActivityHandler.on_turn()` method receives a message reaction activity, it calls this
+            sent activity. Message reactions are only supported by a few channels. The activity that the message
+            reaction corresponds to is indicated in the reply to Id property. The value of this property is the
+            activity id of a previously sent activity given back to the bot as the response from a send call.
+            When the :meth:'on_turn()` method receives a message reaction activity, it calls this
             method.
             If the message reaction indicates that reactions were added to a message, it calls
-            :meth:'ActivityHandler.on_reaction_added().
+            :meth:'on_reaction_added().
             If the message reaction indicates that reactions were removed from a message, it calls
-            :meth:'ActivityHandler.on_reaction_removed().
+            :meth:'on_reaction_removed().
             In a derived class, override this method to add logic that applies to all message reaction activities.
             Add logic to apply before the reactions added or removed logic before the call to the this base class
             method.
@@ -200,11 +207,11 @@ class ActivityHandler:
         :param message_reactions: The list of reactions added
         :type message_reactions: :class:`typing.List`
         :param turn_context: The context object for this turn
-        :type turn_context: :class:`TurnContext`
+        :type turn_context: :class:`botbuilder.core.TurnContext`
 
         :returns: A task that represents the work queued to execute
 
-        .. note::
+        .. remarks::
             Message reactions correspond to the user adding a 'like' or 'sad' etc. (often an emoji)
             to a previously sent message on the conversation. Message reactions are supported by only a few channels.
             The activity that the message is in reaction to is identified by the activity's reply to Id property.
@@ -223,11 +230,11 @@ class ActivityHandler:
         :param message_reactions: The list of reactions removed
         :type message_reactions: :class:`typing.List`
         :param turn_context: The context object for this turn
-        :type turn_context: :class:`TurnContext`
+        :type turn_context: :class:`botbuilder.core.TurnContext`
 
         :returns: A task that represents the work queued to execute
 
-        .. note::
+        .. remarks::
             Message reactions correspond to the user adding a 'like' or 'sad' etc. (often an emoji)
             to a previously sent message on the conversation. Message reactions are supported by only a few channels.
             The activity that the message is in reaction to is identified by the activity's reply to Id property.
@@ -242,19 +249,17 @@ class ActivityHandler:
         :meth:'ActivityHandler.on_turn()` is used.
 
         :param turn_context: The context object for this turn
-        :type turn_context: :class:`TurnContext`
+        :type turn_context: :class:`botbuilder.core.TurnContext`
 
         :returns: A task that represents the work queued to execute
 
-        .. note::
-            When the :meth:'ActivityHandler.on_turn()` method receives an event activity, it calls this method.
-            If the activity name is `tokens/response`, it calls :meth:'ActivityHandler.on_token_response_event()`;
-            otherwise, it calls :meth:'ActivityHandler.on_event()`.
-
+        .. remarks::
+            When the :meth:'on_turn()` method receives an event activity, it calls this method.
+            If the activity name is `tokens/response`, it calls :meth:'on_token_response_event()`;
+            otherwise, it calls :meth:'on_event()`.
             In a derived class, override this method to add logic that applies to all event activities.
             Add logic to apply before the specific event-handling logic before the call to this base class method.
             Add logic to apply after the specific event-handling logic after the call to this base class method.
-
             Event activities communicate programmatic information from a client or channel to a bot.
             The meaning of an event activity is defined by the event activity name property, which is meaningful within
             the scope of a channel.
@@ -273,12 +278,12 @@ class ActivityHandler:
         If using an `oauth_prompt`, override this method to forward this activity to the current dialog.
 
         :param turn_context: The context object for this turn
-        :type turn_context: :class:`TurnContext`
+        :type turn_context: :class:`botbuilder.core.TurnContext`
 
         :returns: A task that represents the work queued to execute
 
-        .. note::
-            When the :meth:'ActivityHandler.on_event()` method receives an event with an activity name of
+        .. remarks::
+            When the :meth:'on_event()` method receives an event with an activity name of
             `tokens/response`, it calls this method. If your bot uses an `oauth_prompt`, forward the incoming
             activity to the current dialog.
         """
@@ -289,16 +294,15 @@ class ActivityHandler:
     ):
         """
         Invoked when an event other than `tokens/response` is received when the base behavior of
-        :meth:'ActivityHandler.on_event_activity()` is used.
-
+        :meth:'on_event_activity()` is used.
 
         :param turn_context: The context object for this turn
-        :type turn_context: :class:`TurnContext`
+        :type turn_context: :class:`botbuilder.core.TurnContext`
 
         :returns: A task that represents the work queued to execute
 
-        .. note::
-            When the :meth:'ActivityHandler.on_event_activity()` is used method receives an event with an
+        .. remarks::
+            When the :meth:'on_event_activity()` is used method receives an event with an
             activity name other than `tokens/response`, it calls this method.
             This method could optionally be overridden if the bot is meant to handle miscellaneous events.
         """
@@ -311,7 +315,7 @@ class ActivityHandler:
         Invoked when a conversation end activity is received from the channel.
 
         :param turn_context: The context object for this turn
-        :type turn_context: :class:`TurnContext`
+        :type turn_context: :class:`botbuilder.core.TurnContext`
         :returns: A task that represents the work queued to execute
         """
         return
@@ -325,11 +329,11 @@ class ActivityHandler:
         If overridden, this method could potentially respond to any of the other activity types.
 
         :param turn_context: The context object for this turn
-        :type turn_context: :class:`TurnContext`
+        :type turn_context: :class:`botbuilder.core.TurnContext`
 
         :returns: A task that represents the work queued to execute
 
-        .. note::
+        .. remarks::
             When the :meth:`ActivityHandler.on_turn()` method receives an activity that is not a message,
             conversation update, message reaction, or event activity, it calls this method.
         """

--- a/libraries/botbuilder-core/botbuilder/core/bot_framework_adapter.py
+++ b/libraries/botbuilder-core/botbuilder/core/bot_framework_adapter.py
@@ -87,12 +87,9 @@ class BotFrameworkAdapterSettings:
         """
         Contains the settings used to initialize a :class:`BotFrameworkAdapter` instance.
 
-        :param app_id: The bot application ID. This is the appId returned by the Azure portal registration, and is
-        the value of the `MicrosoftAppId` parameter in the `config.py` file.
+        :param app_id: The bot application ID. .
         :type app_id: str
-        :param app_password: The bot application password. This is the password returned by the Azure portal
-        registration, and is
-        the value os the `MicrosoftAppPassword` parameter in the `config.py` file.
+        :param app_password: The bot application password.
         :type app_password: str
         :param channel_auth_tenant: The channel tenant to use in conversation
         :type channel_auth_tenant: str
@@ -201,7 +198,7 @@ class BotFrameworkAdapter(BotAdapter, UserTokenProvider):
 
         :return: A task that represents the work queued to execute.
 
-        .. note::
+        .. remarks::
             This is often referred to as the bots *proactive messaging* flow as it lets the bot proactively
             send messages to a conversation or user that are already in a communication.
             Scenarios such as sending notifications or coupons to a user are enabled by this function.
@@ -244,7 +241,7 @@ class BotFrameworkAdapter(BotAdapter, UserTokenProvider):
 
         :return: A task representing the work queued to execute.
 
-        .. note::
+        .. remarks::
             To start a conversation, your bot must know its account information and the user's
             account information on that channel.
             Most channels only support initiating a direct message (non-group) conversation.
@@ -318,7 +315,7 @@ class BotFrameworkAdapter(BotAdapter, UserTokenProvider):
         was `Invoke` and the corresponding key (`channelId` + `activityId`) was found then
         an :class:`InvokeResponse` is returned; otherwise, `null` is returned.
 
-        .. note::
+        .. remarks::
             Call this method to reactively send a message to a conversation.
             If the task completes successfully, then an :class:`InvokeResponse` is returned;
             otherwise. `null` is returned.
@@ -454,7 +451,7 @@ class BotFrameworkAdapter(BotAdapter, UserTokenProvider):
 
         :return: A task that represents the work queued to execute
 
-        .. note::
+        .. remarks::
             If the activity is successfully sent, the task result contains
             a :class:`botbuilder.schema.ResourceResponse` object containing the ID that
             the receiving channel assigned to the activity.
@@ -486,7 +483,7 @@ class BotFrameworkAdapter(BotAdapter, UserTokenProvider):
 
         :return: A task that represents the work queued to execute
 
-        .. note::
+        .. remarks::
             The activity_id of the :class:`botbuilder.schema.ConversationReference` identifies the activity to delete.
         """
         try:
@@ -562,7 +559,7 @@ class BotFrameworkAdapter(BotAdapter, UserTokenProvider):
         Deletes a member from the current conversation.
 
         :param context: The context object for the turn
-        :type context: :class:`TurnContext`
+        :type context: :class:`botbuilder.core.TurnContext`
         :param member_id: The ID of the member to remove from the conversation
         :type member_id: str
 
@@ -600,7 +597,7 @@ class BotFrameworkAdapter(BotAdapter, UserTokenProvider):
         Lists the members of a given activity.
 
         :param context: The context object for the turn
-        :type context: :class:`TurnContext`
+        :type context: :class:`botbuilder.core.TurnContext`
         :param activity_id: (Optional) Activity ID to enumerate.
         If not specified the current activities ID will be used.
 
@@ -642,7 +639,7 @@ class BotFrameworkAdapter(BotAdapter, UserTokenProvider):
         Lists the members of a current conversation.
 
         :param context: The context object for the turn
-        :type context: :class:`TurnContext`
+        :type context: :class:`botbuilder.core.TurnContext`
 
         :raises: An exception error
 
@@ -686,7 +683,7 @@ class BotFrameworkAdapter(BotAdapter, UserTokenProvider):
 
         :return: A task that represents the work queued to execute
 
-        .. note:: If the task completes successfully, the result contains a page of the members of the current
+        .. remarks:: If the task completes successfully, the result contains a page of the members of the current
         conversation.
         This overload may be called from outside the context of a conversation, as only the bot's service URL and
         credentials are required.
@@ -702,7 +699,7 @@ class BotFrameworkAdapter(BotAdapter, UserTokenProvider):
         Attempts to retrieve the token for a user that's in a login flow.
 
         :param context: Context for the current turn of conversation with the user
-        :type context: :class:`TurnContext`
+        :type context: :class:`botbuilder.core.TurnContext`
         :param connection_name: Name of the auth connection to use
         :type connection_name: str
         :param magic_code" (Optional) user entered code to validate
@@ -749,7 +746,7 @@ class BotFrameworkAdapter(BotAdapter, UserTokenProvider):
         Signs the user out with the token server.
 
         :param context: Context for the current turn of conversation with the user
-        :type context: :class:`TurnContext`
+        :type context: :class:`botbuilder.core.TurnContext`
         :param connection_name: Name of the auth connection to use
         :type connection_name: str
         :param user_id: User id of user to sign out
@@ -778,13 +775,13 @@ class BotFrameworkAdapter(BotAdapter, UserTokenProvider):
         Gets the raw sign-in link to be sent to the user for sign-in for a connection name.
 
         :param context: Context for the current turn of conversation with the user
-        :type context: :class:`TurnContext`
+        :type context: :class:`botbuilder.core.TurnContext`
         :param connection_name: Name of the auth connection to use
         :type connection_name: str
 
         :returns: A task that represents the work queued to execute
 
-        .. note::
+        .. remarks::
             If the task completes successfully, the result contains the raw sign-in link
         """
         self.check_emulating_oauth_cards(context)
@@ -811,7 +808,7 @@ class BotFrameworkAdapter(BotAdapter, UserTokenProvider):
         Retrieves the token status for each configured connection for the given user.
 
         :param context: Context for the current turn of conversation with the user
-        :type context: :class:`TurnContext`
+        :type context: :class:`botbuilder.core.TurnContext`
         :param user_id: The user Id for which token status is retrieved
         :type user_id: str
         :param include_filter: (Optional) Comma separated list of connection's to include.
@@ -845,7 +842,7 @@ class BotFrameworkAdapter(BotAdapter, UserTokenProvider):
         Retrieves Azure Active Directory tokens for particular resources on a configured connection.
 
         :param context: Context for the current turn of conversation with the user
-        :type context: :class:`TurnContext`
+        :type context: :class:`botbuilder.core.TurnContext`
 
         :param connection_name: The name of the Azure Active Directory connection configured with this bot
         :type connection_name: str

--- a/libraries/botbuilder-core/botbuilder/core/bot_state.py
+++ b/libraries/botbuilder-core/botbuilder/core/bot_state.py
@@ -63,7 +63,7 @@ class BotState(PropertyManager):
 
     def create_property(self, name: str) -> StatePropertyAccessor:
         """
-        Create a property definition and register it with this :class:`BotState`.
+        Creates a property definition and registers it with this :class:`BotState`.
 
         :param name: The name of the property
         :type name: str
@@ -75,6 +75,14 @@ class BotState(PropertyManager):
         return BotStatePropertyAccessor(self, name)
 
     def get(self, turn_context: TurnContext) -> Dict[str, object]:
+        """
+        Gets a copy of the raw cached data for the :class:`BotState` from the turn context.
+
+        :param turn_context: The context object for this turn
+        :type turn_context: :class:`TurnContext`
+
+        :return: The raw cached data for the :class:`BotState`
+        """
         cached = turn_context.turn_state.get(self._context_service_key)
 
         return getattr(cached, "state", None)
@@ -132,7 +140,7 @@ class BotState(PropertyManager):
         :return: None
 
         .. note::
-            This function must be called in order for the cleared state to be persisted to the underlying store.
+            This method must be called in order for the cleared state to be persisted to the underlying store.
         """
         if turn_context is None:
             raise TypeError("BotState.clear_state(): turn_context cannot be None.")
@@ -161,6 +169,10 @@ class BotState(PropertyManager):
 
     @abstractmethod
     def get_storage_key(self, turn_context: TurnContext) -> str:
+        """
+        When overridden in a derived class, gets the key to use when reading and
+        writing state to and from storage.
+        """
         raise NotImplementedError()
 
     async def get_property_value(self, turn_context: TurnContext, property_name: str):
@@ -233,15 +245,40 @@ class BotState(PropertyManager):
 
 ##
 class BotStatePropertyAccessor(StatePropertyAccessor):
+    """
+    Defines methods for accessing a state property created in a :class:`BotState` object.
+    """
+
     def __init__(self, bot_state: BotState, name: str):
+        """
+        Initializes a new instance of the :class:`BotStatePropertyAccessor` class.
+
+        :param bot_state: The state object to access
+        :type bot_state:  :class:`BotState`
+        :param name: The name of the state property to access
+        :type name: str
+
+        """
         self._bot_state = bot_state
         self._name = name
 
     @property
     def name(self) -> str:
+        """
+        Gets the name of the property.
+
+        :return: The name of the property
+        :rtype: str
+        """
         return self._name
 
     async def delete(self, turn_context: TurnContext) -> None:
+        """
+        Deletes the property.
+
+        :param turn_context: The context object for this turn
+        :type turn_context: :class:`TurnContext`
+        """
         await self._bot_state.load(turn_context, False)
         await self._bot_state.delete_property_value(turn_context, self._name)
 
@@ -250,6 +287,14 @@ class BotStatePropertyAccessor(StatePropertyAccessor):
         turn_context: TurnContext,
         default_value_or_factory: Union[Callable, object] = None,
     ) -> object:
+        """
+        Gets the property value.
+
+        :param turn_context: The context object for this turn
+        :type turn_context: :class:`TurnContext`
+        :param default_value_or_factory: Defines the default value when no value is set for the property
+        :type default_value_or_factory: :typing:Union
+        """
         await self._bot_state.load(turn_context, False)
         try:
             result = await self._bot_state.get_property_value(turn_context, self._name)
@@ -268,5 +313,14 @@ class BotStatePropertyAccessor(StatePropertyAccessor):
             return result
 
     async def set(self, turn_context: TurnContext, value: object) -> None:
+        """
+        Sets the property value.
+
+        :param turn_context: The context object for this turn
+        :type turn_context: :class:`TurnContext`
+
+        :param value: The value to assign to the property
+        :type value: :typing:`Object`
+        """
         await self._bot_state.load(turn_context, False)
         await self._bot_state.set_property_value(turn_context, self._name, value)

--- a/libraries/botbuilder-core/botbuilder/core/bot_state.py
+++ b/libraries/botbuilder-core/botbuilder/core/bot_state.py
@@ -79,7 +79,7 @@ class BotState(PropertyManager):
         Gets a copy of the raw cached data for the :class:`BotState` from the turn context.
 
         :param turn_context: The context object for this turn
-        :type turn_context: :class:`TurnContext`
+        :type turn_context: :class:`botbuilder.core.TurnContext`
 
         :return: The raw cached data for the :class:`BotState`
         """
@@ -92,7 +92,7 @@ class BotState(PropertyManager):
         Reads the current state object and caches it in the context object for this turn.
 
         :param turn_context: The context object for this turn
-        :type turn_context: :class:`TurnContext`
+        :type turn_context: :class:`botbuilder.core.TurnContext`
         :param force: Optional, true to bypass the cache
         :type force: bool
         """
@@ -115,7 +115,7 @@ class BotState(PropertyManager):
         If the state has changed, it saves the state cached in the current context for this turn.
 
         :param turn_context: The context object for this turn
-        :type turn_context: :class:`TurnContext`
+        :type turn_context: :class:`botbuilder.core.TurnContext`
         :param force: Optional, true to save state to storage whether or not there are changes
         :type force: bool
         """
@@ -135,7 +135,7 @@ class BotState(PropertyManager):
         Clears any state currently stored in this state scope.
 
         :param turn_context: The context object for this turn
-        :type turn_context: :class:`TurnContext`
+        :type turn_context: :class:`botbuilder.core.TurnContext`
 
         :return: None
 
@@ -155,7 +155,7 @@ class BotState(PropertyManager):
         Deletes any state currently stored in this state scope.
 
         :param turn_context: The context object for this turn
-        :type turn_context: :class:`TurnContext`
+        :type turn_context: :class:`botbuilder.core.TurnContext`
 
         :return: None
         """
@@ -180,7 +180,7 @@ class BotState(PropertyManager):
         Gets the value of the specified property in the turn context.
 
         :param turn_context: The context object for this turn
-        :type turn_context: :class:`TurnContext`
+        :type turn_context: :class:`botbuilder.core.TurnContext`
         :param property_name: The property name
         :type property_name: str
 
@@ -207,7 +207,7 @@ class BotState(PropertyManager):
         Deletes a property from the state cache in the turn context.
 
         :param turn_context: The context object for this turn
-        :type turn_context: :class:`TurnContext`
+        :type turn_context: :class:`botbuilder.core.TurnContext`
         :param property_name: The name of the property to delete
         :type property_name: str
 
@@ -227,7 +227,7 @@ class BotState(PropertyManager):
         Sets a property to the specified value in the turn context.
 
         :param turn_context: The context object for this turn
-        :type turn_context: :class:`TurnContext`
+        :type turn_context: :class:`botbuilder.core.TurnContext`
         :param property_name: The property name
         :type property_name: str
         :param value: The value to assign to the property
@@ -277,7 +277,7 @@ class BotStatePropertyAccessor(StatePropertyAccessor):
         Deletes the property.
 
         :param turn_context: The context object for this turn
-        :type turn_context: :class:`TurnContext`
+        :type turn_context: :class:`botbuilder.core.TurnContext`
         """
         await self._bot_state.load(turn_context, False)
         await self._bot_state.delete_property_value(turn_context, self._name)
@@ -291,7 +291,7 @@ class BotStatePropertyAccessor(StatePropertyAccessor):
         Gets the property value.
 
         :param turn_context: The context object for this turn
-        :type turn_context: :class:`TurnContext`
+        :type turn_context: :class:`botbuilder.core.TurnContext`
         :param default_value_or_factory: Defines the default value when no value is set for the property
         :type default_value_or_factory: :typing:Union
         """
@@ -317,7 +317,7 @@ class BotStatePropertyAccessor(StatePropertyAccessor):
         Sets the property value.
 
         :param turn_context: The context object for this turn
-        :type turn_context: :class:`TurnContext`
+        :type turn_context: :class:`botbuilder.core.TurnContext`
 
         :param value: The value to assign to the property
         :type value: :typing:`Object`

--- a/libraries/botbuilder-core/botbuilder/core/conversation_state.py
+++ b/libraries/botbuilder-core/botbuilder/core/conversation_state.py
@@ -9,14 +9,13 @@ from .storage import Storage
 class ConversationState(BotState):
     """
     Defines a state management object for conversation state.
-    Extends :class:`BootState` base class.
 
     .. remarks::
         Conversation state is available in any turn in a specific conversation, regardless of the user, such as
         in a group conversation.
     """
 
-    no_key_error_message = "ConversationState: channelId and/or conversation missing from context.activity."
+    no_key_error_message = "ConversationState: channel ID and/or conversation missing from context.activity."
 
     def __init__(self, storage: Storage):
         """
@@ -35,7 +34,7 @@ class ConversationState(BotState):
         :param turn_context: The context object for this turn.
         :type turn_context: :class:`TurnContext`
 
-        :raise: :class:`TypeError` if the :meth:`TurnContext.activity` for the current turn is missing
+        :raises: :class:`TypeError` if the :meth:`TurnContext.activity` for the current turn is missing
         :class:`botbuilder.schema.Activity` channelId or conversation information or the conversation's
         account id is missing.
 

--- a/libraries/botbuilder-core/botbuilder/core/conversation_state.py
+++ b/libraries/botbuilder-core/botbuilder/core/conversation_state.py
@@ -32,7 +32,7 @@ class ConversationState(BotState):
         Gets the key to use when reading and writing state to and from storage.
 
         :param turn_context: The context object for this turn.
-        :type turn_context: :class:`TurnContext`
+        :type turn_context: :class:`botbuilder.core.TurnContext`
 
         :raises: :class:`TypeError` if the :meth:`TurnContext.activity` for the current turn is missing
         :class:`botbuilder.schema.Activity` channelId or conversation information or the conversation's

--- a/libraries/botbuilder-dialogs/botbuilder/dialogs/prompts/oauth_prompt.py
+++ b/libraries/botbuilder-dialogs/botbuilder/dialogs/prompts/oauth_prompt.py
@@ -47,20 +47,17 @@ class OAuthPrompt(Dialog):
         Both flows are automatically supported by the `OAuthPrompt` and they only thing you need to be careful of
         is that you don't block the `event` and `invoke` activities that the prompt might be waiting on.
 
-    .. note::
-        You should avoid persisting the access token with your bots other state. The Bot Frameworks SSO service
-        will securely store the token on your behalf. If you store it in your bots state,
-        it could expire or be revoked in between turns.
-        When calling the prompt from within a waterfall step, you should use the token within the step
+        Notice the following:
+        - You should avoid persisting the access token with your bots other state. The Bot Frameworks SSO service
+        will securely store the token on your behalf. If you store it in your bots state, it could expire or
+        be revoked in between turns.
+        - When calling the prompt from within a waterfall step, you should use the token within the step
         following the prompt and then let the token go out of scope at the end of your function.
-
-        **Prompt Usage**
-        When used with your bots :class:`DialogSet`, you can simply add a new instance of the prompt as a named
-        dialog using
-        :meth`DialogSet.add()`.
-        You can then start the prompt from a waterfall step using either :meth:`DialogContext.begin()` or
+        - When used with your bots :class:`DialogSet`, you can simply add a new instance of the prompt as a named
+        dialog using :meth:`DialogSet.add()`.
+        - You can then start the prompt from a waterfall step using either :meth:`DialogContext.begin()` or
         :meth:`DialogContext.prompt()`.
-        The user will be prompted to sign in as needed and their access token will be passed as an argument to
+        - The user will be prompted to sign in as needed and their access token will be passed as an argument to
         the callers next waterfall step.
     """
 
@@ -81,7 +78,7 @@ class OAuthPrompt(Dialog):
         for this prompt
         :type validator: :class:`PromptValidatorContext`
 
-        .. note::
+        .. remarks::
             The value of :param dialogId: must be unique within the :class:`DialogSet`or :class:`ComponentDialog`
             to which the prompt is added.
         """
@@ -110,7 +107,7 @@ class OAuthPrompt(Dialog):
         :return: Dialog turn result
         :rtype: :class:DialogTurnResult
 
-        .. note::
+        .. remarks::
             If the task is successful, the result indicates whether the prompt is still active after the turn
             has been processed by the prompt.
         """
@@ -163,11 +160,11 @@ class OAuthPrompt(Dialog):
         :return: Dialog turn result
         :rtype: :class:DialogTurnResult
 
-        .. note::
-            If the task is successful, the result indicates whether the dialog is still
-            active after the turn has been processed by the dialog.
-            The prompt generally continues to receive the user's replies until it accepts the
-            user's reply as valid input for the prompt.
+        .. remarks::
+            If the task is successful, the result indicates whether the dialog is still active after
+            the turn has been processed by the dialog.
+            The prompt generally continues to receive the user's replies until it accepts the user's reply
+            as valid input for the prompt.
         """
         # Recognize token
         recognized = await self._recognize_token(dialog_context.context)
@@ -224,7 +221,7 @@ class OAuthPrompt(Dialog):
         :return: A response that includes the user's token
         :rtype: :class:TokenResponse
 
-        .. note::
+        .. remarks::
             If the task is successful and the user already has a token or the user successfully signs in,
             the result contains the user's token.
         """
@@ -249,7 +246,7 @@ class OAuthPrompt(Dialog):
         :return: A :class:`Task` representing the work queued to execute
         :rtype: :class:`Task`
 
-        .. note::
+        .. remarks::
             If the task is successful and the user already has a token or the user successfully signs in,
             the result contains the user's token.
         """

--- a/libraries/botbuilder-dialogs/botbuilder/dialogs/prompts/oauth_prompt.py
+++ b/libraries/botbuilder-dialogs/botbuilder/dialogs/prompts/oauth_prompt.py
@@ -48,16 +48,19 @@ class OAuthPrompt(Dialog):
         is that you don't block the `event` and `invoke` activities that the prompt might be waiting on.
 
         Notice the following:
-        - You should avoid persisting the access token with your bots other state. The Bot Frameworks SSO service
-        will securely store the token on your behalf. If you store it in your bots state, it could expire or
-        be revoked in between turns.
-        - When calling the prompt from within a waterfall step, you should use the token within the step
+
+        You should avoid persisting the access token with your bots other state. The Bot Frameworks SSO service
+        will securely store the token on your behalf. If you store it in your bots state,
+        it could expire or be revoked in between turns.
+        When calling the prompt from within a waterfall step, you should use the token within the step
         following the prompt and then let the token go out of scope at the end of your function.
-        - When used with your bots :class:`DialogSet`, you can simply add a new instance of the prompt as a named
-        dialog using :meth:`DialogSet.add()`.
-        - You can then start the prompt from a waterfall step using either :meth:`DialogContext.begin()` or
+
+        When used with your bots :class:`DialogSet`, you can simply add a new instance of the prompt as a named
+        dialog using
+        :meth`DialogSet.add()`.
+        You can then start the prompt from a waterfall step using either :meth:`DialogContext.begin()` or
         :meth:`DialogContext.prompt()`.
-        - The user will be prompted to sign in as needed and their access token will be passed as an argument to
+        The user will be prompted to sign in as needed and their access token will be passed as an argument to
         the callers next waterfall step.
     """
 
@@ -161,10 +164,10 @@ class OAuthPrompt(Dialog):
         :rtype: :class:DialogTurnResult
 
         .. remarks::
-            If the task is successful, the result indicates whether the dialog is still active after
-            the turn has been processed by the dialog.
-            The prompt generally continues to receive the user's replies until it accepts the user's reply
-            as valid input for the prompt.
+            If the task is successful, the result indicates whether the dialog is still
+            active after the turn has been processed by the dialog.
+            The prompt generally continues to receive the user's replies until it accepts the
+            user's reply as valid input for the prompt.
         """
         # Recognize token
         recognized = await self._recognize_token(dialog_context.context)
@@ -242,7 +245,7 @@ class OAuthPrompt(Dialog):
         Signs out the user
 
         :param context: Context for the current turn of conversation with the user
-        :type context:  :class:`TurnContext`
+        :type context:  :class:`botbuilder.core.TurnContext`
         :return: A :class:`Task` representing the work queued to execute
         :rtype: :class:`Task`
 

--- a/libraries/botbuilder-dialogs/botbuilder/dialogs/prompts/prompt.py
+++ b/libraries/botbuilder-dialogs/botbuilder/dialogs/prompts/prompt.py
@@ -69,8 +69,7 @@ class Prompt(Dialog):
         :rtype: :class:`DialogTurnResult`
 
         .. note::
-            If the task is successful, the result indicates whether the prompt is still active
-            after the turn has been processed by the prompt.
+            If the task is successful, the result indicates whether the prompt is still active after the turn has been processed by the prompt.
         """
         if not dialog_context:
             raise TypeError("Prompt(): dc cannot be None.")
@@ -108,10 +107,8 @@ class Prompt(Dialog):
         :rtype: :class:`DialogTurnResult`
 
         .. note::
-            If the task is successful, the result indicates whether the dialog is still
-            active after the turn has been processed by the dialog.
-            The prompt generally continues to receive the user's replies until it accepts the
-            user's reply as valid input for the prompt.
+            If the task is successful, the result indicates whether the dialog is still active after the turn has been processed by the dialog.
+            The prompt generally continues to receive the user's replies until it accepts the user's reply as valid input for the prompt.
         """
         if not dialog_context:
             raise TypeError("Prompt(): dc cannot be None.")
@@ -167,8 +164,8 @@ class Prompt(Dialog):
         .. note::
             If the task is successful, the result indicates whether the dialog is still active after the turn has been processed by the dialog.
             Prompts are typically leaf nodes on the stack but the dev is free to push other dialogs on top of the stack which will result in
-            the prompt receiving an unexpected call to :meth:resume_dialog() when the pushed on dialog ends.
-            To avoid the prompt prematurely ending we need to simply re-prompt the user.
+            the prompt receiving an unexpected call to :meth:resume_dialog() when the pushed on dialog ends. To avoid the prompt ending prematurely
+            you need to simply re-prompt the user.
         """
         await self.reprompt_dialog(dialog_context.context, dialog_context.active_dialog)
         return Dialog.end_of_turn

--- a/libraries/botbuilder-dialogs/botbuilder/dialogs/prompts/prompt.py
+++ b/libraries/botbuilder-dialogs/botbuilder/dialogs/prompts/prompt.py
@@ -24,16 +24,16 @@ from ..dialog_context import DialogContext
 
 class Prompt(Dialog):
     """
-    Defines the core behavior of prompt dialogs. Extends the :class:`Dialog` base class.
+    Defines the core behavior of prompt dialogs.
 
     .. remarks::
         When the prompt ends, it returns an object that represents the value it was prompted for.
         Use :meth:`DialogSet.add()` or :meth:`ComponentDialog.add_dialog()` to add a prompt to a dialog set or
         component dialog, respectively.
         Use :meth:`DialogContext.prompt()` or :meth:`DialogContext.begin_dialog()` to start the prompt.
-        .. note::
-            If you start a prompt from a :class:`WaterfallStep` in a :class:`WaterfallDialog`, then the prompt result
-            will be available in the next step of the waterfall.
+
+        If you start a prompt from a :class:`WaterfallStep` in a :class:`WaterfallDialog`, then the prompt result
+         will be available in the next step of the waterfall.
     """
 
     ATTEMPT_COUNT_KEY = "AttemptCount"
@@ -165,11 +165,9 @@ class Prompt(Dialog):
         :rtype: :class:`DialogTurnResult`
 
         .. note::
-            If the task is successful, the result indicates whether the dialog is still
-            active after the turn has been processed by the dialog.
-            Prompts are typically leaf nodes on the stack but the dev is free to push other dialogs
-            on top of the stack which will result in the prompt receiving an unexpected call to
-            :meth:resume_dialog() when the pushed on dialog ends.
+            If the task is successful, the result indicates whether the dialog is still active after the turn has been processed by the dialog.
+            Prompts are typically leaf nodes on the stack but the dev is free to push other dialogs on top of the stack which will result in
+            the prompt receiving an unexpected call to :meth:resume_dialog() when the pushed on dialog ends.
             To avoid the prompt prematurely ending we need to simply re-prompt the user.
         """
         await self.reprompt_dialog(dialog_context.context, dialog_context.active_dialog)
@@ -249,7 +247,7 @@ class Prompt(Dialog):
         """
         Composes an output activity containing a set of choices.
         When overridden in a derived class, appends choices to the activity when the user is prompted for input.
-        Helper function to compose an output activity containing a set of choices.
+        This is an helper function to compose an output activity containing a set of choices.
 
         :param prompt: The prompt to append the user's choice to
         :type prompt:

--- a/libraries/botbuilder-dialogs/botbuilder/dialogs/prompts/prompt.py
+++ b/libraries/botbuilder-dialogs/botbuilder/dialogs/prompts/prompt.py
@@ -69,7 +69,8 @@ class Prompt(Dialog):
         :rtype: :class:`DialogTurnResult`
 
         .. note::
-            If the task is successful, the result indicates whether the prompt is still active after the turn has been processed by the prompt.
+            If the task is successful, the result indicates whether the prompt is still active after
+            the turn has been processed by the prompt.
         """
         if not dialog_context:
             raise TypeError("Prompt(): dc cannot be None.")
@@ -107,8 +108,9 @@ class Prompt(Dialog):
         :rtype: :class:`DialogTurnResult`
 
         .. note::
-            If the task is successful, the result indicates whether the dialog is still active after the turn has been processed by the dialog.
-            The prompt generally continues to receive the user's replies until it accepts the user's reply as valid input for the prompt.
+            If the task is successful, the result indicates whether the dialog is still active after
+            the turn has been processed by the dialog. The prompt generally continues to receive the
+            user's replies until it accepts the user's reply as valid input for the prompt.
         """
         if not dialog_context:
             raise TypeError("Prompt(): dc cannot be None.")
@@ -162,10 +164,12 @@ class Prompt(Dialog):
         :rtype: :class:`DialogTurnResult`
 
         .. note::
-            If the task is successful, the result indicates whether the dialog is still active after the turn has been processed by the dialog.
-            Prompts are typically leaf nodes on the stack but the dev is free to push other dialogs on top of the stack which will result in
-            the prompt receiving an unexpected call to :meth:resume_dialog() when the pushed on dialog ends. To avoid the prompt ending prematurely
-            you need to simply re-prompt the user.
+            If the task is successful, the result indicates whether the dialog is still active after
+            the turn has been processed by the dialog.
+            Prompts are typically leaf nodes on the stack but the dev is free to push other dialogs
+            on top of the stack which will result in
+            the prompt receiving an unexpected call to :meth:resume_dialog() when the pushed on dialog ends.
+            To avoid the prompt ending prematurely you need to simply re-prompt the user.
         """
         await self.reprompt_dialog(dialog_context.context, dialog_context.active_dialog)
         return Dialog.end_of_turn


### PR DESCRIPTION
Fixing ref docs issues from preview site: 

- [X] bot_state.py -  Added missing comments to the `BotStatePropertyAccessor` class; and to a couple of methods. Fixed typos. 
- [X] conversation_state.py - Fixed comments in `ConversationState class`. 
- [X] prompt.py - Deleted note in the class remarks section; reformatted notes content.
- [X] oauth_promp.py - Changed notes to remarks. 
- [X] activity_handler.py - Changed notes to remarks. 
