### PR TITLE
mm-api-ref-docs-fixes-wip

### DIFF
--- a/libraries/botbuilder-core/botbuilder/core/activity_handler.py
+++ b/libraries/botbuilder-core/botbuilder/core/activity_handler.py
@@ -13,7 +13,7 @@ class ActivityHandler:
         in order to process an inbound :class:`botbuilder.schema.Activity`.
 
         :param turn_context: The context object for this turn
-        :type turn_context: :class:`TurnContext`
+        :type turn_context: :class:`botbuilder.core.TurnContext`
 
         :returns: A task that represents the work queued to execute
 
@@ -21,12 +21,9 @@ class ActivityHandler:
             It calls other methods in this class based on the type of the activity to
             process, which allows a derived class to provide type-specific logic in a controlled way.
             In a derived class, override this method to add logic that applies to all activity types.
-
-            .. note::
-                - Add logic to apply before the type-specific logic and before the call to the
-                  :meth:`ActivityHandler.on_turn()` method.
-                - Add logic to apply after the type-specific logic after the call to the
-                  :meth:`ActivityHandler.on_turn()` method.
+            Also
+            - Add logic to apply before the type-specific logic and before calling :meth:`ActivityHandler.on_turn()`.
+            - Add logic to apply after the type-specific logic after calling :meth:`ActivityHandler.on_turn()`.
         """
         if turn_context is None:
             raise TypeError("ActivityHandler.on_turn(): turn_context cannot be None.")
@@ -65,10 +62,9 @@ class ActivityHandler:
         such as the conversational logic.
 
         :param turn_context: The context object for this turn
-        :type turn_context: :class:`TurnContext`
+        :type turn_context: :class:`botbuilder.core.TurnContext`
 
         :returns: A task that represents the work queued to execute
-
         """
         return
 
@@ -78,11 +74,11 @@ class ActivityHandler:
         :meth:`ActivityHandler.on_turn()` is used.
 
         :param turn_context: The context object for this turn
-        :type turn_context: :class:`TurnContext`
+        :type turn_context: :class:`botbuilder.core.TurnContext`
 
         :returns: A task that represents the work queued to execute
 
-        .. note::
+        .. remarks::
             When the :meth:'ActivityHandler.on_turn()` method receives a conversation update activity, it calls this
             method.
             If the conversation update activity indicates that members other than the bot joined the conversation,
@@ -119,11 +115,11 @@ class ActivityHandler:
         conversation update activity
         :type members_added: :class:`typing.List`
         :param turn_context: The context object for this turn
-        :type turn_context: :class:`TurnContext`
+        :type turn_context: :class:`botbuilder.core.TurnContext`
 
         :returns: A task that represents the work queued to execute
 
-        .. note::
+        .. remarks::
             When the :meth:'ActivityHandler.on_conversation_update_activity()` method receives a conversation
             update activity that indicates
             one or more users other than the bot are joining the conversation, it calls this method.
@@ -141,11 +137,11 @@ class ActivityHandler:
         conversation update activity
         :type members_added: :class:`typing.List`
         :param turn_context: The context object for this turn
-        :type turn_context: :class:`TurnContext`
+        :type turn_context: :class:`botbuilder.core.TurnContext`
 
         :returns: A task that represents the work queued to execute
 
-        .. note::
+        .. remarks::
             When the :meth:'ActivityHandler.on_conversation_update_activity()` method receives a conversation
             update activity that indicates one or more users other than the bot are leaving the conversation,
             it calls this method.
@@ -159,11 +155,11 @@ class ActivityHandler:
         :meth:'ActivityHandler.on_turn()` is used.
 
         :param turn_context: The context object for this turn
-        :type turn_context: :class:`TurnContext`
+        :type turn_context: :class:`botbuilder.core.TurnContext`
 
         :returns: A task that represents the work queued to execute
 
-        .. note::
+        .. remarks::
             Message reactions correspond to the user adding a 'like' or 'sad' etc. (often an emoji) to a previously
             sent activity.
             Message reactions are only supported by a few channels. The activity that the message reaction corresponds
@@ -200,11 +196,11 @@ class ActivityHandler:
         :param message_reactions: The list of reactions added
         :type message_reactions: :class:`typing.List`
         :param turn_context: The context object for this turn
-        :type turn_context: :class:`TurnContext`
+        :type turn_context: :class:`botbuilder.core.TurnContext`
 
         :returns: A task that represents the work queued to execute
 
-        .. note::
+        .. remarks::
             Message reactions correspond to the user adding a 'like' or 'sad' etc. (often an emoji)
             to a previously sent message on the conversation. Message reactions are supported by only a few channels.
             The activity that the message is in reaction to is identified by the activity's reply to Id property.
@@ -223,11 +219,11 @@ class ActivityHandler:
         :param message_reactions: The list of reactions removed
         :type message_reactions: :class:`typing.List`
         :param turn_context: The context object for this turn
-        :type turn_context: :class:`TurnContext`
+        :type turn_context: :class:`botbuilder.core.TurnContext`
 
         :returns: A task that represents the work queued to execute
 
-        .. note::
+        .. remarks::
             Message reactions correspond to the user adding a 'like' or 'sad' etc. (often an emoji)
             to a previously sent message on the conversation. Message reactions are supported by only a few channels.
             The activity that the message is in reaction to is identified by the activity's reply to Id property.
@@ -242,11 +238,11 @@ class ActivityHandler:
         :meth:'ActivityHandler.on_turn()` is used.
 
         :param turn_context: The context object for this turn
-        :type turn_context: :class:`TurnContext`
+        :type turn_context: :class:`botbuilder.core.TurnContext`
 
         :returns: A task that represents the work queued to execute
 
-        .. note::
+        .. remarks::
             When the :meth:'ActivityHandler.on_turn()` method receives an event activity, it calls this method.
             If the activity name is `tokens/response`, it calls :meth:'ActivityHandler.on_token_response_event()`;
             otherwise, it calls :meth:'ActivityHandler.on_event()`.
@@ -273,11 +269,11 @@ class ActivityHandler:
         If using an `oauth_prompt`, override this method to forward this activity to the current dialog.
 
         :param turn_context: The context object for this turn
-        :type turn_context: :class:`TurnContext`
+        :type turn_context: :class:`botbuilder.core.TurnContext`
 
         :returns: A task that represents the work queued to execute
 
-        .. note::
+        .. remarks::
             When the :meth:'ActivityHandler.on_event()` method receives an event with an activity name of
             `tokens/response`, it calls this method. If your bot uses an `oauth_prompt`, forward the incoming
             activity to the current dialog.
@@ -293,11 +289,11 @@ class ActivityHandler:
 
 
         :param turn_context: The context object for this turn
-        :type turn_context: :class:`TurnContext`
+        :type turn_context: :class:`botbuilder.core.TurnContext`
 
         :returns: A task that represents the work queued to execute
 
-        .. note::
+        .. remarks::
             When the :meth:'ActivityHandler.on_event_activity()` is used method receives an event with an
             activity name other than `tokens/response`, it calls this method.
             This method could optionally be overridden if the bot is meant to handle miscellaneous events.
@@ -311,7 +307,7 @@ class ActivityHandler:
         Invoked when a conversation end activity is received from the channel.
 
         :param turn_context: The context object for this turn
-        :type turn_context: :class:`TurnContext`
+        :type turn_context: :class:`botbuilder.core.TurnContext`
         :returns: A task that represents the work queued to execute
         """
         return
@@ -325,11 +321,11 @@ class ActivityHandler:
         If overridden, this method could potentially respond to any of the other activity types.
 
         :param turn_context: The context object for this turn
-        :type turn_context: :class:`TurnContext`
+        :type turn_context: :class:`botbuilder.core.TurnContext`
 
         :returns: A task that represents the work queued to execute
 
-        .. note::
+        .. remarks::
             When the :meth:`ActivityHandler.on_turn()` method receives an activity that is not a message,
             conversation update, message reaction, or event activity, it calls this method.
         """

--- a/libraries/botbuilder-core/botbuilder/core/bot_framework_adapter.py
+++ b/libraries/botbuilder-core/botbuilder/core/bot_framework_adapter.py
@@ -87,11 +87,9 @@ class BotFrameworkAdapterSettings:
         """
         Contains the settings used to initialize a :class:`BotFrameworkAdapter` instance.
 
-        :param app_id: The bot application ID. This is the appId returned by the Azure portal registration, and is
-        the value of the `MicrosoftAppId` parameter in the `config.py` file.
+        :param app_id: The bot application ID.
         :type app_id: str
-        :param app_password: The bot application password. This is the password returned by the Azure portal
-        registration, and is
+        :param app_password: The bot application password.
         the value os the `MicrosoftAppPassword` parameter in the `config.py` file.
         :type app_password: str
         :param channel_auth_tenant: The channel tenant to use in conversation
@@ -201,7 +199,7 @@ class BotFrameworkAdapter(BotAdapter, UserTokenProvider):
 
         :return: A task that represents the work queued to execute.
 
-        .. note::
+        .. remarks::
             This is often referred to as the bots *proactive messaging* flow as it lets the bot proactively
             send messages to a conversation or user that are already in a communication.
             Scenarios such as sending notifications or coupons to a user are enabled by this function.
@@ -247,7 +245,7 @@ class BotFrameworkAdapter(BotAdapter, UserTokenProvider):
 
         :return: A task representing the work queued to execute.
 
-        .. note::
+        .. remarks::
             To start a conversation, your bot must know its account information and the user's
             account information on that channel.
             Most channels only support initiating a direct message (non-group) conversation.
@@ -306,9 +304,7 @@ class BotFrameworkAdapter(BotAdapter, UserTokenProvider):
 
     async def process_activity(self, req, auth_header: str, logic: Callable):
         """
-        Creates a turn context and runs the middleware pipeline for an incoming activity,
-        Processes an activity received by the bots web server. This includes any messages sent from a
-        user and is the method that drives what's often referred to as the bots *reactive messaging* flow.
+        Creates a turn context and runs the middleware pipeline for an incoming activity.
 
         :param req: The incoming activity
         :type req: :class:`typing.str`
@@ -317,15 +313,15 @@ class BotFrameworkAdapter(BotAdapter, UserTokenProvider):
         :param logic: The logic to execute at the end of the adapter's middleware pipeline.
         :type logic: :class:`typing.Callable`
 
-        :return: A task that represents the work queued to execute. If the activity type
-        was `Invoke` and the corresponding key (`channelId` + `activityId`) was found then
-        an :class:`InvokeResponse` is returned; otherwise, `null` is returned.
+        :return: A task that represents the work queued to execute.
 
-        .. note::
+        .. remarks::
+            This class processes an activity received by the bots web server. This includes any messages
+            sent from a user and is the method that drives what's often referred to as the
+            bots *reactive messaging* flow.
             Call this method to reactively send a message to a conversation.
             If the task completes successfully, then an :class:`InvokeResponse` is returned;
             otherwise. `null` is returned.
-
         """
         activity = await self.parse_request(req)
         auth_header = auth_header or ""
@@ -457,7 +453,7 @@ class BotFrameworkAdapter(BotAdapter, UserTokenProvider):
 
         :return: A task that represents the work queued to execute
 
-        .. note::
+        .. remarks::
             If the activity is successfully sent, the task result contains
             a :class:`botbuilder.schema.ResourceResponse` object containing the ID that
             the receiving channel assigned to the activity.
@@ -490,6 +486,7 @@ class BotFrameworkAdapter(BotAdapter, UserTokenProvider):
         :return: A task that represents the work queued to execute
 
         .. note::
+
             The activity_id of the :class:`botbuilder.schema.ConversationReference` identifies the activity to delete.
         """
         try:
@@ -565,7 +562,7 @@ class BotFrameworkAdapter(BotAdapter, UserTokenProvider):
         Deletes a member from the current conversation.
 
         :param context: The context object for the turn
-        :type context: :class:`TurnContext`
+        :type context: :class:`botbuilder.core.TurnContext`
         :param member_id: The ID of the member to remove from the conversation
         :type member_id: str
 
@@ -603,7 +600,7 @@ class BotFrameworkAdapter(BotAdapter, UserTokenProvider):
         Lists the members of a given activity.
 
         :param context: The context object for the turn
-        :type context: :class:`TurnContext`
+        :type context: :class:`botbuilder.core.TurnContext`
         :param activity_id: (Optional) Activity ID to enumerate.
         If not specified the current activities ID will be used.
 
@@ -645,7 +642,7 @@ class BotFrameworkAdapter(BotAdapter, UserTokenProvider):
         Lists the members of a current conversation.
 
         :param context: The context object for the turn
-        :type context: :class:`TurnContext`
+        :type context: :class:`botbuilder.core.TurnContext`
 
         :raises: An exception error
 
@@ -674,9 +671,7 @@ class BotFrameworkAdapter(BotAdapter, UserTokenProvider):
 
     async def get_conversations(self, service_url: str, continuation_token: str = None):
         """
-        Lists the Conversations in which this bot has participated for a given channel server. The channel server
-        returns results in pages and each page will include a `continuationToken` that can be used to fetch the next
-        page of results from the server.
+        Lists the Conversations in which this bot has participated for a given channel server.
 
         :param service_url: The URL of the channel server to query. This can be retrieved from
         `context.activity.serviceUrl`
@@ -689,8 +684,10 @@ class BotFrameworkAdapter(BotAdapter, UserTokenProvider):
 
         :return: A task that represents the work queued to execute
 
-        .. note:: If the task completes successfully, the result contains a page of the members of the current
-        conversation.
+        .. remarks::
+        The channel server returns results in pages and each page will include a `continuationToken` that
+        can be used to fetch the next page of results from the server.
+        If the task completes successfully, the result contains a page of the members of the current conversation.
         This overload may be called from outside the context of a conversation, as only the bot's service URL and
         credentials are required.
         """
@@ -705,7 +702,7 @@ class BotFrameworkAdapter(BotAdapter, UserTokenProvider):
         Attempts to retrieve the token for a user that's in a login flow.
 
         :param context: Context for the current turn of conversation with the user
-        :type context: :class:`TurnContext`
+        :type context: :class:`botbuilder.core.TurnContext`
         :param connection_name: Name of the auth connection to use
         :type connection_name: str
         :param magic_code" (Optional) user entered code to validate
@@ -752,7 +749,7 @@ class BotFrameworkAdapter(BotAdapter, UserTokenProvider):
         Signs the user out with the token server.
 
         :param context: Context for the current turn of conversation with the user
-        :type context: :class:`TurnContext`
+        :type context: :class:`botbuilder.core.TurnContext`
         :param connection_name: Name of the auth connection to use
         :type connection_name: str
         :param user_id: User id of user to sign out
@@ -781,13 +778,14 @@ class BotFrameworkAdapter(BotAdapter, UserTokenProvider):
         Gets the raw sign-in link to be sent to the user for sign-in for a connection name.
 
         :param context: Context for the current turn of conversation with the user
-        :type context: :class:`TurnContext`
+        :type context: :class:`botbuilder.core.TurnContext`
         :param connection_name: Name of the auth connection to use
         :type connection_name: str
 
         :returns: A task that represents the work queued to execute
 
         .. note::
+
             If the task completes successfully, the result contains the raw sign-in link
         """
         self.check_emulating_oauth_cards(context)
@@ -814,7 +812,7 @@ class BotFrameworkAdapter(BotAdapter, UserTokenProvider):
         Retrieves the token status for each configured connection for the given user.
 
         :param context: Context for the current turn of conversation with the user
-        :type context: :class:`TurnContext`
+        :type context: :class:`botbuilder.core.TurnContext`
         :param user_id: The user Id for which token status is retrieved
         :type user_id: str
         :param include_filter: (Optional) Comma separated list of connection's to include.
@@ -848,14 +846,11 @@ class BotFrameworkAdapter(BotAdapter, UserTokenProvider):
         Retrieves Azure Active Directory tokens for particular resources on a configured connection.
 
         :param context: Context for the current turn of conversation with the user
-        :type context: :class:`TurnContext`
-
+        :type context: :class:`botbuilder.core.TurnContext`
         :param connection_name: The name of the Azure Active Directory connection configured with this bot
         :type connection_name: str
-
         :param resource_urls: The list of resource URLs to retrieve tokens for
         :type resource_urls: :class:`typing.List`
-
         :returns: Dictionary of resource Urls to the corresponding :class:'botbuilder.schema.TokenResponse`
         :rtype: :class:`typing.Dict`
         """

--- a/libraries/botbuilder-core/botbuilder/core/bot_state.py
+++ b/libraries/botbuilder-core/botbuilder/core/bot_state.py
@@ -50,7 +50,7 @@ class BotState(PropertyManager):
         :param context_service_key: The key for the state cache for this :class:`BotState`
         :type context_service_key: str
 
-        .. note::
+        .. remarks::
             This constructor creates a state management object and associated scope. The object uses
             the :param storage: to persist state property values and the :param context_service_key: to cache state
             within the context for each turn.
@@ -84,7 +84,7 @@ class BotState(PropertyManager):
         Reads the current state object and caches it in the context object for this turn.
 
         :param turn_context: The context object for this turn
-        :type turn_context: :class:`TurnContext`
+        :type turn_context: :class:`botbuilder.core.TurnContext`
         :param force: Optional, true to bypass the cache
         :type force: bool
         """
@@ -107,7 +107,7 @@ class BotState(PropertyManager):
         If the state has changed, it saves the state cached in the current context for this turn.
 
         :param turn_context: The context object for this turn
-        :type turn_context: :class:`TurnContext`
+        :type turn_context: :class:`botbuilder.core.TurnContext`
         :param force: Optional, true to save state to storage whether or not there are changes
         :type force: bool
         """
@@ -127,11 +127,11 @@ class BotState(PropertyManager):
         Clears any state currently stored in this state scope.
 
         :param turn_context: The context object for this turn
-        :type turn_context: :class:`TurnContext`
+        :type turn_context: :class:`botbuilder.core.TurnContext`
 
         :return: None
 
-        .. note::
+        .. remarks::
             This function must be called in order for the cleared state to be persisted to the underlying store.
         """
         if turn_context is None:
@@ -147,7 +147,7 @@ class BotState(PropertyManager):
         Deletes any state currently stored in this state scope.
 
         :param turn_context: The context object for this turn
-        :type turn_context: :class:`TurnContext`
+        :type turn_context: :class:`botbuilder.core.TurnContext`
 
         :return: None
         """
@@ -168,7 +168,7 @@ class BotState(PropertyManager):
         Gets the value of the specified property in the turn context.
 
         :param turn_context: The context object for this turn
-        :type turn_context: :class:`TurnContext`
+        :type turn_context: :class:`botbuilder.core.TurnContext`
         :param property_name: The property name
         :type property_name: str
 
@@ -195,7 +195,7 @@ class BotState(PropertyManager):
         Deletes a property from the state cache in the turn context.
 
         :param turn_context: The context object for this turn
-        :type turn_context: :class:`TurnContext`
+        :type turn_context: :class:`botbuilder.core.TurnContext`
         :param property_name: The name of the property to delete
         :type property_name: str
 
@@ -215,7 +215,7 @@ class BotState(PropertyManager):
         Sets a property to the specified value in the turn context.
 
         :param turn_context: The context object for this turn
-        :type turn_context: :class:`TurnContext`
+        :type turn_context: :class:`botbuilder.core.TurnContext`
         :param property_name: The property name
         :type property_name: str
         :param value: The value to assign to the property

--- a/libraries/botbuilder-core/botbuilder/core/bot_state.py
+++ b/libraries/botbuilder-core/botbuilder/core/bot_state.py
@@ -231,17 +231,41 @@ class BotState(PropertyManager):
         cached_state.state[property_name] = value
 
 
-##
 class BotStatePropertyAccessor(StatePropertyAccessor):
+    """
+    Defines methods for accessing a state property created in a :class:`BotState` object.
+    """
+
     def __init__(self, bot_state: BotState, name: str):
+        """
+        Initializes a new instance of the :class:`BotStatePropertyAccessor` class.
+
+        :param bot_state: The state object to access
+        :type bot_state:  :class:`BotState`
+        :param name: The name of the state property to access
+        :type name: str
+
+        """
         self._bot_state = bot_state
         self._name = name
 
     @property
     def name(self) -> str:
+        """
+        Gets the name of the property.
+
+        :return: The name of the property
+        :rtype: str
+        """
         return self._name
 
     async def delete(self, turn_context: TurnContext) -> None:
+        """
+        Deletes the property.
+
+        :param turn_context: The context object for this turn
+        :type turn_context: :class:`botbuilder.core.TurnContext`
+        """
         await self._bot_state.load(turn_context, False)
         await self._bot_state.delete_property_value(turn_context, self._name)
 
@@ -250,6 +274,14 @@ class BotStatePropertyAccessor(StatePropertyAccessor):
         turn_context: TurnContext,
         default_value_or_factory: Union[Callable, object] = None,
     ) -> object:
+        """
+        Gets the property value.
+
+        :param turn_context: The context object for this turn
+        :type turn_context: :class:`botbuilder.core.TurnContext`
+        :param default_value_or_factory: Defines the default value when no value is set for the property
+        :type default_value_or_factory: :typing:Union
+        """
         await self._bot_state.load(turn_context, False)
         try:
             result = await self._bot_state.get_property_value(turn_context, self._name)
@@ -268,5 +300,14 @@ class BotStatePropertyAccessor(StatePropertyAccessor):
             return result
 
     async def set(self, turn_context: TurnContext, value: object) -> None:
+        """
+        Sets the property value.
+
+        :param turn_context: The context object for this turn
+        :type turn_context: :class:`botbuilder.core.TurnContext`
+
+        :param value: The value to assign to the property
+        :type value: :typing:`Object`
+        """
         await self._bot_state.load(turn_context, False)
         await self._bot_state.set_property_value(turn_context, self._name, value)

--- a/libraries/botbuilder-core/botbuilder/core/conversation_state.py
+++ b/libraries/botbuilder-core/botbuilder/core/conversation_state.py
@@ -9,7 +9,6 @@ from .storage import Storage
 class ConversationState(BotState):
     """
     Defines a state management object for conversation state.
-    Extends :class:`BootState` base class.
 
     .. remarks::
         Conversation state is available in any turn in a specific conversation, regardless of the user, such as
@@ -33,7 +32,7 @@ class ConversationState(BotState):
         Gets the key to use when reading and writing state to and from storage.
 
         :param turn_context: The context object for this turn.
-        :type turn_context: :class:`TurnContext`
+        :type turn_context: :class:`botbuilder.core.TurnContext`
 
         :raise: :class:`TypeError` if the :meth:`TurnContext.activity` for the current turn is missing
         :class:`botbuilder.schema.Activity` channelId or conversation information or the conversation's

--- a/libraries/botbuilder-dialogs/botbuilder/dialogs/prompts/oauth_prompt.py
+++ b/libraries/botbuilder-dialogs/botbuilder/dialogs/prompts/oauth_prompt.py
@@ -47,17 +47,14 @@ class OAuthPrompt(Dialog):
         Both flows are automatically supported by the `OAuthPrompt` and they only thing you need to be careful of
         is that you don't block the `event` and `invoke` activities that the prompt might be waiting on.
 
-    .. note::
         You should avoid persisting the access token with your bots other state. The Bot Frameworks SSO service
         will securely store the token on your behalf. If you store it in your bots state,
         it could expire or be revoked in between turns.
         When calling the prompt from within a waterfall step, you should use the token within the step
         following the prompt and then let the token go out of scope at the end of your function.
 
-        **Prompt Usage**
         When used with your bots :class:`DialogSet`, you can simply add a new instance of the prompt as a named
-        dialog using
-        :meth`DialogSet.add()`.
+        dialog using :meth`DialogSet.add()`.
         You can then start the prompt from a waterfall step using either :meth:`DialogContext.begin()` or
         :meth:`DialogContext.prompt()`.
         The user will be prompted to sign in as needed and their access token will be passed as an argument to
@@ -112,7 +109,7 @@ class OAuthPrompt(Dialog):
 
         .. note::
             If the task is successful, the result indicates whether the prompt is still active after the turn
-            has been processed by the prompt.
+            has been processed.
         """
         if dialog_context is None:
             raise TypeError(
@@ -163,7 +160,7 @@ class OAuthPrompt(Dialog):
         :return: Dialog turn result
         :rtype: :class:DialogTurnResult
 
-        .. note::
+        .. remarks::
             If the task is successful, the result indicates whether the dialog is still
             active after the turn has been processed by the dialog.
             The prompt generally continues to receive the user's replies until it accepts the
@@ -245,7 +242,7 @@ class OAuthPrompt(Dialog):
         Signs out the user
 
         :param context: Context for the current turn of conversation with the user
-        :type context:  :class:`TurnContext`
+        :type context:  :class:`botbuilder.core.TurnContext`
         :return: A :class:`Task` representing the work queued to execute
         :rtype: :class:`Task`
 

--- a/libraries/botbuilder-dialogs/botbuilder/dialogs/prompts/prompt.py
+++ b/libraries/botbuilder-dialogs/botbuilder/dialogs/prompts/prompt.py
@@ -31,9 +31,8 @@ class Prompt(Dialog):
         Use :meth:`DialogSet.add()` or :meth:`ComponentDialog.add_dialog()` to add a prompt to a dialog set or
         component dialog, respectively.
         Use :meth:`DialogContext.prompt()` or :meth:`DialogContext.begin_dialog()` to start the prompt.
-        .. note::
-            If you start a prompt from a :class:`WaterfallStep` in a :class:`WaterfallDialog`, then the prompt result
-            will be available in the next step of the waterfall.
+        If you start a prompt from a :class:`WaterfallStep` in a :class:`WaterfallDialog`, then the prompt result
+        will be available in the next step of the waterfall.
     """
 
     ATTEMPT_COUNT_KEY = "AttemptCount"
@@ -70,7 +69,7 @@ class Prompt(Dialog):
 
         .. note::
             If the task is successful, the result indicates whether the prompt is still active
-            after the turn has been processed by the prompt.
+            after the turn has been processed.
         """
         if not dialog_context:
             raise TypeError("Prompt(): dc cannot be None.")
@@ -107,7 +106,7 @@ class Prompt(Dialog):
         :return: The dialog turn result
         :rtype: :class:`DialogTurnResult`
 
-        .. note::
+        .. remarks::
             If the task is successful, the result indicates whether the dialog is still
             active after the turn has been processed by the dialog.
             The prompt generally continues to receive the user's replies until it accepts the
@@ -151,9 +150,7 @@ class Prompt(Dialog):
         self, dialog_context: DialogContext, reason: DialogReason, result: object
     ) -> DialogTurnResult:
         """
-        Resumes a dialog. Called when a prompt dialog resumes being the active dialog
-        on the dialog stack, such as when the previous active dialog on the stack completes.
-
+        Resumes a dialog. C
         :param dialog_context: The dialog context for the current turn of the conversation.
         :type dialog_context:  :class:DialogContext
         :param reason: An enum indicating why the dialog resumed.
@@ -164,7 +161,9 @@ class Prompt(Dialog):
         :return: The dialog turn result
         :rtype: :class:`DialogTurnResult`
 
-        .. note::
+        .. remarks::
+            Called when a prompt dialog resumes being the active dialog on the dialog stack,
+            such as when the previous active dialog on the stack completes.
             If the task is successful, the result indicates whether the dialog is still
             active after the turn has been processed by the dialog.
             Prompts are typically leaf nodes on the stack but the dev is free to push other dialogs
@@ -202,7 +201,7 @@ class Prompt(Dialog):
         Prompts user for input. When overridden in a derived class, prompts the user for input.
 
         :param turn_context: Context for the current turn of conversation with the user
-        :type turn_context:  :class:`TurnContext`
+        :type turn_context:  :class:`botbuilder.core.TurnContext`
         :param state: Contains state for the current instance of the prompt on the dialog stack
         :type state:  :class:Dict
         :param options: A prompt options object constructed from the options initially provided
@@ -227,14 +226,14 @@ class Prompt(Dialog):
         Recognizes the user's input. When overridden in a derived class, attempts to recognize the user's input.
 
         :param turn_context: Context for the current turn of conversation with the user
-        :type turn_context:  :class:`TurnContext`
+        :type turn_context:  :class:`botbuilder.core.TurnContext`
         :param state: Contains state for the current instance of the prompt on the dialog stack
         :type state:  :class:Dict
         :param options: A prompt options object constructed from the options initially provided
         in the call :meth:`DialogContext.prompt(self, dialog_id: str, options)`
         :type options:  :class:PromptOptions
 
-        :return: A :class:Task representing the asynchronous operation.
+        :return: A task representing the asynchronous operation.
         :rtype: :class:Task
         """
 
@@ -248,8 +247,6 @@ class Prompt(Dialog):
     ) -> Activity:
         """
         Composes an output activity containing a set of choices.
-        When overridden in a derived class, appends choices to the activity when the user is prompted for input.
-        Helper function to compose an output activity containing a set of choices.
 
         :param prompt: The prompt to append the user's choice to
         :type prompt:
@@ -264,8 +261,11 @@ class Prompt(Dialog):
         :return: A :class:Task representing the asynchronous operation
         :rtype: :class:Task
 
-        .. note::
+        .. remarks::
             If the task is successful, the result contains the updated activity.
+            When overridden in a derived class, appends choices to the activity when the user
+            is prompted for input. This is an helper function to compose an output activity
+            containing a set of choices.
         """
         # Get base prompt text (if any)
         text = prompt.text if prompt is not None and prompt.text else ""


### PR DESCRIPTION
Fixing ref docs issues from preview site: 
- [X] bot_state.py -  Added missing comments to the `BotStatePropertyAccessor` class; and to a couple of methods. Fixed typos. 
- [X] conversation_state.py - Fixed comments in `ConversationState class`. 
- [X] prompt.py - Deleted note in the class remarks section; reformatted notes content.
- [X] oauth_promp.py - Changed notes to remarks. 
- [X] activity_handler.py - Changed notes to remarks. 
