### PR TITLE
3.6 tests failing due to remove_mention_text

### DIFF
--- a/libraries/botbuilder-core/botbuilder/core/re_escape.py
+++ b/libraries/botbuilder-core/botbuilder/core/re_escape.py
@@ -1,0 +1,25 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+# SPECIAL_CHARS
+# closing ')', '}' and ']'
+# '-' (a range in character set)
+# '&', '~', (extended character set operations)
+# '#' (comment) and WHITESPACE (ignored) in verbose mode
+SPECIAL_CHARS_MAP = {i: "\\" + chr(i) for i in b"()[]{}?*+-|^$\\.&~# \t\n\r\v\f"}
+
+
+def escape(pattern):
+    """
+    Escape special characters in a string.
+
+    This is a copy of the re.escape function in Python 3.8.  This was done
+    because the 3.6.x version didn't escape in the same way and handling
+    bot names with regex characters in it would fail in TurnContext.remove_mention_text
+    without escaping the text.
+    """
+    if isinstance(pattern, str):
+        return pattern.translate(SPECIAL_CHARS_MAP)
+
+    pattern = str(pattern, "latin1")
+    return pattern.translate(SPECIAL_CHARS_MAP).encode("latin1")

--- a/libraries/botbuilder-core/botbuilder/core/turn_context.py
+++ b/libraries/botbuilder-core/botbuilder/core/turn_context.py
@@ -13,6 +13,7 @@ from botbuilder.schema import (
     Mention,
     ResourceResponse,
 )
+from .re_escape import escape
 
 
 class TurnContext:
@@ -362,7 +363,7 @@ class TurnContext:
             if mention.additional_properties["mentioned"]["id"] == identifier:
                 mention_name_match = re.match(
                     r"<at(.*)>(.*?)<\/at>",
-                    re.escape(mention.additional_properties["text"]),
+                    escape(mention.additional_properties["text"]),
                     re.IGNORECASE,
                 )
                 if mention_name_match:

--- a/libraries/botbuilder-core/tests/test_turn_context.py
+++ b/libraries/botbuilder-core/tests/test_turn_context.py
@@ -322,8 +322,8 @@ class TestBotContext(aiounittest.AsyncTestCase):
 
         text = TurnContext.remove_recipient_mention(activity)
 
-        assert text, " test activity"
-        assert activity.text, " test activity"
+        assert text == " test activity"
+        assert activity.text == " test activity"
 
     def test_should_remove_at_mention_with_regex_characters(self):
         activity = Activity(
@@ -343,8 +343,8 @@ class TestBotContext(aiounittest.AsyncTestCase):
 
         text = TurnContext.remove_recipient_mention(activity)
 
-        assert text, " test activity"
-        assert activity.text, " test activity"
+        assert text == " test activity"
+        assert activity.text == " test activity"
 
     async def test_should_send_a_trace_activity(self):
         context = TurnContext(SimpleAdapter(), ACTIVITY)


### PR DESCRIPTION
Fixes #743 

The 3.6 re.escape() doesn't work the same as in 3.7. and 3.8, which was causing remove_mention_text to fail.

Copied the 3.8 re.escape() function into botbuilder.

Also, the remove_mention_text assertions weren't correct.  They would never raise a failure.