### PR TITLE
chore: add issue autotagging

### DIFF
--- a/.github/ISSUE_TEMPLATE/workflows/main.yml
+++ b/.github/ISSUE_TEMPLATE/workflows/main.yml
@@ -1,0 +1,13 @@
+
+on: [issues]
+
+jobs:
+  on-issue-update:
+    runs-on: ubuntu-latest
+    name: Tag issues
+    steps:
+    - name: Issue tagging
+      id: issue-autotagger
+      uses: christopheranderson/issue-autotagger@v1
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
## What is it

Adds an auto tagging GH action that will tag issues opened by the [PORT] tool that Tom is running

## Changes

- Adds issue autotagging (similar to JS repo)