### PR TITLE
Teams tenantId correction

### DIFF
--- a/libraries/botbuilder-core/botbuilder/core/bot_framework_adapter.py
+++ b/libraries/botbuilder-core/botbuilder/core/bot_framework_adapter.py
@@ -351,7 +351,7 @@ class BotFrameworkAdapter(BotAdapter, ExtendedUserTokenProvider):
             if reference.conversation and reference.conversation.tenant_id:
                 # Putting tenant_id in channel_data is a temporary while we wait for the Teams API to be updated
                 parameters.channel_data = {
-                    "tenant": {"id": reference.conversation.tenant_id}
+                    "tenant": {"tenantId": reference.conversation.tenant_id}
                 }
 
                 # Permanent solution is to put tenant_id in parameters.tenant_id

--- a/libraries/botbuilder-core/tests/test_bot_framework_adapter.py
+++ b/libraries/botbuilder-core/tests/test_bot_framework_adapter.py
@@ -303,7 +303,7 @@ class TestBotFrameworkAdapter(aiounittest.AsyncTestCase):
                 "request has invalid tenant_id on conversation",
             )
             self.assertEqual(
-                context.activity.channel_data["tenant"]["id"],
+                context.activity.channel_data["tenant"]["tenantId"],
                 tenant_id,
                 "request has invalid tenant_id in channel_data",
             )


### PR DESCRIPTION
C# was using the property name "tenantId" for the Teams channel data.  Python was using "id".