### PR TITLE
 Fix interface and method names in the OAuth Prompt error messages

### DIFF
--- a/libraries/botbuilder-dialogs/botbuilder/dialogs/prompts/oauth_prompt.py
+++ b/libraries/botbuilder-dialogs/botbuilder/dialogs/prompts/oauth_prompt.py
@@ -450,7 +450,7 @@ class OAuthPrompt(Dialog):
                     self._get_token_exchange_invoke_response(
                         int(HTTPStatus.BAD_GATEWAY),
                         "The bot's BotAdapter does not support token exchange operations."
-                        " Ensure the bot's Adapter supports the ITokenExchangeProvider interface.",
+                        " Ensure the bot's Adapter supports the ExtendedUserTokenProvider interface.",
                     )
                 )
 

--- a/libraries/botbuilder-dialogs/botbuilder/dialogs/prompts/oauth_prompt.py
+++ b/libraries/botbuilder-dialogs/botbuilder/dialogs/prompts/oauth_prompt.py
@@ -124,7 +124,7 @@ class OAuthPrompt(Dialog):
         """
         if dialog_context is None:
             raise TypeError(
-                f"OAuthPrompt.begin_dialog: Expected DialogContext but got NoneType instead"
+                f"OAuthPrompt.begin_dialog(): Expected DialogContext but got NoneType instead"
             )
 
         options = options or PromptOptions()
@@ -149,7 +149,7 @@ class OAuthPrompt(Dialog):
 
         if not isinstance(dialog_context.context.adapter, UserTokenProvider):
             raise TypeError(
-                "OAuthPrompt.get_user_token(): not supported by the current adapter"
+                "OAuthPrompt.begin_dialog(): not supported by the current adapter"
             )
 
         output = await dialog_context.context.adapter.get_user_token(
@@ -357,7 +357,7 @@ class OAuthPrompt(Dialog):
             ):
                 if not hasattr(context.adapter, "get_oauth_sign_in_link"):
                     raise Exception(
-                        "OAuthPrompt.send_oauth_card(): get_oauth_sign_in_link() not supported by the current adapter"
+                        "OAuthPrompt._send_oauth_card(): get_oauth_sign_in_link() not supported by the current adapter"
                     )
 
                 link = await context.adapter.get_oauth_sign_in_link(
@@ -455,7 +455,7 @@ class OAuthPrompt(Dialog):
                 )
 
                 raise AttributeError(
-                    "OAuthPrompt.recognize(): not supported by the current adapter."
+                    "OAuthPrompt._recognize_token(): not supported by the current adapter."
                 )
             else:
                 # No errors. Proceed with token exchange.


### PR DESCRIPTION
 Fixes #897
### Description
Fix mismatched interface and method names in error messages

