### PR TITLE
Do NOT call TeamsInfo.get_member for the bot: cherry pick 4.9 fix (#1066)

### DIFF
--- a/libraries/botbuilder-core/botbuilder/core/teams/teams_activity_handler.py
+++ b/libraries/botbuilder-core/botbuilder/core/teams/teams_activity_handler.py
@@ -350,7 +350,11 @@ class TeamsActivityHandler(ActivityHandler):
 
         team_members_added = []
         for member in members_added:
-            if member.additional_properties != {}:
+            is_bot = (
+                turn_context.activity.recipient is not None
+                and member.id == turn_context.activity.recipient.id
+            )
+            if member.additional_properties != {} or is_bot:
                 team_members_added.append(
                     deserializer_helper(TeamsChannelAccount, member)
                 )

--- a/libraries/botbuilder-core/tests/teams/test_teams_activity_handler.py
+++ b/libraries/botbuilder-core/tests/teams/test_teams_activity_handler.py
@@ -385,6 +385,38 @@ class TestTeamsActivityHandler(aiounittest.AsyncTestCase):
         assert bot.record[0] == "on_conversation_update_activity"
         assert bot.record[1] == "on_teams_members_added"
 
+    async def test_bot_on_teams_members_added_activity(self):
+        # arrange
+        activity = Activity(
+            recipient=ChannelAccount(id="botid"),
+            type=ActivityTypes.conversation_update,
+            channel_data={
+                "eventType": "teamMemberAdded",
+                "team": {"id": "team_id_1", "name": "new_team_name"},
+            },
+            members_added=[
+                ChannelAccount(
+                    id="botid",
+                    name="test_user",
+                    aad_object_id="asdfqwerty",
+                    role="tester",
+                )
+            ],
+            channel_id=Channels.ms_teams,
+            conversation=ConversationAccount(id="456"),
+        )
+
+        turn_context = TurnContext(SimpleAdapter(), activity)
+
+        # Act
+        bot = TestingTeamsActivityHandler()
+        await bot.on_turn(turn_context)
+
+        # Assert
+        assert len(bot.record) == 2
+        assert bot.record[0] == "on_conversation_update_activity"
+        assert bot.record[1] == "on_teams_members_added"
+
     async def test_on_teams_members_removed_activity(self):
         # arrange
         activity = Activity(


### PR DESCRIPTION
Fixes #1065 
* Do not call TeamsInfo.get_member for the bot

* fix botid for test