### PR TITLE
Adding TeamsInfo to on_teams_member_removed

### DIFF
--- a/UsingTestPyPI.md
+++ b/UsingTestPyPI.md
@@ -1,0 +1,19 @@
+# Using TestPyPI to consume rc builds
+The BotBuilder SDK rc build feed is found on [TestPyPI](https://test.pypi.org/). 
+
+The daily builds will be available soon through the mentioned feed as well.
+
+
+# Configure TestPyPI
+
+You can tell pip to download packages from TestPyPI instead of PyPI by specifying the --index-url flag (in the example below, replace 'botbuilder-core' for the name of the library you want to install)
+
+```bash
+$ pip install --index-url https://test.pypi.org/simple/ botbuilder-core
+```
+If you want to allow pip to also pull other packages from PyPI you can specify --extra-index-url to point to PyPI.
+This is useful when the package you’re testing has dependencies:
+
+```bash
+pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ botbuilder-core
+```

--- a/libraries/botbuilder-core/botbuilder/core/teams/teams_activity_handler.py
+++ b/libraries/botbuilder-core/botbuilder/core/teams/teams_activity_handler.py
@@ -412,10 +412,10 @@ class TeamsActivityHandler(ActivityHandler):
                 TeamsChannelAccount().deserialize(new_account_json)
             )
 
-        return await self.on_teams_members_removed(teams_members_removed, turn_context)
+        return await self.on_teams_members_removed(teams_members_removed, team_info, turn_context)
 
     async def on_teams_members_removed(
-        self, teams_members_removed: [TeamsChannelAccount], turn_context: TurnContext
+        self, teams_members_removed: [TeamsChannelAccount], teams_info: TeamInfo, turn_context: TurnContext
     ):
         members_removed = [
             ChannelAccount().deserialize(member.serialize())

--- a/libraries/botbuilder-core/botbuilder/core/teams/teams_activity_handler.py
+++ b/libraries/botbuilder-core/botbuilder/core/teams/teams_activity_handler.py
@@ -412,10 +412,15 @@ class TeamsActivityHandler(ActivityHandler):
                 TeamsChannelAccount().deserialize(new_account_json)
             )
 
-        return await self.on_teams_members_removed(teams_members_removed, team_info, turn_context)
+        return await self.on_teams_members_removed(
+            teams_members_removed, team_info, turn_context
+        )
 
     async def on_teams_members_removed(  # pylint: disable=unused-argument
-        self, teams_members_removed: [TeamsChannelAccount], team_info: TeamInfo, turn_context: TurnContext
+        self,
+        teams_members_removed: [TeamsChannelAccount],
+        team_info: TeamInfo,
+        turn_context: TurnContext,
     ):
         members_removed = [
             ChannelAccount().deserialize(member.serialize())

--- a/libraries/botbuilder-core/tests/teams/test_teams_activity_handler.py
+++ b/libraries/botbuilder-core/tests/teams/test_teams_activity_handler.py
@@ -50,7 +50,10 @@ class TestingTeamsActivityHandler(TeamsActivityHandler):
         )
 
     async def on_teams_members_removed(
-        self, teams_members_removed: [TeamsChannelAccount], team_info: TeamInfo, turn_context: TurnContext
+        self,
+        teams_members_removed: [TeamsChannelAccount],
+        team_info: TeamInfo,
+        turn_context: TurnContext,
     ):
         self.record.append("on_teams_members_removed")
         return await super().on_teams_members_removed(
@@ -422,9 +425,9 @@ class TestTeamsActivityHandler(aiounittest.AsyncTestCase):
         activity = Activity(
             type=ActivityTypes.conversation_update,
             channel_data={
-                        "eventType": "teamMemberRemoved",
-                        "team": {"id": "team_id_1", "name": "new_team_name"}
-                        },
+                "eventType": "teamMemberRemoved",
+                "team": {"id": "team_id_1", "name": "new_team_name"},
+            },
             members_removed=[
                 ChannelAccount(
                     id="123",

--- a/libraries/botbuilder-core/tests/teams/test_teams_activity_handler.py
+++ b/libraries/botbuilder-core/tests/teams/test_teams_activity_handler.py
@@ -50,11 +50,11 @@ class TestingTeamsActivityHandler(TeamsActivityHandler):
         )
 
     async def on_teams_members_removed(
-        self, teams_members_removed: [TeamsChannelAccount], turn_context: TurnContext
+        self, teams_members_removed: [TeamsChannelAccount], team_info: TeamInfo, turn_context: TurnContext
     ):
         self.record.append("on_teams_members_removed")
         return await super().on_teams_members_removed(
-            teams_members_removed, turn_context
+            teams_members_removed, team_info, turn_context
         )
 
     async def on_message_activity(self, turn_context: TurnContext):
@@ -421,7 +421,10 @@ class TestTeamsActivityHandler(aiounittest.AsyncTestCase):
         # arrange
         activity = Activity(
             type=ActivityTypes.conversation_update,
-            channel_data={"eventType": "teamMemberRemoved"},
+            channel_data={
+                        "eventType": "teamMemberRemoved",
+                        "team": {"id": "team_id_1", "name": "new_team_name"}
+                        },
             members_removed=[
                 ChannelAccount(
                     id="123",


### PR DESCRIPTION
on_teams_members_removed is not consistent with the JS and C#. This is a breaking change. I'm not sure how we want to handle this. 