### PR TITLE
Updated requests to 2.23.0, pinned more dependencies

### DIFF
--- a/libraries/botbuilder-adapters-slack/requirements.txt
+++ b/libraries/botbuilder-adapters-slack/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp
+aiohttp==3.6.2
 pyslack
-botbuilder-core>=4.10.0
+botbuilder-core==4.10.0
 slackclient

--- a/libraries/botbuilder-adapters-slack/setup.py
+++ b/libraries/botbuilder-adapters-slack/setup.py
@@ -5,9 +5,9 @@ import os
 from setuptools import setup
 
 REQUIRES = [
-    "botbuilder-schema>=4.10.0",
-    "botframework-connector>=4.10.0",
-    "botbuilder-core>=4.10.0",
+    "botbuilder-schema==4.10.0",
+    "botframework-connector==4.10.0",
+    "botbuilder-core==4.10.0",
 ]
 
 TEST_REQUIRES = ["aiounittest==1.3.0"]

--- a/libraries/botbuilder-ai/requirements.txt
+++ b/libraries/botbuilder-ai/requirements.txt
@@ -1,6 +1,6 @@
 msrest==0.6.10
-botbuilder-schema>=4.10.0
-botbuilder-core>=4.10.0
-requests==2.22.0
+botbuilder-schema==4.10.0
+botbuilder-core==4.10.0
+requests==2.23.0
 aiounittest==1.3.0
 azure-cognitiveservices-language-luis==0.2.0

--- a/libraries/botbuilder-ai/setup.py
+++ b/libraries/botbuilder-ai/setup.py
@@ -6,8 +6,8 @@ from setuptools import setup
 
 REQUIRES = [
     "azure-cognitiveservices-language-luis==0.2.0",
-    "botbuilder-schema>=4.10.0",
-    "botbuilder-core>=4.10.0",
+    "botbuilder-schema==4.10.0",
+    "botbuilder-core==4.10.0",
     "aiohttp==3.6.2",
 ]
 

--- a/libraries/botbuilder-applicationinsights/requirements.txt
+++ b/libraries/botbuilder-applicationinsights/requirements.txt
@@ -1,3 +1,3 @@
 msrest==0.6.10
-botbuilder-core>=4.10.0
+botbuilder-core==4.10.0
 aiounittest==1.3.0

--- a/libraries/botbuilder-applicationinsights/setup.py
+++ b/libraries/botbuilder-applicationinsights/setup.py
@@ -5,10 +5,10 @@ import os
 from setuptools import setup
 
 REQUIRES = [
-    "applicationinsights>=0.11.9",
-    "botbuilder-schema>=4.10.0",
-    "botframework-connector>=4.10.0",
-    "botbuilder-core>=4.10.0",
+    "applicationinsights==0.11.9",
+    "botbuilder-schema==4.10.0",
+    "botframework-connector==4.10.0",
+    "botbuilder-core==4.10.0",
 ]
 TESTS_REQUIRES = [
     "aiounittest==1.3.0",

--- a/libraries/botbuilder-azure/setup.py
+++ b/libraries/botbuilder-azure/setup.py
@@ -7,8 +7,8 @@ from setuptools import setup
 REQUIRES = [
     "azure-cosmos==3.1.2",
     "azure-storage-blob==2.1.0",
-    "botbuilder-schema>=4.10.0",
-    "botframework-connector>=4.10.0",
+    "botbuilder-schema==4.10.0",
+    "botframework-connector==4.10.0",
     "jsonpickle==1.2",
 ]
 TEST_REQUIRES = ["aiounittest==1.3.0"]

--- a/libraries/botbuilder-core/requirements.txt
+++ b/libraries/botbuilder-core/requirements.txt
@@ -1,7 +1,7 @@
 msrest==0.6.10
-botframework-connector>=4.10.0
-botbuilder-schema>=4.10.0
-requests==2.22.0
+botframework-connector==4.10.0
+botbuilder-schema==4.10.0
+requests==2.23.0
 PyJWT==1.5.3
 cryptography==2.8.0
 aiounittest==1.3.0

--- a/libraries/botbuilder-core/setup.py
+++ b/libraries/botbuilder-core/setup.py
@@ -6,8 +6,8 @@ from setuptools import setup
 
 VERSION = os.environ["packageVersion"] if "packageVersion" in os.environ else "4.10.0"
 REQUIRES = [
-    "botbuilder-schema>=4.10.0",
-    "botframework-connector>=4.10.0",
+    "botbuilder-schema==4.10.0",
+    "botframework-connector==4.10.0",
     "jsonpickle==1.2",
 ]
 

--- a/libraries/botbuilder-dialogs/requirements.txt
+++ b/libraries/botbuilder-dialogs/requirements.txt
@@ -1,8 +1,8 @@
 msrest==0.6.10
-botframework-connector>=4.10.0
-botbuilder-schema>=4.10.0
-botbuilder-core>=4.10.0
-requests==2.22.0
+botframework-connector==4.10.0
+botbuilder-schema==4.10.0
+botbuilder-core==4.10.0
+requests==2.23.0
 PyJWT==1.5.3
 cryptography==2.8
 aiounittest==1.3.0

--- a/libraries/botbuilder-dialogs/setup.py
+++ b/libraries/botbuilder-dialogs/setup.py
@@ -12,9 +12,9 @@ REQUIRES = [
     "recognizers-text>=1.0.2a1",
     "recognizers-text-choice>=1.0.2a1",
     "babel==2.7.0",
-    "botbuilder-schema>=4.10.0",
-    "botframework-connector>=4.10.0",
-    "botbuilder-core>=4.10.0",
+    "botbuilder-schema==4.10.0",
+    "botframework-connector==4.10.0",
+    "botbuilder-core==4.10.0",
 ]
 
 TEST_REQUIRES = ["aiounittest==1.3.0"]

--- a/libraries/botbuilder-integration-aiohttp/requirements.txt
+++ b/libraries/botbuilder-integration-aiohttp/requirements.txt
@@ -1,4 +1,4 @@
 msrest==0.6.10
-botframework-connector>=4.10.0
-botbuilder-schema>=4.10.0
-aiohttp>=3.6.2
+botframework-connector==4.10.0
+botbuilder-schema==4.10.0
+aiohttp==3.6.2

--- a/libraries/botbuilder-integration-aiohttp/setup.py
+++ b/libraries/botbuilder-integration-aiohttp/setup.py
@@ -6,9 +6,9 @@ from setuptools import setup
 
 VERSION = os.environ["packageVersion"] if "packageVersion" in os.environ else "4.10.0"
 REQUIRES = [
-    "botbuilder-schema>=4.10.0",
-    "botframework-connector>=4.10.0",
-    "botbuilder-core>=4.10.0",
+    "botbuilder-schema==4.10.0",
+    "botframework-connector==4.10.0",
+    "botbuilder-core==4.10.0",
     "aiohttp==3.6.2",
 ]
 

--- a/libraries/botbuilder-integration-applicationinsights-aiohttp/setup.py
+++ b/libraries/botbuilder-integration-applicationinsights-aiohttp/setup.py
@@ -7,10 +7,10 @@ from setuptools import setup
 REQUIRES = [
     "applicationinsights>=0.11.9",
     "aiohttp==3.6.2",
-    "botbuilder-schema>=4.10.0",
-    "botframework-connector>=4.10.0",
-    "botbuilder-core>=4.10.0",
-    "botbuilder-applicationinsights>=4.10.0",
+    "botbuilder-schema==4.10.0",
+    "botframework-connector==4.10.0",
+    "botbuilder-core==4.10.0",
+    "botbuilder-applicationinsights==4.10.0",
 ]
 TESTS_REQUIRES = [
     "aiounittest==1.3.0",

--- a/libraries/botbuilder-testing/requirements.txt
+++ b/libraries/botbuilder-testing/requirements.txt
@@ -1,4 +1,4 @@
-botbuilder-schema>=4.10.0
-botbuilder-core>=4.10.0
-botbuilder-dialogs>=4.10.0
+botbuilder-schema==4.10.0
+botbuilder-core==4.10.0
+botbuilder-dialogs==4.10.0
 aiounittest==1.3.0

--- a/libraries/botbuilder-testing/setup.py
+++ b/libraries/botbuilder-testing/setup.py
@@ -5,9 +5,9 @@ import os
 from setuptools import setup
 
 REQUIRES = [
-    "botbuilder-schema>=4.10.0",
-    "botbuilder-core>=4.10.0",
-    "botbuilder-dialogs>=4.10.0",
+    "botbuilder-schema==4.10.0",
+    "botbuilder-core==4.10.0",
+    "botbuilder-dialogs==4.10.0",
 ]
 
 TESTS_REQUIRES = ["aiounittest==1.3.0"]

--- a/libraries/botframework-connector/requirements.txt
+++ b/libraries/botframework-connector/requirements.txt
@@ -1,6 +1,6 @@
 msrest==0.6.10
-botbuilder-schema>=4.10.0
-requests==2.22.0
+botbuilder-schema==4.10.0
+requests==2.23.0
 PyJWT==1.5.3
 cryptography==2.8.0
 msal==1.2.0

--- a/libraries/botframework-connector/setup.py
+++ b/libraries/botframework-connector/setup.py
@@ -7,10 +7,10 @@ NAME = "botframework-connector"
 VERSION = os.environ["packageVersion"] if "packageVersion" in os.environ else "4.10.0"
 REQUIRES = [
     "msrest==0.6.10",
-    "requests==2.22.0",
+    "requests==2.23.0",
     "cryptography==2.8.0",
     "PyJWT==1.5.3",
-    "botbuilder-schema>=4.10.0",
+    "botbuilder-schema==4.10.0",
     "adal==1.2.1",
     "msal==1.2.0",
 ]


### PR DESCRIPTION
Fixes #1070 

This should allow the latest CookieCutter to work with us (since it depends on requests 2.23.0)