### PR TITLE
Hardened prompts

### DIFF
--- a/libraries/botbuilder-dialogs/botbuilder/dialogs/prompts/choice_prompt.py
+++ b/libraries/botbuilder-dialogs/botbuilder/dialogs/prompts/choice_prompt.py
@@ -152,6 +152,8 @@ class ChoicePrompt(Prompt):
         if turn_context.activity.type == ActivityTypes.message:
             activity: Activity = turn_context.activity
             utterance: str = activity.text
+            if not utterance:
+                return result
             opt: FindChoicesOptions = self.recognizer_options if self.recognizer_options else FindChoicesOptions()
             opt.locale = (
                 activity.locale

--- a/libraries/botbuilder-dialogs/botbuilder/dialogs/prompts/confirm_prompt.py
+++ b/libraries/botbuilder-dialogs/botbuilder/dialogs/prompts/confirm_prompt.py
@@ -122,9 +122,11 @@ class ConfirmPrompt(Prompt):
         result = PromptRecognizerResult()
         if turn_context.activity.type == ActivityTypes.message:
             # Recognize utterance
-            message = turn_context.activity
+            utterance = turn_context.activity.text
+            if not utterance:
+                return result
             culture = self.determine_culture(turn_context.activity)
-            results = recognize_boolean(message.text, culture)
+            results = recognize_boolean(utterance, culture)
             if results:
                 first = results[0]
                 if "value" in first.resolution:
@@ -151,7 +153,7 @@ class ConfirmPrompt(Prompt):
                     )
                     choices = {confirm_choices[0], confirm_choices[1]}
                     second_attempt_results = ChoiceRecognizers.recognize_choices(
-                        message.text, choices
+                        utterance, choices
                     )
                     if second_attempt_results:
                         result.succeeded = True

--- a/libraries/botbuilder-dialogs/botbuilder/dialogs/prompts/datetime_prompt.py
+++ b/libraries/botbuilder-dialogs/botbuilder/dialogs/prompts/datetime_prompt.py
@@ -50,11 +50,17 @@ class DateTimePrompt(Prompt):
         result = PromptRecognizerResult()
         if turn_context.activity.type == ActivityTypes.message:
             # Recognize utterance
-            message = turn_context.activity
+            utterance = turn_context.activity.text
+            if not utterance:
+                return result
             # TODO: English constant needs to be ported.
-            culture = message.locale if message.locale is not None else "English"
+            culture = (
+                turn_context.activity.locale
+                if turn_context.activity.locale is not None
+                else "English"
+            )
 
-            results = recognize_datetime(message.text, culture)
+            results = recognize_datetime(utterance, culture)
             if results:
                 result.succeeded = True
                 result.value = []

--- a/libraries/botbuilder-dialogs/botbuilder/dialogs/prompts/number_prompt.py
+++ b/libraries/botbuilder-dialogs/botbuilder/dialogs/prompts/number_prompt.py
@@ -55,9 +55,11 @@ class NumberPrompt(Prompt):
 
         result = PromptRecognizerResult()
         if turn_context.activity.type == ActivityTypes.message:
-            message = turn_context.activity
+            utterance = turn_context.activity.text
+            if not utterance:
+                return result
             culture = self._get_culture(turn_context)
-            results: [ModelResult] = recognize_number(message.text, culture)
+            results: [ModelResult] = recognize_number(utterance, culture)
 
             if results:
                 result.succeeded = True


### PR DESCRIPTION
See parent PR: https://github.com/microsoft/botbuilder-js/pull/2246

## Description

Some of the prompts break if user uploads an attachment instead of responding with text because of some of the `string` methods that get called on `activity.text` (which doesn't exist if an attachment is sent).

## Specific Changes

Add some variation of

```python
if not utterance:
  return result
```

to:

1. ChoicePrompt
2. DatetimePrompt
3. NumberPrompt
4. ConfirmPrompt

I also renamed `message` to `utterance` to be more in line with other prompts.

The original issue was only for DatetimePrompt, but I added the other two. Other prompts didn't seem relevant for this.
