### PR TITLE
Possible fix for BotBuilder-Python-Functional-Tests-Linux-yaml build error

### DIFF
--- a/libraries/functional-tests/functionaltestbot/requirements.txt
+++ b/libraries/functional-tests/functionaltestbot/requirements.txt
@@ -1,5 +1,5 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-botbuilder-core>=4.10.0a0
+botbuilder-core>=4.9.0
 flask==1.1.1

--- a/libraries/functional-tests/functionaltestbot/requirements.txt
+++ b/libraries/functional-tests/functionaltestbot/requirements.txt
@@ -1,5 +1,5 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-botbuilder-core>=4.10.0a
+botbuilder-core>=4.10.0a0
 flask==1.1.1

--- a/libraries/functional-tests/functionaltestbot/requirements.txt
+++ b/libraries/functional-tests/functionaltestbot/requirements.txt
@@ -1,5 +1,5 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-botbuilder-core>=4.10
+botbuilder-core>=4.10.0a
 flask==1.1.1

--- a/libraries/functional-tests/functionaltestbot/setup.py
+++ b/libraries/functional-tests/functionaltestbot/setup.py
@@ -5,7 +5,7 @@ import os
 from setuptools import setup
 
 REQUIRES = [
-    "botbuilder-core>=4.10.0a0",
+    "botbuilder-core>=4.9.0",
     "flask==1.1.1",
 ]
 

--- a/libraries/functional-tests/functionaltestbot/setup.py
+++ b/libraries/functional-tests/functionaltestbot/setup.py
@@ -5,7 +5,7 @@ import os
 from setuptools import setup
 
 REQUIRES = [
-    "botbuilder-core>=4.10.0a",
+    "botbuilder-core>=4.10.0a0",
     "flask==1.1.1",
 ]
 

--- a/libraries/functional-tests/functionaltestbot/setup.py
+++ b/libraries/functional-tests/functionaltestbot/setup.py
@@ -5,7 +5,7 @@ import os
 from setuptools import setup
 
 REQUIRES = [
-    "botbuilder-core>=4.10",
+    "botbuilder-core>=4.10.0a",
     "flask==1.1.1",
 ]
 


### PR DESCRIPTION
No idea whether this is the correct fix for the problem. However, it makes the build run without error.

The failing build: https://fuselabs.visualstudio.com/SDK_v4/_build/results?buildId=128418&view=results

The successful build: https://fuselabs.visualstudio.com/SDK_v4/_build/results?buildId=132248&view=results