### PR TITLE
R9 Reference comment fixes

### DIFF
--- a/libraries/botbuilder-ai/botbuilder/ai/luis/luis_application.py
+++ b/libraries/botbuilder-ai/botbuilder/ai/luis/luis_application.py
@@ -47,6 +47,7 @@ class LuisApplication:
     @classmethod
     def from_application_endpoint(cls, application_endpoint: str):
         """Initializes a new instance of the <see cref="LuisApplication"/> class.
+
         :param application_endpoint: LUIS application endpoint.
         :type application_endpoint: str
         :return:

--- a/libraries/botbuilder-ai/botbuilder/ai/luis/luis_recognizer.py
+++ b/libraries/botbuilder-ai/botbuilder/ai/luis/luis_recognizer.py
@@ -108,6 +108,7 @@ class LuisRecognizer(Recognizer):
         luis_prediction_options: LuisPredictionOptions = None,
     ) -> RecognizerResult:
         """Return results of the analysis (Suggested actions and intents).
+
         :param turn_context: Context object containing information for a single turn of conversation with a user.
         :type turn_context: TurnContext
         :param telemetry_properties: Additional properties to be logged to telemetry with the LuisResult event, defaults

--- a/libraries/botbuilder-ai/botbuilder/ai/luis/luis_recognizer.py
+++ b/libraries/botbuilder-ai/botbuilder/ai/luis/luis_recognizer.py
@@ -136,6 +136,7 @@ class LuisRecognizer(Recognizer):
         telemetry_metrics: Dict[str, float] = None,
     ):
         """Invoked prior to a LuisResult being logged.
+
         :param recognizer_result: The Luis Results for the call.
         :type recognizer_result: RecognizerResult
         :param turn_context: Context object containing information for a single turn of conversation with a user.
@@ -179,6 +180,7 @@ class LuisRecognizer(Recognizer):
         telemetry_properties: Dict[str, str] = None,
     ) -> Dict[str, str]:
         """Fills the event properties for LuisResult event for telemetry.
+
         These properties are logged when the recognizer is called.
         :param recognizer_result: Last activity sent from user.
         :type recognizer_result: RecognizerResult

--- a/libraries/botbuilder-ai/botbuilder/ai/luis/luis_recognizer.py
+++ b/libraries/botbuilder-ai/botbuilder/ai/luis/luis_recognizer.py
@@ -73,6 +73,7 @@ class LuisRecognizer(Recognizer):
         results: RecognizerResult, default_intent: str = "None", min_score: float = 0.0
     ) -> str:
         """Returns the name of the top scoring intent from a set of LUIS results.
+
         :param results: Result set to be searched.
         :type results: RecognizerResult
         :param default_intent: Intent name to return should a top intent be found, defaults to "None"

--- a/libraries/botbuilder-ai/botbuilder/ai/qna/qnamaker.py
+++ b/libraries/botbuilder-ai/botbuilder/ai/qna/qnamaker.py
@@ -78,10 +78,16 @@ class QnAMaker(QnAMakerTelemetryClient):
         telemetry_properties: Dict[str, str] = None,
         telemetry_metrics: Dict[str, int] = None,
     ) -> [QueryResult]:
-        """Generates answers from the knowledge base.
+        """
+        Generates answers from the knowledge base.
 
-        :return: A list of answers for the user's query, sorted in decreasing order of ranking score.
-        :rtype:List[QueryResult]
+        return:
+        -------
+        A list of answers for the user's query, sorted in decreasing order of ranking score.
+
+        rtype:
+        ------
+        List[QueryResult]
         """
         result = await self.get_answers_raw(
             context, options, telemetry_properties, telemetry_metrics

--- a/libraries/botbuilder-ai/botbuilder/ai/qna/qnamaker.py
+++ b/libraries/botbuilder-ai/botbuilder/ai/qna/qnamaker.py
@@ -78,16 +78,10 @@ class QnAMaker(QnAMakerTelemetryClient):
         telemetry_properties: Dict[str, str] = None,
         telemetry_metrics: Dict[str, int] = None,
     ) -> [QueryResult]:
-        """
-        Generates answers from the knowledge base.
+        """Generates answers from the knowledge base.
 
-        return:
-        -------
-        A list of answers for the user's query, sorted in decreasing order of ranking score.
-
-        rtype:
-        ------
-        List[QueryResult]
+        :return: A list of answers for the user's query, sorted in decreasing order of ranking score.
+        :rtype:List[QueryResult]
         """
         result = await self.get_answers_raw(
             context, options, telemetry_properties, telemetry_metrics

--- a/libraries/botbuilder-ai/botbuilder/ai/qna/qnamaker.py
+++ b/libraries/botbuilder-ai/botbuilder/ai/qna/qnamaker.py
@@ -127,13 +127,10 @@ class QnAMaker(QnAMakerTelemetryClient):
         """
         Filters the ambiguous question for active learning.
 
-        Parameters:
-        -----------
-        query_result: User query output.
+        :param query_result: User query output.
+        :type query_result: :class:`QueryResult`
 
-        Return:
-        -------
-        Filtered aray of ambigous questions.
+        :return: Filtered array of ambiguous questions.
         """
         return ActiveLearningUtils.get_low_score_variation(query_result)
 
@@ -141,9 +138,8 @@ class QnAMaker(QnAMakerTelemetryClient):
         """
         Sends feedback to the knowledge base.
 
-        Parameters:
-        -----------
-        feedback_records
+        :param feedback_records:
+        :type feedback_records: :class:`typing.List`
         """
         return await self._active_learning_train_helper.call_train(feedback_records)
 

--- a/libraries/botbuilder-ai/botbuilder/ai/qna/qnamaker.py
+++ b/libraries/botbuilder-ai/botbuilder/ai/qna/qnamaker.py
@@ -127,10 +127,13 @@ class QnAMaker(QnAMakerTelemetryClient):
         """
         Filters the ambiguous question for active learning.
 
-        :param query_result: User query output.
-        :type query_result: :class:`QueryResult`
+        Parameters:
+        -----------
+        query_result: User query output.
 
-        :return: Filtered array of ambiguous questions.
+        Return:
+        -------
+        Filtered aray of ambigous questions.
         """
         return ActiveLearningUtils.get_low_score_variation(query_result)
 
@@ -138,8 +141,9 @@ class QnAMaker(QnAMakerTelemetryClient):
         """
         Sends feedback to the knowledge base.
 
-        :param feedback_records:
-        :type feedback_records: :class:`typing.List`
+        Parameters:
+        -----------
+        feedback_records
         """
         return await self._active_learning_train_helper.call_train(feedback_records)
 

--- a/libraries/botbuilder-core/botbuilder/core/skills/conversation_id_factory.py
+++ b/libraries/botbuilder-core/botbuilder/core/skills/conversation_id_factory.py
@@ -28,11 +28,10 @@ class ConversationIdFactoryBase(ABC):
         Using the options passed in, creates a conversation id and
         SkillConversationReference, storing them for future use.
 
-        :param options_or_conversation_reference: The options contain properties useful
-        for generating a SkillConversationReference and conversation id.
+        :param options_or_conversation_reference: The options contain properties
+        useful for generating a SkillConversationReference and conversation id.
         :type options_or_conversation_reference: :class:
         `Union[SkillConversationIdFactoryOptions, ConversationReference]`
-
         :returns: A skill conversation id.
 
         .. note::
@@ -48,8 +47,7 @@ class ConversationIdFactoryBase(ABC):
         """
         Retrieves a SkillConversationReference using a conversation id passed in.
 
-        :param skill_conversation_id: The conversation id for which to retrieve
-        the SkillConversationReference.
+        :param skill_conversation_id: The conversation id for which to retrieve the SkillConversationReference.
         :type skill_conversation_id: str
 
         .. note::

--- a/libraries/botbuilder-core/botbuilder/core/skills/skill_handler.py
+++ b/libraries/botbuilder-core/botbuilder/core/skills/skill_handler.py
@@ -72,6 +72,7 @@ class SkillHandler(ChannelServiceHandler):
         conversation.
 
         Use SendToConversation in all other cases.
+
         :param claims_identity:
         :param conversation_id:
         :param activity:
@@ -104,6 +105,7 @@ class SkillHandler(ChannelServiceHandler):
         conversation.
 
         Use SendToConversation in all other cases.
+
         :param claims_identity:
         :param conversation_id:
         :param activity_id:

--- a/libraries/botbuilder-integration-applicationinsights-aiohttp/botbuilder/integration/applicationinsights/aiohttp/aiohttp_telemetry_middleware.py
+++ b/libraries/botbuilder-integration-applicationinsights-aiohttp/botbuilder/integration/applicationinsights/aiohttp/aiohttp_telemetry_middleware.py
@@ -7,6 +7,7 @@ _REQUEST_BODIES = {}
 
 def retrieve_aiohttp_body():
     """ retrieve_flask_body
+
     Retrieve the POST body text from temporary cache.
     The POST body corresponds with the thread id and should resides in
     cache just for lifetime of request.


### PR DESCRIPTION
Fixing malformed classes in [Python ref doc build](https://ceapex.visualstudio.com/Onboarding/_workitems/edit/219590?src=WorkItemMention&src-action=artifact_link) for R9.

Classes:
- [x] [AiohttpTelemetryMiddleware](https://github.com/microsoft/botbuilder-python/blob/master/libraries/botbuilder-integration-applicationinsights-aiohttp/botbuilder/integration/applicationinsights/aiohttp/aiohttp_telemetry_middleware.py)
- [x] [ConversationIdFactoryBase](https://github.com/microsoft/botbuilder-python/blob/master/libraries/botbuilder-core/botbuilder/core/skills/conversation_id_factory.py)
- [x] [LuisApplication](https://github.com/microsoft/botbuilder-python/blob/master/libraries/botbuilder-ai/botbuilder/ai/luis/luis_application.py)
- [x] [LuisRecognizer](https://github.com/microsoft/botbuilder-python/blob/master/libraries/botbuilder-ai/botbuilder/ai/luis/luis_recognizer.py)
- [ ] [QnAMaker](https://github.com/microsoft/botbuilder-python/blob/master/libraries/botbuilder-ai/botbuilder/ai/qna/qnamaker.py)
- [x] [SkillHandler](https://github.com/microsoft/botbuilder-python/blob/master/libraries/botbuilder-core/botbuilder/core/skills/skill_handler.py)
