### PR TITLE
R10 reference comment fixes

### DIFF
--- a/libraries/botbuilder-applicationinsights/botbuilder/applicationinsights/application_insights_telemetry_client.py
+++ b/libraries/botbuilder-applicationinsights/botbuilder/applicationinsights/application_insights_telemetry_client.py
@@ -171,7 +171,7 @@ class ApplicationInsightsTelemetryClient(BotTelemetryClient):
         :param url: The actual URL for this request (to show in individual request instances).
         :param success: True if the request ended in success, False otherwise.
         :param start_time: the start time of the request. The value should look the same as the one returned by
-         :func:`datetime.isoformat()` (defaults to: None)
+         :func:`datetime.isoformat` (defaults to: None)
         :param duration: the number of milliseconds that this request lasted. (defaults to: None)
         :param response_code: the response code that this request returned. (defaults to: None)
         :param http_method: the HTTP method that triggered this request. (defaults to: None)

--- a/libraries/botbuilder-applicationinsights/botbuilder/applicationinsights/application_insights_telemetry_client.py
+++ b/libraries/botbuilder-applicationinsights/botbuilder/applicationinsights/application_insights_telemetry_client.py
@@ -171,7 +171,7 @@ class ApplicationInsightsTelemetryClient(BotTelemetryClient):
         :param url: The actual URL for this request (to show in individual request instances).
         :param success: True if the request ended in success, False otherwise.
         :param start_time: the start time of the request. The value should look the same as the one returned by
-         :func:`datetime.isoformat` (defaults to: None)
+         :func:`datetime.isoformat`. (defaults to: None)
         :param duration: the number of milliseconds that this request lasted. (defaults to: None)
         :param response_code: the response code that this request returned. (defaults to: None)
         :param http_method: the HTTP method that triggered this request. (defaults to: None)

--- a/libraries/botbuilder-applicationinsights/botbuilder/applicationinsights/application_insights_telemetry_client.py
+++ b/libraries/botbuilder-applicationinsights/botbuilder/applicationinsights/application_insights_telemetry_client.py
@@ -170,8 +170,8 @@ class ApplicationInsightsTelemetryClient(BotTelemetryClient):
         :param name: The name for this request. All requests with the same name will be grouped together.
         :param url: The actual URL for this request (to show in individual request instances).
         :param success: True if the request ended in success, False otherwise.
-        :param start_time: the start time of the request. The value should look the same 
-        as the one returned by :func:`datetime.isoformat`. (defaults to: None)
+        :param start_time: the start time of the request. The value should look the same as the one returned by
+         :func:`datetime.isoformat()` (defaults to: None)
         :param duration: the number of milliseconds that this request lasted. (defaults to: None)
         :param response_code: the response code that this request returned. (defaults to: None)
         :param http_method: the HTTP method that triggered this request. (defaults to: None)

--- a/libraries/botbuilder-applicationinsights/botbuilder/applicationinsights/application_insights_telemetry_client.py
+++ b/libraries/botbuilder-applicationinsights/botbuilder/applicationinsights/application_insights_telemetry_client.py
@@ -170,8 +170,8 @@ class ApplicationInsightsTelemetryClient(BotTelemetryClient):
         :param name: The name for this request. All requests with the same name will be grouped together.
         :param url: The actual URL for this request (to show in individual request instances).
         :param success: True if the request ended in success, False otherwise.
-        :param start_time: the start time of the request. The value should look the same as the one returned by
-         :func:`datetime.isoformat()` (defaults to: None)
+        :param start_time: the start time of the request. The value should look the same 
+        as the one returned by :func:`datetime.isoformat`. (defaults to: None)
         :param duration: the number of milliseconds that this request lasted. (defaults to: None)
         :param response_code: the response code that this request returned. (defaults to: None)
         :param http_method: the HTTP method that triggered this request. (defaults to: None)

--- a/libraries/botbuilder-core/botbuilder/core/bot_telemetry_client.py
+++ b/libraries/botbuilder-core/botbuilder/core/bot_telemetry_client.py
@@ -144,7 +144,7 @@ class BotTelemetryClient(ABC):
         :param url: The actual URL for this request (to show in individual request instances).
         :param success: True if the request ended in success, False otherwise.
         :param start_time: the start time of the request. \
-        The value should look the same as the one returned by :func:`datetime.isoformat()` (defaults to: None)
+        The value should look the same as the one returned by :func:`datetime.isoformat` (defaults to: None)
         :param duration: the number of milliseconds that this request lasted. (defaults to: None)
         :param response_code: the response code that this request returned. (defaults to: None)
         :param http_method: the HTTP method that triggered this request. (defaults to: None)

--- a/libraries/botbuilder-core/botbuilder/core/null_telemetry_client.py
+++ b/libraries/botbuilder-core/botbuilder/core/null_telemetry_client.py
@@ -117,8 +117,7 @@ class NullTelemetryClient(BotTelemetryClient):
         :param name: The name for this request. All requests with the same name will be grouped together.
         :param url: The actual URL for this request (to show in individual request instances).
         :param success: True if the request ended in success, False otherwise.
-        :param start_time: the start time of the request. The value should look the same as the one returned \
-        by :func:`datetime.isoformat()` (defaults to: None)
+        :param start_time: the start time of the request. The value should look the same as the one returned by datetime.isoformat(). Defaults to None.
         :param duration: the number of milliseconds that this request lasted. (defaults to: None)
         :param response_code: the response code that this request returned. (defaults to: None)
         :param http_method: the HTTP method that triggered this request. (defaults to: None)

--- a/libraries/botbuilder-core/botbuilder/core/null_telemetry_client.py
+++ b/libraries/botbuilder-core/botbuilder/core/null_telemetry_client.py
@@ -118,7 +118,7 @@ class NullTelemetryClient(BotTelemetryClient):
         :param url: The actual URL for this request (to show in individual request instances).
         :param success: True if the request ended in success, False otherwise.
         :param start_time: the start time of the request. The value should look the same as the one returned \
-        by datetime.isoformat(). Defaults to None.
+        by :func:`datetime.isoformat`. (defaults to: None)
         :param duration: the number of milliseconds that this request lasted. (defaults to: None)
         :param response_code: the response code that this request returned. (defaults to: None)
         :param http_method: the HTTP method that triggered this request. (defaults to: None)

--- a/libraries/botbuilder-core/botbuilder/core/null_telemetry_client.py
+++ b/libraries/botbuilder-core/botbuilder/core/null_telemetry_client.py
@@ -117,8 +117,8 @@ class NullTelemetryClient(BotTelemetryClient):
         :param name: The name for this request. All requests with the same name will be grouped together.
         :param url: The actual URL for this request (to show in individual request instances).
         :param success: True if the request ended in success, False otherwise.
-        :param start_time: the start time of the request. The value should look the same as the one returned by \
-        datetime.isoformat(). Defaults to None.
+        :param start_time: the start time of the request. The value should look the same as the one returned \
+        by datetime.isoformat(). Defaults to None.
         :param duration: the number of milliseconds that this request lasted. (defaults to: None)
         :param response_code: the response code that this request returned. (defaults to: None)
         :param http_method: the HTTP method that triggered this request. (defaults to: None)

--- a/libraries/botbuilder-core/botbuilder/core/null_telemetry_client.py
+++ b/libraries/botbuilder-core/botbuilder/core/null_telemetry_client.py
@@ -117,7 +117,8 @@ class NullTelemetryClient(BotTelemetryClient):
         :param name: The name for this request. All requests with the same name will be grouped together.
         :param url: The actual URL for this request (to show in individual request instances).
         :param success: True if the request ended in success, False otherwise.
-        :param start_time: the start time of the request. The value should look the same as the one returned by datetime.isoformat(). Defaults to None.
+        :param start_time: the start time of the request. The value should look the same as the one returned by \
+        datetime.isoformat(). Defaults to None.
         :param duration: the number of milliseconds that this request lasted. (defaults to: None)
         :param response_code: the response code that this request returned. (defaults to: None)
         :param http_method: the HTTP method that triggered this request. (defaults to: None)

--- a/libraries/botbuilder-core/botbuilder/core/skills/skill_handler.py
+++ b/libraries/botbuilder-core/botbuilder/core/skills/skill_handler.py
@@ -73,8 +73,11 @@ class SkillHandler(ChannelServiceHandler):
 
         Use SendToConversation in all other cases.
         :param claims_identity:
+        :type claims_identity:
         :param conversation_id:
+        :type conversation_id: string
         :param activity:
+        :type activity: Activity
         :return:
         """
         return await self._process_activity(
@@ -105,9 +108,13 @@ class SkillHandler(ChannelServiceHandler):
 
         Use SendToConversation in all other cases.
         :param claims_identity:
+        :type claims_identity:
         :param conversation_id:
+        :type conversation_id: string
         :param activity_id:
+        :param activity_id: string
         :param activity:
+        :type activity: Activity
         :return:
         """
         return await self._process_activity(

--- a/libraries/botbuilder-core/botbuilder/core/skills/skill_handler.py
+++ b/libraries/botbuilder-core/botbuilder/core/skills/skill_handler.py
@@ -73,7 +73,7 @@ class SkillHandler(ChannelServiceHandler):
 
         Use SendToConversation in all other cases.
         :param claims_identity:
-        :type claims_identity:
+        :type claims_identity: :class:`botframework.connector.auth.ClaimsIdentity`
         :param conversation_id:
         :type conversation_id: string
         :param activity:
@@ -108,7 +108,7 @@ class SkillHandler(ChannelServiceHandler):
 
         Use SendToConversation in all other cases.
         :param claims_identity:
-        :type claims_identity:
+        :type claims_identity: :class:`botframework.connector.auth.ClaimsIdentity`
         :param conversation_id:
         :type conversation_id: string
         :param activity_id:


### PR DESCRIPTION
## Description
Updating reference comments to fix formatting issues on SDK site. 

## Specific Changes
 - Removed parentheses from `:func:`