### PR TITLE
Add e_tag to storeItems tests

### DIFF
--- a/libraries/botbuilder-testing/botbuilder/testing/storage_base_tests.py
+++ b/libraries/botbuilder-testing/botbuilder/testing/storage_base_tests.py
@@ -10,10 +10,10 @@ Therefore, all tests using theses static tests should strictly check that the me
 
 Note: Python cannot have dicts with properties with a None value like other SDKs can have properties with null values.
       Because of this, StoreItem tests have "e_tag: *" where the tests in the other SDKs do not.
-      This has also caused us to comment out some parts of these tests where we assert that "e_tag" is None for the same reason.
-      A null e_tag should work just like a * e_tag when writing, as far as the storage adapters are concerened,
-      so this shouldn't cause issues.
-      
+      This has also caused us to comment out some parts of these tests where we assert that "e_tag"
+      is None for the same reason. A null e_tag should work just like a * e_tag when writing,
+      as far as the storage adapters are concerened, so this shouldn't cause issues.
+
 
 :Example:
     async def test_handle_null_keys_when_reading(self):
@@ -102,7 +102,7 @@ class StorageBaseTests:
             store_items["createPocoStoreItem"]["id"]
             == read_store_items["createPocoStoreItem"]["id"]
         )
-     
+
         # If decided to validate e_tag integrity again, uncomment this code
         # assert read_store_items["createPoco"]["e_tag"] is not None
         assert read_store_items["createPocoStoreItem"]["e_tag"] is not None


### PR DESCRIPTION
Related to: https://github.com/microsoft/botbuilder-dotnet/issues/4038

## Description

[This commit](https://github.com/microsoft/botbuilder-python/blame/master/libraries/botbuilder-testing/botbuilder/testing/storage_base_tests.py#L134) caused the live tests for Cosmos and Blob to fail because of how e_tags are used in each storage adapter. It wasn't caught because in CI, those tests are disabled (working on the fix in the issue linked above).

The real "issue" here is that this commit, some of the tests had to be commented out in Python, making them differ from the other SDKs. This would generally indicate that therefore, the Python storage adapters behave differently than the other SDKs.

@axelsrz and I discussed this and this is mostly due to a limitation in Python; unlike C# and JS, Python can't have a dict with a key that contains a null property value--the key/property just wouldn't exist at all.

So, to keep the changes in the commit linked above, I adjusted the tests so that `storeItems` include an e_tag of "*". For the storage adapters, this functions exactly the same way as a null e_tag. Therefore, I don't *expect* this to cause any issues down the road. However, it could use a deeper look by some folks that know more about Python and e_tags than I do.

## Specific Changes

- Uncomment some of the comment-ed out asserts in the tests
- Add `"e_tag": "*"` to some of the storeItems so that tests pass for all storage adapters