### PR TITLE
[Engineering] update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,30 +11,81 @@
 # In each subsection folders are ordered first by depth, then alphabetically.
 # This should make it easy to add new rules without breaking existing ones.
 
-# Bot Framework SDK notes:
-# The first code owners for a file or library are the primary approvers.
-# The later code owners represent a "escalation path" in case the primary code owners are unavailable.
-# - @microsoft/bb-python will also never receive a request for a PR review and should be manually requested
-#   for PRs that only trigger the Global rule ("*")
-# - @microsoft/bf-admin should never receive a request for a PR review
-
 # Global rule:
-* @microsoft/bb-python @microsoft/bf-admin
+* @microsoft/bb-python
+
+# Functional tests
+/libraries/functional-tests/**                                                      @tracyboehrer
 
 # Adapters
-/libraries/botbuilder-adapters-slack/**                                            @garypretty @microsoft/bb-python @microsoft/bf-admin
+/libraries/botbuilder-adapters-slack/**                                             @tracyboehrer @garypretty
 
-# Platform Integration Libaries
-/libraries/botbuilder-integration-aiohttp/**                                       @microsoft/bf-admin @axelsrz @tracyboehrer
-/libraries/botbuilder-integration-applicationinsights-aiohttp/**                   @microsoft/bf-admin @axelsrz @tracyboehrer
+# Platform Integration Libaries (aiohttp)
+/libraries/botbuilder-integration-aiohttp/**                                        @microsoft/bb-python-integration
+/libraries/botbuilder-integration-applicationinsights-aiohttp/**                    @microsoft/bb-python-integration @garypretty
 
-# BotBuilder libraries
-/libraries/botbuilder-ai/botbuilder/ai/luis/**                                     @microsoft/bf-admin @bb-python @munozemilio
-/libraries/botbuilder-ai/botbuilder/ai/qna/**                                      @microsoft/bf-admin @bb-python @johnataylor
-/libraries/botbuilder-applicationinsights/**                                       @microsoft/bf-admin @bb-python @munozemilio
-/libraries/botbuilder-core/**                                                      @johnataylor @microsoft/bb-python @microsoft/bf-admin
-/libraries/botbuilder-core/botbuilder/core/teams/**                                @microsoft/bb-python @microsoft/bf-admin @microsoft/bf-teams
-/libraries/botbuilder-dialogs/**                                                   @johnataylor @microsoft/bb-python @microsoft/bf-admin
-/libraries/botframework-connector/**                                               @microsoft/bf-admin @bb-python @johnataylor
-/libraries/botframework-connector/botframework/connector/auth/**                   @microsoft/bf-admin @bb-python @bf-auth
-/libraries/botbuilder-streaming/**                                                 @microsoft/bf-admin @microsoft/bf-streaming
+# Application Insights/Telemetry
+/libraries/botbuilder-applicationinsights/**                                        @axelsrz @garypretty
+
+# AI: LUIS + QnA Maker
+/libraries/botbuilder-ai/**                                                         @microsoft/bf-cog-services
+
+# Azure (Storage)
+/libraries/botbuilder-azure/**                                                      @tracyboehrer @EricDahlvang
+
+# Adaptive Dialogs
+/libraries/botbuilder-dialogs-*/**                                                  @tracyboehrer @microsoft/bf-adaptive
+
+# AdaptiveExpressions & LanguageGeneration libraries
+/libraries/adaptive-expressions/**                                                  @axelsrz @microsoft/bf-adaptive
+/libraries/botbuilder-lg/**                                                         @axelsrz @microsoft/bf-adaptive
+
+# BotBuilder Testing
+/libraries/botbuilder-testing/**                                                    @axelsrz @gabog
+
+# Streaming library
+/libraries/botbuilder-streaming/**                                                  @microsoft/bf-streaming
+
+# BotBuilder library
+/libraries/botbuilder-core/**                                                       @axelsrz @gabog @johnataylor
+
+# BotBuilder Dialogs
+/libraries/botbuilder-dialogs/**                                                    @microsoft/bf-dialogs
+
+# Swagger
+/libraries/swagger/**                                                               @axelsrz @EricDahlvang
+
+# Bot Framework Schema
+/libraries/botbuilder-schema/**                                                     @EricDahlvang @johnataylor
+
+# Bot Framework connector
+libraries\botframework-connector/**                                                 @axelsrz @carlosscastro @johnataylor
+
+# Bot Framework Authentication
+/libraries/botbuilder-core/botbuilder/core/oauth/**                                 @microsoft/bf-auth
+/libraries/botframework-connector/botframework/connector/auth/**                    @microsoft/bf-auth
+
+# Bot Framework Skills
+/libraries/botbuilder-core/botbuilder/core/skills/**                                @microsoft/bf-skills
+/libraries/botbuilder-integration-aiohttp/botbuilder/integration/aiohttp/skills/**  @microsoft/bf-skills
+/tests/skills/**                                                                    @microsoft/bf-skills
+
+# Bot Framework & Microsoft Teams
+/libraries/botbuilder-core/botbuilder/core/teams/**                                 @microsoft/bf-teams
+/libraries/botbuilder-schema/botbuilder/schema/teams/**                             @microsoft/bf-teams
+/tests/teams/**                                                                     @microsoft/bf-teams
+
+# Ownership by specific files or file types
+# This section MUST stay at the bottom of the CODEOWNERS file. For more information, see
+# https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#example-of-a-codeowners-file
+
+# Shipped package files
+# e.g. READMEs, requirements.txt, setup.py, MANIFEST.in
+/libraries/**/README.rst                                                            @microsoft/bb-python
+/libraries/**/requirements.txt                                                      @microsoft/bb-python
+/libraries/**/setup.py                                                              @microsoft/bb-python
+/libraries/**/setup.cfg                                                             @microsoft/bb-python
+/libraries/**/MANIFEST.in                                                           @microsoft/bb-python
+
+# CODEOWNERS
+/.github/CODEOWNERS                                                                 @stevengum @cleemullins @microsoft/bb-python


### PR DESCRIPTION
Iterates on https://github.com/microsoft/botbuilder-python/pull/1225 which fixed https://github.com/microsoft/botbuilder-python/issues/1208

## Description
Adds appropriate Bot Framework SDK GitHub Teams as code owners
Applies @microsoft/bb-python specific ownership over package-crucial files, such as `setup.py` and `MANIFEST.in`