### PR TITLE
correcting none check to check parameter

### DIFF
--- a/libraries/botbuilder-core/botbuilder/core/teams/teams_info.py
+++ b/libraries/botbuilder-core/botbuilder/core/teams/teams_info.py
@@ -22,8 +22,8 @@ class TeamsInfo:
     ) -> Tuple[ConversationReference, str]:
         if not turn_context:
             raise ValueError("The turn_context cannot be None")
-        if not turn_context.activity:
-            raise ValueError("The turn_context.activity cannot be None")
+        if not activity:
+            raise ValueError("The activity cannot be None")
         if not teams_channel_id:
             raise ValueError("The teams_channel_id cannot be None or empty")
 

--- a/libraries/botbuilder-core/tests/teams/test_teams_info.py
+++ b/libraries/botbuilder-core/tests/teams/test_teams_info.py
@@ -13,6 +13,26 @@ from simple_adapter_with_create_conversation import SimpleAdapterWithCreateConve
 
 
 class TestTeamsInfo(aiounittest.AsyncTestCase):
+    async def test_send_message_to_teams_channels_without_activity(self):
+        def create_conversation():
+            pass
+
+        adapter = SimpleAdapterWithCreateConversation(
+            call_create_conversation=create_conversation
+        )
+
+        activity = Activity()
+        turn_context = TurnContext(adapter, activity)
+
+        try:
+            await TeamsInfo.send_message_to_teams_channel(
+                turn_context, None, "channelId123"
+            )
+        except ValueError:
+            pass
+        else:
+            assert False, "should have raise ValueError"
+
     async def test_send_message_to_teams(self):
         def create_conversation():
             pass


### PR DESCRIPTION
Fixes check to check the argument instead of the turn context