### PR TITLE
Update azure-cosmos to 3.2.0

### DIFF
--- a/libraries/botbuilder-azure/setup.py
+++ b/libraries/botbuilder-azure/setup.py
@@ -5,7 +5,7 @@ import os
 from setuptools import setup
 
 REQUIRES = [
-    "azure-cosmos==3.1.2",
+    "azure-cosmos==3.2.0",
     "azure-storage-blob==2.1.0",
     "botbuilder-schema==4.10.0",
     "botframework-connector==4.10.0",


### PR DESCRIPTION
Fixes #1302 

## Description

We're currently on `azure-cosmos` v3.1.2. Not a ton of changes in 3.2.0, but it looks like it will be their last stable version, now that they're working on v4:

![image](https://user-images.githubusercontent.com/40401643/89065922-64fe7280-d321-11ea-8e3d-553ec1efbec4.png)

## Specific Changes

Updates the `setup.py` in `libraries\botbuilder-azure` to use `azure-cosmos` v3.2.0.

## Testing

![image](https://user-images.githubusercontent.com/40401643/89078926-3640c600-d33a-11ea-9f98-f280080a3fa9.png)

**test_cosmos_storage.py** with `EMULATOR_RUNNING = True`:

![image](https://user-images.githubusercontent.com/40401643/89078965-4fe20d80-d33a-11ea-819b-67236daa6b1f.png)

**test_cosmos_partitioned_storage.py** with `EMULATOR_RUNNING = True`:

![image](https://user-images.githubusercontent.com/40401643/89078993-5ff9ed00-d33a-11ea-8ff7-db25a89f0f44.png)

Note: Both test files have warning, but they're all due to not using a SSL Certificate for Cosmos Emulator. Totally normal.