### PR TITLE
Add installation update sub events to ActivityHandler

### DIFF
--- a/libraries/botbuilder-core/botbuilder/core/activity_handler.py
+++ b/libraries/botbuilder-core/botbuilder/core/activity_handler.py
@@ -379,12 +379,12 @@ class ActivityHandler:
         :returns: A task that represents the work queued to execute
         """
         if turn_context.activity.action == "add":
-            return await self.on_installation_update_add_activity(turn_context)
+            return await self.on_installation_update_add(turn_context)
         if turn_context.activity.action == "remove":
-            return await self.on_installation_update_remove_activity(turn_context)
+            return await self.on_installation_update_remove(turn_context)
         return
 
-    async def on_installation_update_add_activity(  # pylint: disable=unused-argument
+    async def on_installation_update_add(  # pylint: disable=unused-argument
         self, turn_context: TurnContext
     ):
         """
@@ -397,7 +397,7 @@ class ActivityHandler:
         """
         return
 
-    async def on_installation_update_remove_activity(  # pylint: disable=unused-argument
+    async def on_installation_update_remove(  # pylint: disable=unused-argument
         self, turn_context: TurnContext
     ):
         """

--- a/libraries/botbuilder-core/botbuilder/core/activity_handler.py
+++ b/libraries/botbuilder-core/botbuilder/core/activity_handler.py
@@ -378,6 +378,36 @@ class ActivityHandler:
         :type turn_context: :class:`botbuilder.core.TurnContext`
         :returns: A task that represents the work queued to execute
         """
+        if turn_context.activity.action == "add":
+            return await self.on_installation_update_add_activity(turn_context)
+        if turn_context.activity.action == "remove":
+            return await self.on_installation_update_remove_activity(turn_context)
+        return
+
+    async def on_installation_update_add_activity(  # pylint: disable=unused-argument
+        self, turn_context: TurnContext
+    ):
+        """
+        Override this in a derived class to provide logic specific to
+        ActivityTypes.InstallationUpdate activities with 'action' set to 'add'.
+
+        :param turn_context: The context object for this turn
+        :type turn_context: :class:`botbuilder.core.TurnContext`
+        :returns: A task that represents the work queued to execute
+        """
+        return
+
+    async def on_installation_update_remove_activity(  # pylint: disable=unused-argument
+        self, turn_context: TurnContext
+    ):
+        """
+        Override this in a derived class to provide logic specific to
+        ActivityTypes.InstallationUpdate activities with 'action' set to 'remove'.
+
+        :param turn_context: The context object for this turn
+        :type turn_context: :class:`botbuilder.core.TurnContext`
+        :returns: A task that represents the work queued to execute
+        """
         return
 
     async def on_unrecognized_activity_type(  # pylint: disable=unused-argument

--- a/libraries/botbuilder-core/tests/test_activity_handler.py
+++ b/libraries/botbuilder-core/tests/test_activity_handler.py
@@ -77,13 +77,13 @@ class TestingActivityHandler(ActivityHandler):
         self.record.append("on_installation_update")
         return await super().on_installation_update(turn_context)
 
-    async def on_installation_update_add_activity(self, turn_context: TurnContext):
-        self.record.append("on_installation_update_add_activity")
-        return await super().on_installation_update_add_activity(turn_context)
+    async def on_installation_update_add(self, turn_context: TurnContext):
+        self.record.append("on_installation_update_add")
+        return await super().on_installation_update_add(turn_context)
 
-    async def on_installation_update_remove_activity(self, turn_context: TurnContext):
-        self.record.append("on_installation_update_remove_activity")
-        return await super().on_installation_update_remove_activity(turn_context)
+    async def on_installation_update_remove(self, turn_context: TurnContext):
+        self.record.append("on_installation_update_remove")
+        return await super().on_installation_update_remove(turn_context)
 
     async def on_unrecognized_activity_type(self, turn_context: TurnContext):
         self.record.append("on_unrecognized_activity_type")
@@ -254,7 +254,7 @@ class TestActivityHandler(aiounittest.AsyncTestCase):
         assert len(bot.record) == 1
         assert bot.record[0] == "on_installation_update"
 
-    async def test_on_installation_update_add_activity(self):
+    async def test_on_installation_update_add(self):
         activity = Activity(type=ActivityTypes.installation_update, action="add")
 
         adapter = TestInvokeAdapter()
@@ -266,9 +266,9 @@ class TestActivityHandler(aiounittest.AsyncTestCase):
 
         assert len(bot.record) == 2
         assert bot.record[0] == "on_installation_update"
-        assert bot.record[1] == "on_installation_update_add_activity"
+        assert bot.record[1] == "on_installation_update_add"
 
-    async def test_on_installation_update_add_remove_activity(self):
+    async def test_on_installation_update_add_remove(self):
         activity = Activity(type=ActivityTypes.installation_update, action="remove")
 
         adapter = TestInvokeAdapter()
@@ -280,7 +280,7 @@ class TestActivityHandler(aiounittest.AsyncTestCase):
 
         assert len(bot.record) == 2
         assert bot.record[0] == "on_installation_update"
-        assert bot.record[1] == "on_installation_update_remove_activity"
+        assert bot.record[1] == "on_installation_update_remove"
 
     async def test_healthcheck(self):
         activity = Activity(type=ActivityTypes.invoke, name="healthcheck",)

--- a/libraries/botbuilder-core/tests/test_activity_handler.py
+++ b/libraries/botbuilder-core/tests/test_activity_handler.py
@@ -77,6 +77,14 @@ class TestingActivityHandler(ActivityHandler):
         self.record.append("on_installation_update")
         return await super().on_installation_update(turn_context)
 
+    async def on_installation_update_add_activity(self, turn_context: TurnContext):
+        self.record.append("on_installation_update_add_activity")
+        return await super().on_installation_update_add_activity(turn_context)
+
+    async def on_installation_update_remove_activity(self, turn_context: TurnContext):
+        self.record.append("on_installation_update_remove_activity")
+        return await super().on_installation_update_remove_activity(turn_context)
+
     async def on_unrecognized_activity_type(self, turn_context: TurnContext):
         self.record.append("on_unrecognized_activity_type")
         return await super().on_unrecognized_activity_type(turn_context)
@@ -245,6 +253,34 @@ class TestActivityHandler(aiounittest.AsyncTestCase):
 
         assert len(bot.record) == 1
         assert bot.record[0] == "on_installation_update"
+
+    async def test_on_installation_update_add_activity(self):
+        activity = Activity(type=ActivityTypes.installation_update, action="add")
+
+        adapter = TestInvokeAdapter()
+        turn_context = TurnContext(adapter, activity)
+
+        # Act
+        bot = TestingActivityHandler()
+        await bot.on_turn(turn_context)
+
+        assert len(bot.record) == 2
+        assert bot.record[0] == "on_installation_update"
+        assert bot.record[1] == "on_installation_update_add_activity"
+
+    async def test_on_installation_update_add_remove_activity(self):
+        activity = Activity(type=ActivityTypes.installation_update, action="remove")
+
+        adapter = TestInvokeAdapter()
+        turn_context = TurnContext(adapter, activity)
+
+        # Act
+        bot = TestingActivityHandler()
+        await bot.on_turn(turn_context)
+
+        assert len(bot.record) == 2
+        assert bot.record[0] == "on_installation_update"
+        assert bot.record[1] == "on_installation_update_remove_activity"
 
     async def test_healthcheck(self):
         activity = Activity(type=ActivityTypes.invoke, name="healthcheck",)


### PR DESCRIPTION
Fixes https://github.com/microsoft/botbuilder-python/issues/1347

While adding this, I realized on_installation_update should be named on_installation_update_activity... yet, we have released it as on_installation_update in 4.10.0 (although this is not likely to be used by any bots just yet, since the event is not sent from Teams yet).  Any recommendation, should we update this event name to match the convention, or leave it?