### PR TITLE
Allow requests module as QnAMaker's HTTP client

### DIFF
--- a/libraries/botbuilder-ai/botbuilder/ai/qna/models/prompt.py
+++ b/libraries/botbuilder-ai/botbuilder/ai/qna/models/prompt.py
@@ -15,7 +15,7 @@ class Prompt(Model):
     }
 
     def __init__(self, **kwargs):
-        super(Prompt, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.display_order = kwargs.get("display_order", None)
         self.qna_id = kwargs.get("qna_id", None)
         self.display_text = kwargs.get("display_text", None)

--- a/libraries/botbuilder-ai/botbuilder/ai/qna/models/qna_response_context.py
+++ b/libraries/botbuilder-ai/botbuilder/ai/qna/models/qna_response_context.py
@@ -26,6 +26,6 @@ class QnAResponseContext(Model):
 
         """
 
-        super(QnAResponseContext, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.is_context_only = kwargs.get("is_context_only", None)
         self.prompts = kwargs.get("prompts", None)

--- a/libraries/botbuilder-ai/botbuilder/ai/qna/models/query_result.py
+++ b/libraries/botbuilder-ai/botbuilder/ai/qna/models/query_result.py
@@ -18,7 +18,7 @@ class QueryResult(Model):
     }
 
     def __init__(self, **kwargs):
-        super(QueryResult, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.questions = kwargs.get("questions", None)
         self.answer = kwargs.get("answer", None)
         self.score = kwargs.get("score", None)

--- a/libraries/botbuilder-ai/botbuilder/ai/qna/models/query_results.py
+++ b/libraries/botbuilder-ai/botbuilder/ai/qna/models/query_results.py
@@ -25,6 +25,6 @@ class QueryResults(Model):
 
         active_learning_enabled: The active learning enable flag.
         """
-        super(QueryResults, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.answers = answers
         self.active_learning_enabled = active_learning_enabled

--- a/libraries/botbuilder-ai/botbuilder/ai/qna/utils/generate_answer_utils.py
+++ b/libraries/botbuilder-ai/botbuilder/ai/qna/utils/generate_answer_utils.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 from copy import copy
-from typing import List, Union
+from typing import Any, List, Union
 import json
 import requests
 
@@ -165,7 +165,7 @@ class GenerateAnswerUtils:
 
         http_request_helper = HttpRequestUtils(self._http_client)
 
-        response: Union[ClientResponse, requests.Response] = await http_request_helper.execute_http_request(
+        response: Any = await http_request_helper.execute_http_request(
             url, question, self._endpoint, options.timeout
         )
 

--- a/libraries/botbuilder-ai/botbuilder/ai/qna/utils/http_request_utils.py
+++ b/libraries/botbuilder-ai/botbuilder/ai/qna/utils/http_request_utils.py
@@ -14,7 +14,7 @@ from ..qnamaker_endpoint import QnAMakerEndpoint
 
 
 class HttpRequestUtils:
-    """ HTTP request utils class. 
+    """ HTTP request utils class.
 
     Parameters:
     -----------

--- a/libraries/botbuilder-ai/botbuilder/ai/qna/utils/http_request_utils.py
+++ b/libraries/botbuilder-ai/botbuilder/ai/qna/utils/http_request_utils.py
@@ -3,6 +3,7 @@
 
 import json
 import platform
+from typing import Any
 import requests
 
 from aiohttp import ClientResponse, ClientSession, ClientTimeout
@@ -13,9 +14,15 @@ from ..qnamaker_endpoint import QnAMakerEndpoint
 
 
 class HttpRequestUtils:
-    """ HTTP request utils class. Execute HTTP requests using `QnAMaker._http_client`. """
+    """ HTTP request utils class. 
 
-    def __init__(self, http_client: ClientSession):
+    Parameters:
+    -----------
+
+    http_client: Client to make HTTP requests with. Default client used in the SDK is `aiohttp.ClientSession`.
+    """
+
+    def __init__(self, http_client: Any):
         self._http_client = http_client
 
     async def execute_http_request(

--- a/libraries/botbuilder-ai/botbuilder/ai/qna/utils/http_request_utils.py
+++ b/libraries/botbuilder-ai/botbuilder/ai/qna/utils/http_request_utils.py
@@ -105,22 +105,6 @@ class HttpRequestUtils:
             self._http_client.__name__ == "requests"
         )
 
-    def _make_request_with_requests(
-        self, request_url: str, payload_body: str, headers: dict, timeout: float
-    ) -> requests.Response:
-        if timeout:
-            # requests' timeouts are in seconds
-            timeout_in_seconds = timeout / 1000
-
-            return self._http_client.post(
-                request_url,
-                data=payload_body,
-                headers=headers,
-                timeout=timeout_in_seconds,
-            )
-
-        return self._http_client.post(request_url, data=payload_body, headers=headers)
-
     async def _make_request_with_aiohttp(
         self, request_url: str, payload_body: str, headers: dict, timeout: float
     ) -> ClientResponse:
@@ -138,3 +122,19 @@ class HttpRequestUtils:
         return await self._http_client.post(
             request_url, data=payload_body, headers=headers
         )
+
+    def _make_request_with_requests(
+        self, request_url: str, payload_body: str, headers: dict, timeout: float
+    ) -> requests.Response:
+        if timeout:
+            # requests' timeouts are in seconds
+            timeout_in_seconds = timeout / 1000
+
+            return self._http_client.post(
+                request_url,
+                data=payload_body,
+                headers=headers,
+                timeout=timeout_in_seconds,
+            )
+
+        return self._http_client.post(request_url, data=payload_body, headers=headers)

--- a/libraries/botbuilder-ai/tests/qna/test_qna.py
+++ b/libraries/botbuilder-ai/tests/qna/test_qna.py
@@ -20,7 +20,8 @@ from botbuilder.ai.qna.models import (
     QueryResult,
     QnARequestContext,
 )
-from botbuilder.ai.qna.utils import QnATelemetryConstants
+from botbuilder.ai.qna.utils import HttpRequestUtils, QnATelemetryConstants
+from botbuilder.ai.qna.models import GenerateAnswerRequestBody
 from botbuilder.core import BotAdapter, BotTelemetryClient, TurnContext
 from botbuilder.core.adapters import TestAdapter
 from botbuilder.schema import (
@@ -164,7 +165,7 @@ class QnaApplicationTest(aiounittest.AsyncTestCase):
         self.assertIsNotNone(result)
         self.assertEqual(1, len(result.answers))
         self.assertFalse(result.active_learning_enabled)
-    
+
     async def test_returns_answer_using_requests_module(self):
         question: str = "how do I clean the stove?"
         response_path: str = "ReturnsAnswer.json"
@@ -275,6 +276,39 @@ class QnaApplicationTest(aiounittest.AsyncTestCase):
             self.assertEqual(
                 options.timeout, qna._generate_answer_helper.options.timeout
             )
+
+    async def test_returns_answer_using_requests_module_with_no_timeout(self):
+        url = f"{QnaApplicationTest._host}/knowledgebases/{QnaApplicationTest._knowledge_base_id}/generateAnswer"
+        question = GenerateAnswerRequestBody(
+            question="how do I clean the stove?",
+            top=1,
+            score_threshold=0.3,
+            strict_filters=[],
+            context=None,
+            qna_id=None,
+            is_test=False,
+            ranker_type="Default"
+        )
+        response_path = "ReturnsAnswer.json"
+        response_json = QnaApplicationTest._get_json_for_file(response_path)
+
+        http_request_helper = HttpRequestUtils(requests)
+
+        with patch("requests.post", return_value=response_json):
+            result = await http_request_helper.execute_http_request(
+                url,
+                question,
+                QnaApplicationTest.tests_endpoint,
+                timeout=None
+            )
+            answers = result["answers"]
+
+            self.assertIsNotNone(result)
+            self.assertEqual(1, len(answers))
+            self.assertEqual(
+                "BaseCamp: You can use a damp rag to clean around the Power Pack",
+                answers[0]["answer"],
+        )
 
     async def test_telemetry_returns_answer(self):
         # Arrange

--- a/libraries/botbuilder-ai/tests/qna/test_qna.py
+++ b/libraries/botbuilder-ai/tests/qna/test_qna.py
@@ -5,6 +5,7 @@
 # pylint: disable=too-many-lines
 
 import json
+import requests
 from os import path
 from typing import List, Dict
 import unittest
@@ -163,6 +164,27 @@ class QnaApplicationTest(aiounittest.AsyncTestCase):
         self.assertIsNotNone(result)
         self.assertEqual(1, len(result.answers))
         self.assertFalse(result.active_learning_enabled)
+    
+    async def test_returns_answer_using_requests_module(self):
+        question: str = "how do I clean the stove?"
+        response_path: str = "ReturnsAnswer.json"
+        response_json = QnaApplicationTest._get_json_for_file(response_path)
+
+        qna = QnAMaker(
+            endpoint=QnaApplicationTest.tests_endpoint, http_client=requests
+        )
+        context = QnaApplicationTest._get_context(question, TestAdapter())
+
+        with patch("requests.post", return_value=response_json):
+            result = await qna.get_answers_raw(context)
+            answers = result.answers
+
+            self.assertIsNotNone(result)
+            self.assertEqual(1, len(answers))
+            self.assertEqual(
+                "BaseCamp: You can use a damp rag to clean around the Power Pack",
+                answers[0].answer,
+        )
 
     async def test_returns_answer_using_options(self):
         # Arrange


### PR DESCRIPTION
Fixes #1187 

## Description
Properly allow requests to be made and consumed using  Python's built-in `requests` library.

This will allow the option to use an HTTP client that isn't from `aiohttp`, which may be a sought out option for frameworks that don't wrap their requests in a running "`ProactorEventLoop`" that's necessary for `aiohttp.ClientSession`'s to work.

For example, using the Quart 13.core-bot sample, it can properly call `QnAMaker` service with just the following
*app.py*
```python
import requests

QNAMAKER = QnAMaker(
    endpoint=QnAMakerEndpoint(
        knowledge_base_id=APP.config["QNA_KNOWLEDGEBASE_ID"],
        endpoint_key=APP.config["QNA_ENDPOINT_KEY"],
        host=APP.config["QNA_ENDPOINT_HOST"],
    ),
    http_client=requests
)
```

## Specific Changes

- Configures the request to `QnAMaker` to the proper shape for the given HTTP client, whether it be `aiohttp` or `requests`-based in `generate_answer_utils.py` and `http_request_utils.py`
- `HttpRequestUtils.execute_http_request` method return type goes from `aiohttp.ClientResponse` -> `Any`, given that different clients can be passed in to make requests, which return different shapes
- Open`QnAMaker._http_client` type from `aiohttp.ClientSession` to `Any`
   - Note: we *could* create an interface instead, I suppose, instead of "`Any`" type with the requirement that it needs to have a `post` method, however I'm not sure if this is necessary or not, given that most do (but who knows!)