### PR TITLE
Reference comment fixes

### DIFF
--- a/libraries/botbuilder-ai/botbuilder/ai/luis/luis_recognizer.py
+++ b/libraries/botbuilder-ai/botbuilder/ai/luis/luis_recognizer.py
@@ -80,7 +80,7 @@ class LuisRecognizer(Recognizer):
         :param default_intent: Intent name to return should a top intent be found, defaults to None.
         :type default_intent: str, optional
         :param min_score: Minimum score needed for an intent to be considered as a top intent. If all intents in
-        the set are below this threshold then the `defaultIntent` will be returned, defaults to 0.0.
+         the set are below this threshold then the `defaultIntent` will be returned, defaults to 0.0.
         :type min_score: float, optional
         :raises TypeError:
         :return: The top scoring intent name.
@@ -191,7 +191,7 @@ class LuisRecognizer(Recognizer):
          defaults to None
         :param telemetry_properties: :class:`typing.Dict[str, str]`, optional
         :return: A dictionary that is sent as "Properties" to :func:`botbuilder.core.BotTelemetryClient.track_event`
-        method for the BotMessageSend event.
+         method for the BotMessageSend event.
         :rtype: `typing.Dict[str, str]`
         """
 

--- a/libraries/botbuilder-ai/botbuilder/ai/qna/qnamaker.py
+++ b/libraries/botbuilder-ai/botbuilder/ai/qna/qnamaker.py
@@ -166,14 +166,16 @@ class QnAMaker(QnAMakerTelemetryClient):
         """
         Fills the event properties and metrics for the QnaMessage event for telemetry.
 
-        :return: A tuple of event data properties and metrics that will be sent to the
-        :func:`botbuilder.core.BotTelemetryClient.track_event` method for the QnAMessage event.
-        The properties and metrics returned the standard properties logged
-        with any properties passed from the :func:`get_answers` method.
+        :param query_results: QnA service results.
+        :type quert_results: :class:`QueryResult`
+        :param turn_context: Context object containing information for a single turn of conversation with a user.
+        :type turn_context: :class:`botbuilder.core.TurnContext`
+        :param telemetry_properties: Properties to add/override for the event.
+        :type telemetry_properties: :class:`Typing.Dict`
+        :param telemetry_metrics: Metrics to add/override for the event.
+        :type telemetry_metrics: :class:`Typing.Dict`
         :return: Event properties and metrics for the QnaMessage event for telemetry.
         :rtype: :class:`EventData`
-        ------
-        EventData
         """
 
         properties: Dict[str, str] = dict()


### PR DESCRIPTION
## Description
Fixes for malformed reference comments.

## Specific
- fixing incorrect RST and Markdown formatting 
- copy editing grammar, tone, and spelling

