### PR TITLE
Reference comment fixes

### DIFF
--- a/libraries/botbuilder-adapters-slack/botbuilder/adapters/slack/slack_adapter.py
+++ b/libraries/botbuilder-adapters-slack/botbuilder/adapters/slack/slack_adapter.py
@@ -24,8 +24,7 @@ from .slack_helper import SlackHelper
 
 class SlackAdapter(BotAdapter, ABC):
     """
-    BotAdapter that can handle incoming slack events.  Incoming slack events are deserialized to an Activity
-    that is dispatch through the middleware and bot pipeline.
+    BotAdapter that can handle incoming Slack events. Incoming Slack events are deserialized to an Activity that is dispatched through the middleware and bot pipeline.
     """
 
     def __init__(
@@ -41,11 +40,14 @@ class SlackAdapter(BotAdapter, ABC):
         self, context: TurnContext, activities: List[Activity]
     ) -> List[ResourceResponse]:
         """
-        Standard BotBuilder adapter method to send a message from the bot to the messaging API.
+        Send a message from the bot to the messaging API.
 
         :param context: A TurnContext representing the current incoming message and environment.
+        :type context: :class:`botbuilder.core.TurnContext`
         :param activities: An array of outgoing activities to be sent back to the messaging API.
+        :type activities: :class:`typing.List`
         :return: An array of ResourceResponse objects containing the IDs that Slack assigned to the sent messages.
+        :rtype: :class:`typing.List`
         """
 
         if not context:
@@ -76,11 +78,14 @@ class SlackAdapter(BotAdapter, ABC):
 
     async def update_activity(self, context: TurnContext, activity: Activity):
         """
-        Standard BotBuilder adapter method to update a previous message with new content.
+        Update a previous message with new content.
 
         :param context: A TurnContext representing the current incoming message and environment.
+        :type context: :class:`botbuilder.core.TurnContext`
         :param activity: The updated activity in the form '{id: `id of activity to update`, ...}'.
-        :return: A resource response with the Id of the updated activity.
+        :type activity: :class:`botbuilder.schema.Activity`
+        :return: A resource response with the ID of the updated activity.
+        :rtype: :class:`botbuilder.schema.ResourceResponse`
         """
 
         if not context:
@@ -106,11 +111,13 @@ class SlackAdapter(BotAdapter, ABC):
         self, context: TurnContext, reference: ConversationReference
     ):
         """
-        Standard BotBuilder adapter method to delete a previous message.
+        Delete a previous message.
 
         :param context: A TurnContext representing the current incoming message and environment.
+        :type context: :class:`botbuilder.core.TurnContext`
         :param reference: An object in the form "{activityId: `id of message to delete`,
-        conversation: { id: `id of slack channel`}}".
+         conversation: { id: `id of Slack channel`}}".
+        :type reference: :class:`botbuilder.schema.ConversationReference`
         """
 
         if not context:
@@ -135,15 +142,22 @@ class SlackAdapter(BotAdapter, ABC):
         audience: str = None,
     ):
         """
-        Sends a proactive message to a conversation. Call this method to proactively send a message to a conversation.
-        Most _channels require a user to initiate a conversation with a bot before the bot can send activities
-        to the user.
+        Send a proactive message to a conversation.
+        
+        .. remarks::
+        
+            Most channels require a user to initiate a conversation with a bot before the bot can send activities to the user.
 
-        :param bot_id: Unused for this override.
         :param reference: A reference to the conversation to continue.
+        :type reference: :class:`botbuilder.schema.ConversationReference`
         :param callback: The method to call for the resulting bot turn.
+        :type callback: :class:`typing.Callable`
+        :param bot_id: Unused for this override.
+        :type bot_id: str
         :param claims_identity: A ClaimsIdentity for the conversation.
+        :type claims_identity: :class:`botframework.connector.auth.ClaimsIdentity`
         :param audience: Unused for this override.
+        :type audience: str
         """
 
         if not reference:
@@ -171,10 +185,14 @@ class SlackAdapter(BotAdapter, ABC):
         """
         Accept an incoming webhook request and convert it into a TurnContext which can be processed by the bot's logic.
 
-        :param req: The aoihttp Request object
+        :param req: The aiohttp Request object.
+        :type req: :class:`aiohttp.web_request.Request`
         :param logic: The method to call for the resulting bot turn.
-        :return: The aoihttp Response
+        :type logic: :class:`typing.List`
+        :return: The aiohttp Response. 
+        :rtype: :class:`aiohttp.web_response.Response`
         """
+
         if not req:
             raise Exception("Request is required")
 

--- a/libraries/botbuilder-adapters-slack/botbuilder/adapters/slack/slack_adapter.py
+++ b/libraries/botbuilder-adapters-slack/botbuilder/adapters/slack/slack_adapter.py
@@ -188,7 +188,7 @@ class SlackAdapter(BotAdapter, ABC):
         :param req: The aiohttp Request object.
         :type req: :class:`aiohttp.web_request.Request`
         :param logic: The method to call for the resulting bot turn.
-        :type logic: :class:`Callable`
+        :type logic: :class:`tying.Callable`
         :return: The aiohttp Response. 
         :rtype: :class:`aiohttp.web_response.Response`
         """

--- a/libraries/botbuilder-adapters-slack/botbuilder/adapters/slack/slack_adapter.py
+++ b/libraries/botbuilder-adapters-slack/botbuilder/adapters/slack/slack_adapter.py
@@ -115,8 +115,7 @@ class SlackAdapter(BotAdapter, ABC):
 
         :param context: A TurnContext representing the current incoming message and environment.
         :type context: :class:`botbuilder.core.TurnContext`
-        :param reference: An object in the form "{activityId: `id of message to delete`,
-         conversation: { id: `id of Slack channel`}}".
+        :param reference: An object in the form "{activityId: `id of message to delete`,conversation: { id: `id of Slack channel`}}".
         :type reference: :class:`botbuilder.schema.ConversationReference`
         """
 

--- a/libraries/botbuilder-adapters-slack/botbuilder/adapters/slack/slack_adapter.py
+++ b/libraries/botbuilder-adapters-slack/botbuilder/adapters/slack/slack_adapter.py
@@ -45,9 +45,9 @@ class SlackAdapter(BotAdapter, ABC):
         :param context: A TurnContext representing the current incoming message and environment.
         :type context: :class:`botbuilder.core.TurnContext`
         :param activities: An array of outgoing activities to be sent back to the messaging API.
-        :type activities: :class:`typing.List`
+        :type activities: :class:`typing.List[Activity]`
         :return: An array of ResourceResponse objects containing the IDs that Slack assigned to the sent messages.
-        :rtype: :class:`typing.List`
+        :rtype: :class:`typing.List[ResourceResponse]`
         """
 
         if not context:
@@ -188,7 +188,7 @@ class SlackAdapter(BotAdapter, ABC):
         :param req: The aiohttp Request object.
         :type req: :class:`aiohttp.web_request.Request`
         :param logic: The method to call for the resulting bot turn.
-        :type logic: :class:`typing.List`
+        :type logic: :class:`Callable`
         :return: The aiohttp Response. 
         :rtype: :class:`aiohttp.web_response.Response`
         """

--- a/libraries/botbuilder-adapters-slack/botbuilder/adapters/slack/slack_helper.py
+++ b/libraries/botbuilder-adapters-slack/botbuilder/adapters/slack/slack_helper.py
@@ -27,10 +27,12 @@ class SlackHelper:
     @staticmethod
     def activity_to_slack(activity: Activity) -> SlackMessage:
         """
-        Formats a BotBuilder activity into an outgoing Slack message.
+        Formats a BotBuilder Activity into an outgoing Slack message.
+        
         :param activity: A BotBuilder Activity object.
-        :return: A Slack message object with {text, attachments, channel, thread ts} as well
-        as any fields found in activity.channelData
+        :type activity: :class:`botbuilder.schema.Activity`
+        :return: A Slack message object with {text, attachments, channel, thread ts} and any fields found in activity.channelData.
+        :rtype: :class:`SlackMessage`
         """
 
         if not activity:
@@ -83,13 +85,18 @@ class SlackHelper:
         req: Request, code: int, text: str = None, encoding: str = None
     ) -> Response:
         """
-        Formats an aiohttp Response
+        Formats an aiohttp Response.
 
-        :param req: The original aoihttp Request
-        :param code: The HTTP result code to return
-        :param text: The text to return
-        :param encoding: The text encoding.  Defaults to utf-8
+        :param req: The original aiohttp Request.
+        :type req: :class:`aiohttp.web_request.Request`
+        :param code: The HTTP result code to return.
+        :type code: int
+        :param text: The text to return.
+        :type text: str
+        :param encoding: The text encoding. Defaults to UTF-8.
+        :type encoding: str
         :return: The aoihttp Response
+        :rtype: :class:`aiohttp.web_response.Response`
         """
 
         response = Response(status=code)
@@ -103,10 +110,12 @@ class SlackHelper:
     @staticmethod
     def payload_to_activity(payload: SlackPayload) -> Activity:
         """
-        Creates an activity based on the slack event payload.
+        Creates an activity based on the Slack event payload.
 
-        :param payload: The payload of the slack event.
+        :param payload: The payload of the Slack event.
+        :type payload: :class:`SlackPayload`
         :return: An activity containing the event data.
+        :rtype: :class:`botbuilder.schema.Activity`
         """
 
         if not payload:
@@ -138,11 +147,14 @@ class SlackHelper:
     @staticmethod
     async def event_to_activity(event: SlackEvent, client: SlackClient) -> Activity:
         """
-        Creates an activity based on the slack event data.
+        Creates an activity based on the Slack event data.
 
-        :param event: The data of the slack event.
+        :param event: The data of the Slack event.
+        :type event: :class:`SlackEvent`
         :param client: The Slack client.
+        :type client: :class:`SlackClient`
         :return: An activity containing the event data.
+        :rtype: :class:`botbuilder.schema.Activity`
         """
 
         if not event:
@@ -191,11 +203,14 @@ class SlackHelper:
         body: SlackRequestBody, client: SlackClient
     ) -> Activity:
         """
-        Creates an activity based on a slack event related to a slash command.
+        Creates an activity based on a Slack event related to a slash command.
 
-        :param body: The data of the slack event.
+        :param body: The data of the Slack event.
+        :type body: :class:`SlackRequestBody`
         :param client: The Slack client.
+        :type client: :class:`SlackClient`
         :return: An activity containing the event data.
+        :rtype: :class:`botbuilder.schema.Activity`
         """
 
         if not body:
@@ -223,7 +238,9 @@ class SlackHelper:
         Converts a query string to a dictionary with key-value pairs.
 
         :param query: The query string to convert.
+        :type query: str
         :return: A dictionary with the query values.
+        :rtype: :class:`typing.Dict`
         """
 
         values = {}
@@ -247,9 +264,12 @@ class SlackHelper:
         """
         Deserializes the request's body as a SlackRequestBody object.
 
-        :param content_type: The content type of the body
-        :param request_body: The body of the request
-        :return: A SlackRequestBody object
+        :param content_type: The content type of the body.
+        :type content_type: str
+        :param request_body: The body of the request.
+        :type request_body: str
+        :return: A SlackRequestBody object.
+        :rtype: :class:`SlackRequestBody`
         """
 
         if not request_body:

--- a/libraries/botbuilder-adapters-slack/botbuilder/adapters/slack/slack_options.py
+++ b/libraries/botbuilder-adapters-slack/botbuilder/adapters/slack/slack_options.py
@@ -4,7 +4,7 @@
 
 class SlackAdapterOptions:
     """
-    Class for defining implementation of the SlackAdapter Options.
+    Defines the implementation of the SlackAdapter options.
     """
 
     def __init__(
@@ -14,10 +14,14 @@ class SlackAdapterOptions:
         slack_client_signing_secret: str,
     ):
         """
-        Initializes new instance of SlackAdapterOptions
+        Initializes a new instance of SlackAdapterOptions.
+        
         :param slack_verification_token: A token for validating the origin of incoming webhooks.
+        :type slack_verification_token: str
         :param slack_bot_token: A token for a bot to work on a single workspace.
-        :param slack_client_signing_secret: The token used to validate that incoming webhooks are originated from Slack.
+        :type slack_bot_token: str
+        :param slack_client_signing_secret: The token used to validate that incoming webhooks originated from Slack.
+        :type slack_client_signing_secret: str
         """
         self.slack_verification_token = slack_verification_token
         self.slack_bot_token = slack_bot_token
@@ -29,18 +33,20 @@ class SlackAdapterOptions:
 
     async def get_token_for_team(self, team_id: str) -> str:
         """
-        A method that receives a Slack team id and returns the bot token associated with that team. Required for
-        multi-team apps.
-        :param team_id:Team ID.
-        :return:The bot token associated with the team.
+        Receives a Slack team ID and returns the bot token associated with that team. Required for multi-team apps.
+        
+        :param team_id: The team ID.
+        :type team_id: str
+        :raises: :func:`NotImplementedError`
         """
         raise NotImplementedError()
 
     async def get_bot_user_by_team(self, team_id: str) -> str:
         """
-        A method that receives a Slack team id and returns the bot user id associated with that team. Required for
-        multi-team apps.
-        :param team_id:Team ID.
-        :return:The bot user id associated with that team.
+        A method that receives a Slack team ID and returns the bot user ID associated with that team. Required for multi-team apps.
+        
+        :param team_id: The team ID.
+        :type team_id: str
+        :raises: :func:`NotImplementedError`
         """
         raise NotImplementedError()

--- a/libraries/botbuilder-ai/botbuilder/ai/luis/luis_recognizer.py
+++ b/libraries/botbuilder-ai/botbuilder/ai/luis/luis_recognizer.py
@@ -80,7 +80,7 @@ class LuisRecognizer(Recognizer):
         :param default_intent: Intent name to return should a top intent be found, defaults to None.
         :type default_intent: str, optional
         :param min_score: Minimum score needed for an intent to be considered as a top intent. If all intents in
-        the set are below this threshold then the `defaultIntent` will be returned, defaults to 0.0.
+         the set are below this threshold then the `defaultIntent` will be returned, defaults to 0.0.
         :type min_score: float, optional
         :raises TypeError:
         :return: The top scoring intent name.
@@ -191,7 +191,7 @@ class LuisRecognizer(Recognizer):
          defaults to None
         :param telemetry_properties: :class:`typing.Dict[str, str]`, optional
         :return: A dictionary that is sent as "Properties" to :func:`botbuilder.core.BotTelemetryClient.track_event`
-        method for the BotMessageSend event.
+         method for the BotMessageSend event.
         :rtype: `typing.Dict[str, str]`
         """
 

--- a/libraries/botbuilder-ai/botbuilder/ai/luis/luis_recognizer.py
+++ b/libraries/botbuilder-ai/botbuilder/ai/luis/luis_recognizer.py
@@ -79,10 +79,9 @@ class LuisRecognizer(Recognizer):
         :type results: :class:`botbuilder.core.RecognizerResult`
         :param default_intent: Intent name to return should a top intent be found, defaults to None.
         :type default_intent: str, optional
-        :param min_score: Minimum score needed for an intent to be considered as a top intent. If all 
-         intents in the set are below this threshold then the `defaultIntent` is returned, defaults to 0.0.
+        :param min_score: Minimum score needed for an intent to be considered as a top intent. If all intents in the set are below this threshold then the `defaultIntent` is returned, defaults to 0.0.
         :type min_score: float, optional
-        :raises:  TypeError
+        :raises: TypeError
         :return: The top scoring intent name.
         :rtype: str
         """

--- a/libraries/botbuilder-ai/botbuilder/ai/luis/luis_recognizer.py
+++ b/libraries/botbuilder-ai/botbuilder/ai/luis/luis_recognizer.py
@@ -20,7 +20,7 @@ from .luis_recognizer_options_v3 import LuisRecognizerOptionsV3
 
 class LuisRecognizer(Recognizer):
     """
-    A LUIS based implementation of <see cref="IRecognizer"/>.
+    A LUIS based implementation of :class:`botbuilder.core.Recognizer`.
     """
 
     # The value type for a LUIS trace activity.
@@ -45,7 +45,7 @@ class LuisRecognizer(Recognizer):
         :type prediction_options: :class:`LuisPredictionOptions`, optional
         :param include_api_results: True to include raw LUIS API response, defaults to False.
         :type include_api_results: bool, optional
-        :raises TypeError:
+        :raises: TypeError
         """
 
         if isinstance(application, LuisApplication):
@@ -79,10 +79,10 @@ class LuisRecognizer(Recognizer):
         :type results: :class:`botbuilder.core.RecognizerResult`
         :param default_intent: Intent name to return should a top intent be found, defaults to None.
         :type default_intent: str, optional
-        :param min_score: Minimum score needed for an intent to be considered as a top intent. If all intents in
-         the set are below this threshold then the `defaultIntent` will be returned, defaults to 0.0.
+        :param min_score: Minimum score needed for an intent to be considered as a top intent. If all 
+         intents in the set are below this threshold then the `defaultIntent` is returned, defaults to 0.0.
         :type min_score: float, optional
-        :raises TypeError:
+        :raises:  TypeError
         :return: The top scoring intent name.
         :rtype: str
         """
@@ -108,9 +108,9 @@ class LuisRecognizer(Recognizer):
         telemetry_metrics: Dict[str, float] = None,
         luis_prediction_options: LuisPredictionOptions = None,
     ) -> RecognizerResult:
-        """Return results of the analysis (Suggested actions and intents).
+        """Return results of the analysis (suggested actions and intents).
 
-        :param turn_context: Context object containing information for a single turn of conversation with a user.
+        :param turn_context: Context object containing information for a single conversation turn with a user.
         :type turn_context: :class:`botbuilder.core.TurnContext`
         :param telemetry_properties: Additional properties to be logged to telemetry with the LuisResult event, defaults
          to None.
@@ -138,7 +138,7 @@ class LuisRecognizer(Recognizer):
     ):
         """Invoked prior to a LuisResult being logged.
 
-        :param recognizer_result: The Luis Results for the call.
+        :param recognizer_result: The LuisResult for the call.
         :type recognizer_result: :class:`botbuilder.core.RecognizerResult`
         :param turn_context: Context object containing information for a single turn of conversation with a user.
         :type turn_context: :class:`botbuilder.core.TurnContext`
@@ -187,11 +187,9 @@ class LuisRecognizer(Recognizer):
         :type recognizer_result: :class:`botbuilder.core.RecognizerResult`
         :param turn_context: Context object containing information for a single turn of conversation with a user.
         :type turn_context: :class:`botbuilder.core.TurnContext`
-        :param telemetry_properties: Additional properties to be logged to telemetry with the LuisResult event,
-         defaults to None
-        :param telemetry_properties: :class:`typing.Dict[str, str]`, optional
-        :return: A dictionary that is sent as "Properties" to :func:`botbuilder.core.BotTelemetryClient.track_event`
-         method for the BotMessageSend event.
+        :param telemetry_properties: Additional properties to be logged to telemetry with the LuisResult event, defaults to None.
+        :type telemetry_properties: :class:`typing.Dict[str, str]`, optional
+        :return: A dictionary sent as "Properties" to :func:`botbuilder.core.BotTelemetryClient.track_event` for the BotMessageSend event.
         :rtype: `typing.Dict[str, str]`
         """
 

--- a/libraries/botbuilder-ai/botbuilder/ai/qna/qnamaker.py
+++ b/libraries/botbuilder-ai/botbuilder/ai/qna/qnamaker.py
@@ -166,14 +166,16 @@ class QnAMaker(QnAMakerTelemetryClient):
         """
         Fills the event properties and metrics for the QnaMessage event for telemetry.
 
-        :return: A tuple of event data properties and metrics that will be sent to the
-        :func:`botbuilder.core.BotTelemetryClient.track_event` method for the QnAMessage event.
-        The properties and metrics returned the standard properties logged
-        with any properties passed from the :func:`get_answers` method.
+        :param query_results: QnA service results.
+        :type quert_results: :class:`QueryResult`
+        :param turn_context: Context object containing information for a single turn of conversation with a user.
+        :type turn_context: :class:`botbuilder.core.TurnContext`
+        :param telemetry_properties: Properties to add/override for the event.
+        :type telemetry_properties: :class:`Typing.Dict`
+        :param telemetry_metrics: Metrics to add/override for the event.
+        :type telemetry_metrics: :class:`Typing.Dict`
         :return: Event properties and metrics for the QnaMessage event for telemetry.
         :rtype: :class:`EventData`
-        ------
-        EventData
         """
 
         properties: Dict[str, str] = dict()

--- a/libraries/botbuilder-ai/botbuilder/ai/qna/qnamaker.py
+++ b/libraries/botbuilder-ai/botbuilder/ai/qna/qnamaker.py
@@ -126,6 +126,7 @@ class QnAMaker(QnAMakerTelemetryClient):
         :param query_result: User query output.
         :type query_result: :class:`QueryResult`
         :return: Filtered array of ambiguous questions.
+        :rtype: :class:`typing.List[QueryResult]`
         """
         return ActiveLearningUtils.get_low_score_variation(query_result)
 
@@ -171,9 +172,9 @@ class QnAMaker(QnAMakerTelemetryClient):
         :param turn_context: Context object containing information for a single turn of conversation with a user.
         :type turn_context: :class:`botbuilder.core.TurnContext`
         :param telemetry_properties: Properties to add/override for the event.
-        :type telemetry_properties: :class:`Typing.Dict`
+        :type telemetry_properties: :class:`typing.Dict[str, str]`
         :param telemetry_metrics: Metrics to add/override for the event.
-        :type telemetry_metrics: :class:`Typing.Dict`
+        :type telemetry_metrics: :class:`typing.Dict[str, float]`
         :return: Event properties and metrics for the QnaMessage event for telemetry.
         :rtype: :class:`EventData`
         """

--- a/libraries/botbuilder-applicationinsights/botbuilder/applicationinsights/application_insights_telemetry_client.py
+++ b/libraries/botbuilder-applicationinsights/botbuilder/applicationinsights/application_insights_telemetry_client.py
@@ -68,13 +68,19 @@ class ApplicationInsightsTelemetryClient(BotTelemetryClient):
     ) -> None:
         """
         Send information about the page viewed in the application (a web page for instance).
+        
         :param name: the name of the page that was viewed.
+        :type name: str
         :param url: the URL of the page that was viewed.
+        :type url: str
         :param duration: the duration of the page view in milliseconds. (defaults to: 0)
+        :duration: int
         :param properties: the set of custom properties the client wants attached to this data item.
          (defaults to: None)
+        :type properties: :class:`typing.Dict[str, object]`
         :param measurements: the set of custom measurements the client wants to attach to this data item.
          (defaults to: None)
+        :type measurements: :class:`typing.Dict[str, object]`
         """
         self._client.track_pageview(name, url, duration, properties, measurements)
 
@@ -88,13 +94,16 @@ class ApplicationInsightsTelemetryClient(BotTelemetryClient):
     ) -> None:
         """
         Send information about a single exception that occurred in the application.
+        
         :param exception_type: the type of the exception that was thrown.
         :param value: the exception that the client wants to send.
         :param trace: the traceback information as returned by :func:`sys.exc_info`.
         :param properties: the set of custom properties the client wants attached to this data item.
          (defaults to: None)
+        :type properties: :class:`typing.Dict[str, object]`
         :param measurements: the set of custom measurements the client wants to attach to this data item.
          (defaults to: None)
+        :type measurements: :class:`typing.Dict[str, object]`
         """
         self._client.track_exception(
             exception_type, value, trace, properties, measurements
@@ -108,11 +117,15 @@ class ApplicationInsightsTelemetryClient(BotTelemetryClient):
     ) -> None:
         """
         Send information about a single event that has occurred in the context of the application.
+        
         :param name: the data to associate to this event.
+        :type name: str
         :param properties: the set of custom properties the client wants attached to this data item.
          (defaults to: None)
+        :type properties: :class:`typing.Dict[str, object]`
         :param measurements: the set of custom measurements the client wants to attach to this data item.
          (defaults to: None)
+        :type measurements: :class:`typing.Dict[str, object]`
         """
         self._client.track_event(name, properties=properties, measurements=measurements)
 
@@ -129,19 +142,27 @@ class ApplicationInsightsTelemetryClient(BotTelemetryClient):
     ) -> NotImplemented:
         """
         Send information about a single metric data point that was captured for the application.
+        
         :param name: The name of the metric that was captured.
+        :type name: str
         :param value: The value of the metric that was captured.
+        :type value: float
         :param tel_type: The type of the metric. (defaults to: TelemetryDataPointType.aggregation`)
         :param count: the number of metrics that were aggregated into this data point. (defaults to: None)
+        :type count: int
         :param min_val: the minimum of all metrics collected that were aggregated into this data point.
          (defaults to: None)
+        :type min_val: float
         :param max_val: the maximum of all metrics collected that were aggregated into this data point.
          (defaults to: None)
+        :type max_val: float
         :param std_dev: the standard deviation of all metrics collected that were aggregated into this data point.
          (defaults to: None)
+        :type std_dev: float
         :param properties: the set of custom properties the client wants attached to this data item.
          (defaults to: None)
-        """
+        :type properties: :class:`typing.Dict[str, object]`
+        """ 
         self._client.track_metric(
             name, value, tel_type, count, min_val, max_val, std_dev, properties
         )
@@ -151,8 +172,11 @@ class ApplicationInsightsTelemetryClient(BotTelemetryClient):
     ):
         """
         Sends a single trace statement.
+        
         :param name: the trace statement.
+        :type name: str
         :param properties: the set of custom properties the client wants attached to this data item. (defaults to: None)
+        :type properties: :class:`typing.Dict[str, object]`
         :param severity: the severity level of this trace, one of DEBUG, INFO, WARNING, ERROR, CRITICAL
         """
         self._client.track_trace(name, properties, severity)
@@ -172,19 +196,30 @@ class ApplicationInsightsTelemetryClient(BotTelemetryClient):
     ):
         """
         Sends a single request that was captured for the application.
+        
         :param name: The name for this request. All requests with the same name will be grouped together.
+        :type name: str
         :param url: The actual URL for this request (to show in individual request instances).
+        :type url: str
         :param success: True if the request ended in success, False otherwise.
+        :type success: bool
         :param start_time: the start time of the request. The value should look the same as the one returned by
          :func:`datetime.isoformat`. (defaults to: None)
+        :type start_time: str
         :param duration: the number of milliseconds that this request lasted. (defaults to: None)
+        :type duration: int
         :param response_code: the response code that this request returned. (defaults to: None)
+        :type response_code: str
         :param http_method: the HTTP method that triggered this request. (defaults to: None)
+        :type http_method: str
         :param properties: the set of custom properties the client wants attached to this data item.
          (defaults to: None)
+        :type properties: :class:`typing.Dict[str, object]`
         :param measurements: the set of custom measurements the client wants to attach to this data item.
          (defaults to: None)
+        :type measurements: :class:`typing.Dict[str, object]`
         :param request_id: the id for this request. If None, a new uuid will be generated. (defaults to: None)
+        :type request_id: str
         """
         self._client.track_request(
             name,
@@ -214,25 +249,33 @@ class ApplicationInsightsTelemetryClient(BotTelemetryClient):
     ):
         """
         Sends a single dependency telemetry that was captured for the application.
+        
         :param name: the name of the command initiated with this dependency call. Low cardinality value.
          Examples are stored procedure name and URL path template.
+        :type name: str
         :param data: the command initiated by this dependency call.
+        :type data: str
          Examples are SQL statement and HTTP URL with all query parameters.
         :param type_name: the dependency type name. Low cardinality value for logical grouping of dependencies and
          interpretation of other fields like commandName and resultCode. Examples are SQL, Azure table, and HTTP.
-          (default to: None)
-        :param target: the target site of a dependency call. Examples are server name, host address.
          (default to: None)
-        :param duration: the number of milliseconds that this dependency call lasted.
-         (defaults to: None)
-        :param success: true if the dependency call ended in success, false otherwise.
-         (defaults to: None)
+        :type type_name: str
+        :param target: the target site of a dependency call. Examples are server name, host address. (default to: None)
+        :type target: str
+        :param duration: the number of milliseconds that this dependency call lasted. (defaults to: None)
+        :type duration: int
+        :param success: true if the dependency call ended in success, false otherwise. (defaults to: None)
+        :type success: bool
         :param result_code: the result code of a dependency call. Examples are SQL error code and HTTP status code.
          (defaults to: None)
+        :type result_code: str
         :param properties: the set of custom properties the client wants attached to this data item. (defaults to: None)
+        :type properties: :class:`typing.Dict[str, object]`
         :param measurements: the set of custom measurements the client wants to attach to this data item.
          (defaults to: None)
-        :param id: the id for this dependency call. If None, a new uuid will be generated. (defaults to: None)
+        :type measurements: :class:`typing.Dict[str, object]`
+        :param dependency_id: the id for this dependency call. If None, a new uuid will be generated. (defaults to: None)
+        :type dependency_id: str 
         """
         self._client.track_dependency(
             name,

--- a/libraries/botbuilder-applicationinsights/botbuilder/applicationinsights/application_insights_telemetry_client.py
+++ b/libraries/botbuilder-applicationinsights/botbuilder/applicationinsights/application_insights_telemetry_client.py
@@ -75,11 +75,9 @@ class ApplicationInsightsTelemetryClient(BotTelemetryClient):
         :type url: str
         :param duration: the duration of the page view in milliseconds. (defaults to: 0)
         :duration: int
-        :param properties: the set of custom properties the client wants attached to this data item.
-         (defaults to: None)
+        :param properties: the set of custom properties the client wants attached to this data item. (defaults to: None)
         :type properties: :class:`typing.Dict[str, object]`
-        :param measurements: the set of custom measurements the client wants to attach to this data item.
-         (defaults to: None)
+        :param measurements: the set of custom measurements the client wants to attach to this data item. (defaults to: None)
         :type measurements: :class:`typing.Dict[str, object]`
         """
         self._client.track_pageview(name, url, duration, properties, measurements)
@@ -98,11 +96,9 @@ class ApplicationInsightsTelemetryClient(BotTelemetryClient):
         :param exception_type: the type of the exception that was thrown.
         :param value: the exception that the client wants to send.
         :param trace: the traceback information as returned by :func:`sys.exc_info`.
-        :param properties: the set of custom properties the client wants attached to this data item.
-         (defaults to: None)
+        :param properties: the set of custom properties the client wants attached to this data item. (defaults to: None)
         :type properties: :class:`typing.Dict[str, object]`
-        :param measurements: the set of custom measurements the client wants to attach to this data item.
-         (defaults to: None)
+        :param measurements: the set of custom measurements the client wants to attach to this data item. (defaults to: None)
         :type measurements: :class:`typing.Dict[str, object]`
         """
         self._client.track_exception(
@@ -120,11 +116,9 @@ class ApplicationInsightsTelemetryClient(BotTelemetryClient):
         
         :param name: the data to associate to this event.
         :type name: str
-        :param properties: the set of custom properties the client wants attached to this data item.
-         (defaults to: None)
+        :param properties: the set of custom properties the client wants attached to this data item. (defaults to: None)
         :type properties: :class:`typing.Dict[str, object]`
-        :param measurements: the set of custom measurements the client wants to attach to this data item.
-         (defaults to: None)
+        :param measurements: the set of custom measurements the client wants to attach to this data item. (defaults to: None)
         :type measurements: :class:`typing.Dict[str, object]`
         """
         self._client.track_event(name, properties=properties, measurements=measurements)
@@ -150,17 +144,13 @@ class ApplicationInsightsTelemetryClient(BotTelemetryClient):
         :param tel_type: The type of the metric. (defaults to: TelemetryDataPointType.aggregation`)
         :param count: the number of metrics that were aggregated into this data point. (defaults to: None)
         :type count: int
-        :param min_val: the minimum of all metrics collected that were aggregated into this data point.
-         (defaults to: None)
+        :param min_val: the minimum of all metrics collected that were aggregated into this data point. (defaults to: None)
         :type min_val: float
-        :param max_val: the maximum of all metrics collected that were aggregated into this data point.
-         (defaults to: None)
+        :param max_val: the maximum of all metrics collected that were aggregated into this data point. (defaults to: None)
         :type max_val: float
-        :param std_dev: the standard deviation of all metrics collected that were aggregated into this data point.
-         (defaults to: None)
+        :param std_dev: the standard deviation of all metrics collected that were aggregated into this data point. (defaults to: None)
         :type std_dev: float
-        :param properties: the set of custom properties the client wants attached to this data item.
-         (defaults to: None)
+        :param properties: the set of custom properties the client wants attached to this data item. (defaults to: None)
         :type properties: :class:`typing.Dict[str, object]`
         """ 
         self._client.track_metric(
@@ -203,8 +193,7 @@ class ApplicationInsightsTelemetryClient(BotTelemetryClient):
         :type url: str
         :param success: True if the request ended in success, False otherwise.
         :type success: bool
-        :param start_time: the start time of the request. The value should look the same as the one returned by
-         :func:`datetime.isoformat`. (defaults to: None)
+        :param start_time: the start time of the request. The value should look the same as the one returned by :func:`datetime.isoformat`. (defaults to: None)
         :type start_time: str
         :param duration: the number of milliseconds that this request lasted. (defaults to: None)
         :type duration: int
@@ -212,11 +201,9 @@ class ApplicationInsightsTelemetryClient(BotTelemetryClient):
         :type response_code: str
         :param http_method: the HTTP method that triggered this request. (defaults to: None)
         :type http_method: str
-        :param properties: the set of custom properties the client wants attached to this data item.
-         (defaults to: None)
+        :param properties: the set of custom properties the client wants attached to this data item. (defaults to: None)
         :type properties: :class:`typing.Dict[str, object]`
-        :param measurements: the set of custom measurements the client wants to attach to this data item.
-         (defaults to: None)
+        :param measurements: the set of custom measurements the client wants to attach to this data item. (defaults to: None)
         :type measurements: :class:`typing.Dict[str, object]`
         :param request_id: the id for this request. If None, a new uuid will be generated. (defaults to: None)
         :type request_id: str
@@ -253,12 +240,9 @@ class ApplicationInsightsTelemetryClient(BotTelemetryClient):
         :param name: the name of the command initiated with this dependency call. Low cardinality value.
          Examples are stored procedure name and URL path template.
         :type name: str
-        :param data: the command initiated by this dependency call.
+        :param data: the command initiated by this dependency call. Examples are SQL statement and HTTP URL with all query parameters.
         :type data: str
-         Examples are SQL statement and HTTP URL with all query parameters.
-        :param type_name: the dependency type name. Low cardinality value for logical grouping of dependencies and
-         interpretation of other fields like commandName and resultCode. Examples are SQL, Azure table, and HTTP.
-         (default to: None)
+        :param type_name: the dependency type name. Low cardinality value for logical grouping of dependencies and interpretation of other fields like commandName and resultCode. Examples are SQL, Azure table, and HTTP. (default to: None)
         :type type_name: str
         :param target: the target site of a dependency call. Examples are server name, host address. (default to: None)
         :type target: str
@@ -266,13 +250,11 @@ class ApplicationInsightsTelemetryClient(BotTelemetryClient):
         :type duration: int
         :param success: true if the dependency call ended in success, false otherwise. (defaults to: None)
         :type success: bool
-        :param result_code: the result code of a dependency call. Examples are SQL error code and HTTP status code.
-         (defaults to: None)
+        :param result_code: the result code of a dependency call. Examples are SQL error code and HTTP status code. (defaults to: None)
         :type result_code: str
         :param properties: the set of custom properties the client wants attached to this data item. (defaults to: None)
         :type properties: :class:`typing.Dict[str, object]`
-        :param measurements: the set of custom measurements the client wants to attach to this data item.
-         (defaults to: None)
+        :param measurements: the set of custom measurements the client wants to attach to this data item. (defaults to: None)
         :type measurements: :class:`typing.Dict[str, object]`
         :param dependency_id: the id for this dependency call. If None, a new uuid will be generated. (defaults to: None)
         :type dependency_id: str 

--- a/libraries/botbuilder-applicationinsights/botbuilder/applicationinsights/django/bot_telemetry_middleware.py
+++ b/libraries/botbuilder-applicationinsights/botbuilder/applicationinsights/django/bot_telemetry_middleware.py
@@ -13,7 +13,7 @@ def retrieve_bot_body():
     """ 
     Retrieve the POST body text from temporary cache.
     
-    The POST body corresponds to the thread ID and should reside in cache just for the lifetime of a request.
+    The POST body corresponds to the thread ID and must reside in the cache just for the lifetime of the request.
     """
 
     result = _REQUEST_BODIES.get(current_thread().ident, None)

--- a/libraries/botbuilder-applicationinsights/botbuilder/applicationinsights/django/bot_telemetry_middleware.py
+++ b/libraries/botbuilder-applicationinsights/botbuilder/applicationinsights/django/bot_telemetry_middleware.py
@@ -10,10 +10,10 @@ _REQUEST_BODIES = {}
 
 
 def retrieve_bot_body():
-    """ retrieve_bot_body
+    """ 
     Retrieve the POST body text from temporary cache.
-    The POST body corresponds with the thread id and should resides in
-    cache just for lifetime of request.
+    
+    The POST body corresponds to the thread ID and should reside in cache just for the lifetime of a request.
     """
 
     result = _REQUEST_BODIES.get(current_thread().ident, None)
@@ -22,15 +22,17 @@ def retrieve_bot_body():
 
 class BotTelemetryMiddleware:
     """
-    Save off the POST body to later populate bot-specific properties to
-    add to Application Insights.
+    Save off the POST body to later populate bot-specific properties to add to Application Insights.
 
     Example activating MIDDLEWARE in Django settings:
-    MIDDLEWARE = [
-        # Ideally add somewhere near top
-        'botbuilder.applicationinsights.django.BotTelemetryMiddleware',
-        ...
-        ]
+    
+    .. code-block:: python
+    
+        MIDDLEWARE = [
+            # Ideally add somewhere near top
+            'botbuilder.applicationinsights.django.BotTelemetryMiddleware',
+            ...
+            ]
     """
 
     def __init__(self, get_response):

--- a/libraries/botbuilder-applicationinsights/botbuilder/applicationinsights/django/logging.py
+++ b/libraries/botbuilder-applicationinsights/botbuilder/applicationinsights/django/logging.py
@@ -8,7 +8,7 @@ from . import common
 class LoggingHandler(logging.LoggingHandler):
     """This class is a LoggingHandler that uses the same settings as the Django middleware to configure
     the telemetry client.  This can be referenced from LOGGING in your Django settings.py file.  As an
-    example, this code would send all Django log messages--WARNING and up--to Application Insights:
+    example, this code would send all Django log messages, WARNING and up, to Application Insights:
 
     .. code:: python
 

--- a/libraries/botbuilder-integration-aiohttp/botbuilder/integration/aiohttp/bot_framework_http_client.py
+++ b/libraries/botbuilder-integration-aiohttp/botbuilder/integration/aiohttp/bot_framework_http_client.py
@@ -28,8 +28,8 @@ from botframework.connector.auth import (
 class BotFrameworkHttpClient(BotFrameworkClient):
 
     """
-    A skill host adapter implements API to forward activity to a skill and
-    implements routing ChannelAPI calls from the Skill up through the bot/adapter.
+    A skill host adapter that implements the API to forward activity to a skill and
+    implements routing ChannelAPI calls from the skill up through the bot/adapter.
     """
 
     INVOKE_ACTIVITY_NAME = "SkillEvents.ChannelApiInvoke"

--- a/libraries/botbuilder-integration-applicationinsights-aiohttp/botbuilder/integration/applicationinsights/aiohttp/aiohttp_telemetry_middleware.py
+++ b/libraries/botbuilder-integration-applicationinsights-aiohttp/botbuilder/integration/applicationinsights/aiohttp/aiohttp_telemetry_middleware.py
@@ -6,8 +6,9 @@ _REQUEST_BODIES = {}
 
 
 def retrieve_aiohttp_body():
-    """ retrieve_flask_body
+    """ 
     Retrieve the POST body text from temporary cache.
+    
     The POST body corresponds with the thread id and should resides in
     cache just for lifetime of request.
     """


### PR DESCRIPTION
## Description
Fixes for malformed reference comments.

## Specific
- fixing incorrect RST and Markdown formatting 
- copy editing grammar, tone, and spelling