### PR TITLE
Allow skills with no appId or password

### DIFF
--- a/libraries/botbuilder-core/botbuilder/core/channel_service_handler.py
+++ b/libraries/botbuilder-core/botbuilder/core/channel_service_handler.py
@@ -150,7 +150,9 @@ class ChannelServiceHandler:
         )
 
     async def on_get_conversations(
-        self, claims_identity: ClaimsIdentity, continuation_token: str = "",
+        self,
+        claims_identity: ClaimsIdentity,
+        continuation_token: str = "",
     ) -> ConversationsResult:
         """
         get_conversations() API for Skill
@@ -175,7 +177,9 @@ class ChannelServiceHandler:
         raise BotActionNotImplementedError()
 
     async def on_create_conversation(
-        self, claims_identity: ClaimsIdentity, parameters: ConversationParameters,
+        self,
+        claims_identity: ClaimsIdentity,
+        parameters: ConversationParameters,
     ) -> ConversationResourceResponse:
         """
         create_conversation() API for Skill
@@ -209,7 +213,10 @@ class ChannelServiceHandler:
         raise BotActionNotImplementedError()
 
     async def on_send_to_conversation(
-        self, claims_identity: ClaimsIdentity, conversation_id: str, activity: Activity,
+        self,
+        claims_identity: ClaimsIdentity,
+        conversation_id: str,
+        activity: Activity,
     ) -> ResourceResponse:
         """
         send_to_conversation() API for Skill
@@ -318,7 +325,10 @@ class ChannelServiceHandler:
         raise BotActionNotImplementedError()
 
     async def on_delete_activity(
-        self, claims_identity: ClaimsIdentity, conversation_id: str, activity_id: str,
+        self,
+        claims_identity: ClaimsIdentity,
+        conversation_id: str,
+        activity_id: str,
     ):
         """
         delete_activity() API for Skill.
@@ -336,7 +346,9 @@ class ChannelServiceHandler:
         raise BotActionNotImplementedError()
 
     async def on_get_conversation_members(
-        self, claims_identity: ClaimsIdentity, conversation_id: str,
+        self,
+        claims_identity: ClaimsIdentity,
+        conversation_id: str,
     ) -> List[ChannelAccount]:
         """
         get_conversation_members() API for Skill.
@@ -353,7 +365,10 @@ class ChannelServiceHandler:
         raise BotActionNotImplementedError()
 
     async def on_get_conversation_member(
-        self, claims_identity: ClaimsIdentity, conversation_id: str, member_id: str,
+        self,
+        claims_identity: ClaimsIdentity,
+        conversation_id: str,
+        member_id: str,
     ) -> ChannelAccount:
         """
         get_conversation_member() API for Skill.
@@ -407,7 +422,10 @@ class ChannelServiceHandler:
         raise BotActionNotImplementedError()
 
     async def on_delete_conversation_member(
-        self, claims_identity: ClaimsIdentity, conversation_id: str, member_id: str,
+        self,
+        claims_identity: ClaimsIdentity,
+        conversation_id: str,
+        member_id: str,
     ):
         """
         delete_conversation_member() API for Skill.
@@ -477,8 +495,8 @@ class ChannelServiceHandler:
         Helper to authenticate the header.
 
         This code is very similar to the code in JwtTokenValidation.authenticate_request,
-        we should move this code somewhere in that library when we refactor auth, for now we keep it private to avoid adding
-        more public static functions that we will need to deprecate later.
+        we should move this code somewhere in that library when we refactor auth,
+        for now we keep it private to avoid adding more public static functions that we will need to deprecate later.
         """
         if not auth_header:
             is_auth_disabled = (
@@ -491,14 +509,16 @@ class ChannelServiceHandler:
             # In the scenario where Auth is disabled, we still want to have the
             # IsAuthenticated flag set in the ClaimsIdentity. To do this requires
             # adding in an empty claim.
+            # Since ChannelServiceHandler calls are always a skill callback call, we set the skill claim too.
             return ClaimsIdentity(
                 {
                     AuthenticationConstants.APP_ID_CLAIM: AuthenticationConstants.ANONYMOUS_SKILL_APP_ID
                 },
                 True,
-                AuthenticationConstants.ANONYMOUS_AUTH_TYPE
+                AuthenticationConstants.ANONYMOUS_AUTH_TYPE,
             )
 
+        # Validate the header and extract claims.
         return await JwtTokenValidation.validate_auth_header(
             auth_header,
             self._credential_provider,

--- a/libraries/botbuilder-core/botbuilder/core/channel_service_handler.py
+++ b/libraries/botbuilder-core/botbuilder/core/channel_service_handler.py
@@ -17,7 +17,6 @@ from botbuilder.schema import (
 
 from botframework.connector.auth import (
     AuthenticationConfiguration,
-    AuthenticationConstants,
     ChannelProvider,
     ClaimsIdentity,
     CredentialProvider,

--- a/libraries/botbuilder-core/botbuilder/core/channel_service_handler.py
+++ b/libraries/botbuilder-core/botbuilder/core/channel_service_handler.py
@@ -17,6 +17,7 @@ from botbuilder.schema import (
 
 from botframework.connector.auth import (
     AuthenticationConfiguration,
+    AuthenticationConstants,
     ChannelProvider,
     ClaimsIdentity,
     CredentialProvider,
@@ -469,17 +470,30 @@ class ChannelServiceHandler:
         raise BotActionNotImplementedError()
 
     async def _authenticate(self, auth_header: str) -> ClaimsIdentity:
+        """
+        Helper to authenticate the header.
+
+        This code is very similar to the code in JwtTokenValidation.authenticate_request,
+        we should move this code somewhere in that library when we refactor auth, for now we keep it private to avoid adding
+        more public static functions that we will need to deprecate later.
+        """
         if not auth_header:
             is_auth_disabled = (
                 await self._credential_provider.is_authentication_disabled()
             )
-            if is_auth_disabled:
-                # In the scenario where Auth is disabled, we still want to have the
-                # IsAuthenticated flag set in the ClaimsIdentity. To do this requires
-                # adding in an empty claim.
-                return ClaimsIdentity({}, True)
+            if not is_auth_disabled:
+                # No auth header. Auth is required. Request is not authorized.
+                raise PermissionError()
 
-            raise PermissionError()
+            # In the scenario where Auth is disabled, we still want to have the
+            # IsAuthenticated flag set in the ClaimsIdentity. To do this requires
+            # adding in an empty claim.
+            return ClaimsIdentity(
+                {
+                    AuthenticationConstants.APP_ID_CLAIM: AuthenticationConstants.ANONYMOUS_SKILL_APP_ID
+                },
+                True,
+            )
 
         return await JwtTokenValidation.validate_auth_header(
             auth_header,

--- a/libraries/botbuilder-core/botbuilder/core/channel_service_handler.py
+++ b/libraries/botbuilder-core/botbuilder/core/channel_service_handler.py
@@ -427,7 +427,10 @@ class ChannelServiceHandler:
         raise BotActionNotImplementedError()
 
     async def on_get_activity_members(
-        self, claims_identity: ClaimsIdentity, conversation_id: str, activity_id: str,
+        self,
+        claims_identity: ClaimsIdentity,
+        conversation_id: str,
+        activity_id: str,
     ) -> List[ChannelAccount]:
         """
         get_activity_members() API for Skill.
@@ -493,6 +496,7 @@ class ChannelServiceHandler:
                     AuthenticationConstants.APP_ID_CLAIM: AuthenticationConstants.ANONYMOUS_SKILL_APP_ID
                 },
                 True,
+                AuthenticationConstants.ANONYMOUS_AUTH_TYPE
             )
 
         return await JwtTokenValidation.validate_auth_header(

--- a/libraries/botbuilder-core/botbuilder/core/channel_service_handler.py
+++ b/libraries/botbuilder-core/botbuilder/core/channel_service_handler.py
@@ -22,6 +22,7 @@ from botframework.connector.auth import (
     ClaimsIdentity,
     CredentialProvider,
     JwtTokenValidation,
+    SkillValidation,
 )
 
 
@@ -489,13 +490,7 @@ class ChannelServiceHandler:
             # IsAuthenticated flag set in the ClaimsIdentity. To do this requires
             # adding in an empty claim.
             # Since ChannelServiceHandler calls are always a skill callback call, we set the skill claim too.
-            return ClaimsIdentity(
-                {
-                    AuthenticationConstants.APP_ID_CLAIM: AuthenticationConstants.ANONYMOUS_SKILL_APP_ID
-                },
-                True,
-                AuthenticationConstants.ANONYMOUS_AUTH_TYPE,
-            )
+            return SkillValidation.create_anonymous_skill_claim()
 
         # Validate the header and extract claims.
         return await JwtTokenValidation.validate_auth_header(

--- a/libraries/botbuilder-core/botbuilder/core/channel_service_handler.py
+++ b/libraries/botbuilder-core/botbuilder/core/channel_service_handler.py
@@ -150,9 +150,7 @@ class ChannelServiceHandler:
         )
 
     async def on_get_conversations(
-        self,
-        claims_identity: ClaimsIdentity,
-        continuation_token: str = "",
+        self, claims_identity: ClaimsIdentity, continuation_token: str = "",
     ) -> ConversationsResult:
         """
         get_conversations() API for Skill
@@ -177,9 +175,7 @@ class ChannelServiceHandler:
         raise BotActionNotImplementedError()
 
     async def on_create_conversation(
-        self,
-        claims_identity: ClaimsIdentity,
-        parameters: ConversationParameters,
+        self, claims_identity: ClaimsIdentity, parameters: ConversationParameters,
     ) -> ConversationResourceResponse:
         """
         create_conversation() API for Skill
@@ -213,10 +209,7 @@ class ChannelServiceHandler:
         raise BotActionNotImplementedError()
 
     async def on_send_to_conversation(
-        self,
-        claims_identity: ClaimsIdentity,
-        conversation_id: str,
-        activity: Activity,
+        self, claims_identity: ClaimsIdentity, conversation_id: str, activity: Activity,
     ) -> ResourceResponse:
         """
         send_to_conversation() API for Skill
@@ -325,10 +318,7 @@ class ChannelServiceHandler:
         raise BotActionNotImplementedError()
 
     async def on_delete_activity(
-        self,
-        claims_identity: ClaimsIdentity,
-        conversation_id: str,
-        activity_id: str,
+        self, claims_identity: ClaimsIdentity, conversation_id: str, activity_id: str,
     ):
         """
         delete_activity() API for Skill.
@@ -346,9 +336,7 @@ class ChannelServiceHandler:
         raise BotActionNotImplementedError()
 
     async def on_get_conversation_members(
-        self,
-        claims_identity: ClaimsIdentity,
-        conversation_id: str,
+        self, claims_identity: ClaimsIdentity, conversation_id: str,
     ) -> List[ChannelAccount]:
         """
         get_conversation_members() API for Skill.
@@ -365,10 +353,7 @@ class ChannelServiceHandler:
         raise BotActionNotImplementedError()
 
     async def on_get_conversation_member(
-        self,
-        claims_identity: ClaimsIdentity,
-        conversation_id: str,
-        member_id: str,
+        self, claims_identity: ClaimsIdentity, conversation_id: str, member_id: str,
     ) -> ChannelAccount:
         """
         get_conversation_member() API for Skill.
@@ -422,10 +407,7 @@ class ChannelServiceHandler:
         raise BotActionNotImplementedError()
 
     async def on_delete_conversation_member(
-        self,
-        claims_identity: ClaimsIdentity,
-        conversation_id: str,
-        member_id: str,
+        self, claims_identity: ClaimsIdentity, conversation_id: str, member_id: str,
     ):
         """
         delete_conversation_member() API for Skill.
@@ -445,10 +427,7 @@ class ChannelServiceHandler:
         raise BotActionNotImplementedError()
 
     async def on_get_activity_members(
-        self,
-        claims_identity: ClaimsIdentity,
-        conversation_id: str,
-        activity_id: str,
+        self, claims_identity: ClaimsIdentity, conversation_id: str, activity_id: str,
     ) -> List[ChannelAccount]:
         """
         get_activity_members() API for Skill.

--- a/libraries/botbuilder-core/tests/test_channel_service_handler.py
+++ b/libraries/botbuilder-core/tests/test_channel_service_handler.py
@@ -1,0 +1,40 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+import aiounittest
+from botbuilder.core import ChannelServiceHandler
+from botframework.connector.auth import (
+    AuthenticationConfiguration,
+    ClaimsIdentity,
+    SimpleCredentialProvider,
+    JwtTokenValidation,
+)
+from botbuilder.schema import Activity, ResourceResponse
+
+
+class TestChannelServiceHandler(ChannelServiceHandler):
+    def __init__(self):
+        self.claims_identity = None
+        ChannelServiceHandler.__init__(
+            self, SimpleCredentialProvider("", ""), AuthenticationConfiguration()
+        )
+
+    async def on_reply_to_activity(
+        self,
+        claims_identity: ClaimsIdentity,
+        conversation_id: str,
+        activity_id: str,
+        activity: Activity,
+    ) -> ResourceResponse:
+        self.claims_identity = claims_identity
+        return ResourceResponse()
+
+
+class ChannelServiceHandlerTests(aiounittest.AsyncTestCase):
+    async def test_should_authenticate_anonymous_skill_claim(self):
+        sut = TestChannelServiceHandler()
+        await sut.handle_reply_to_activity(None, "123", "456", {})
+
+        assert "AnonymousSkill" == JwtTokenValidation.get_app_id_from_claims(
+            sut.claims_identity.claims
+        )

--- a/libraries/botbuilder-core/tests/test_channel_service_handler.py
+++ b/libraries/botbuilder-core/tests/test_channel_service_handler.py
@@ -7,9 +7,10 @@ from botframework.connector.auth import (
     AuthenticationConfiguration,
     ClaimsIdentity,
     SimpleCredentialProvider,
-    JwtTokenValidation, AuthenticationConstants,
+    JwtTokenValidation,
+    AuthenticationConstants,
 )
-from botbuilder.schema import Activity, ResourceResponse
+import botbuilder.schema
 
 
 class TestChannelServiceHandler(ChannelServiceHandler):
@@ -24,10 +25,10 @@ class TestChannelServiceHandler(ChannelServiceHandler):
         claims_identity: ClaimsIdentity,
         conversation_id: str,
         activity_id: str,
-        activity: Activity,
-    ) -> ResourceResponse:
+        activity: botbuilder.schema.Activity,
+    ) -> botbuilder.schema.ResourceResponse:
         self.claims_identity = claims_identity
-        return ResourceResponse()
+        return botbuilder.schema.ResourceResponse()
 
 
 class ChannelServiceHandlerTests(aiounittest.AsyncTestCase):
@@ -35,5 +36,11 @@ class ChannelServiceHandlerTests(aiounittest.AsyncTestCase):
         sut = TestChannelServiceHandler()
         await sut.handle_reply_to_activity(None, "123", "456", {})
 
-        assert sut.claims_identity.authentication_type == AuthenticationConstants.ANONYMOUS_AUTH_TYPE
-        assert JwtTokenValidation.get_app_id_from_claims(sut.claims_identity.claims) == "AnonymousSkill"
+        assert (
+            sut.claims_identity.authentication_type
+            == AuthenticationConstants.ANONYMOUS_AUTH_TYPE
+        )
+        assert (
+            JwtTokenValidation.get_app_id_from_claims(sut.claims_identity.claims)
+            == "AnonymousSkill"
+        )

--- a/libraries/botbuilder-core/tests/test_channel_service_handler.py
+++ b/libraries/botbuilder-core/tests/test_channel_service_handler.py
@@ -42,5 +42,5 @@ class ChannelServiceHandlerTests(aiounittest.AsyncTestCase):
         )
         assert (
             JwtTokenValidation.get_app_id_from_claims(sut.claims_identity.claims)
-            == "AnonymousSkill"
+            == AuthenticationConstants.ANONYMOUS_SKILL_APP_ID
         )

--- a/libraries/botbuilder-core/tests/test_channel_service_handler.py
+++ b/libraries/botbuilder-core/tests/test_channel_service_handler.py
@@ -7,7 +7,7 @@ from botframework.connector.auth import (
     AuthenticationConfiguration,
     ClaimsIdentity,
     SimpleCredentialProvider,
-    JwtTokenValidation,
+    JwtTokenValidation, AuthenticationConstants,
 )
 from botbuilder.schema import Activity, ResourceResponse
 
@@ -35,6 +35,5 @@ class ChannelServiceHandlerTests(aiounittest.AsyncTestCase):
         sut = TestChannelServiceHandler()
         await sut.handle_reply_to_activity(None, "123", "456", {})
 
-        assert "AnonymousSkill" == JwtTokenValidation.get_app_id_from_claims(
-            sut.claims_identity.claims
-        )
+        assert sut.claims_identity.authentication_type == AuthenticationConstants.ANONYMOUS_AUTH_TYPE
+        assert JwtTokenValidation.get_app_id_from_claims(sut.claims_identity.claims) == "AnonymousSkill"

--- a/libraries/botbuilder-integration-aiohttp/botbuilder/integration/aiohttp/bot_framework_http_client.py
+++ b/libraries/botbuilder-integration-aiohttp/botbuilder/integration/aiohttp/bot_framework_http_client.py
@@ -15,6 +15,7 @@ from botbuilder.schema import (
     ConversationReference,
     ConversationAccount,
     ChannelAccount,
+    RoleTypes,
 )
 from botframework.connector.auth import (
     ChannelProvider,
@@ -97,7 +98,9 @@ class BotFrameworkHttpClient(BotFrameworkClient):
             activity.conversation.id = conversation_id
             activity.service_url = service_url
             if not activity.recipient:
-                activity.recipient = ChannelAccount()
+                activity.recipient = ChannelAccount(role=RoleTypes.skill)
+            else:
+                activity.recipient.role = RoleTypes.skill
 
             status, content = await self._post_content(to_url, token, activity)
 

--- a/libraries/botbuilder-integration-aiohttp/tests/test_bot_framework_http_client.py
+++ b/libraries/botbuilder-integration-aiohttp/tests/test_bot_framework_http_client.py
@@ -1,7 +1,7 @@
 from unittest.mock import Mock
 
 import aiounittest
-from botbuilder.schema import ConversationAccount, ChannelAccount
+from botbuilder.schema import ConversationAccount, ChannelAccount, RoleTypes
 from botbuilder.integration.aiohttp import BotFrameworkHttpClient
 from botframework.connector.auth import CredentialProvider, Activity
 
@@ -69,3 +69,4 @@ class TestBotFrameworkHttpClient(aiounittest.AsyncTestCase):
         )
 
         assert activity.recipient.id == skill_recipient_id
+        assert activity.recipient.role is RoleTypes.skill

--- a/libraries/botbuilder-schema/botbuilder/schema/_connector_client_enums.py
+++ b/libraries/botbuilder-schema/botbuilder/schema/_connector_client_enums.py
@@ -8,6 +8,7 @@ class RoleTypes(str, Enum):
 
     user = "user"
     bot = "bot"
+    skill = "skill"
 
 
 class ActivityTypes(str, Enum):

--- a/libraries/botbuilder-schema/botbuilder/schema/_models_py3.py
+++ b/libraries/botbuilder-schema/botbuilder/schema/_models_py3.py
@@ -1307,8 +1307,8 @@ class ConversationAccount(Model):
     :param aad_object_id: This account's object ID within Azure Active
      Directory (AAD)
     :type aad_object_id: str
-    :param role: Role of the entity behind the account (Example: User, Bot,
-     etc.). Possible values include: 'user', 'bot'
+    :param role: Role of the entity behind the account (Example: User, Bot, Skill
+     etc.). Possible values include: 'user', 'bot', 'skill'
     :type role: str or ~botframework.connector.models.RoleTypes
     :param tenant_id: This conversation's tenant ID
     :type tenant_id: str

--- a/libraries/botframework-connector/botframework/connector/auth/app_credentials.py
+++ b/libraries/botframework-connector/botframework/connector/auth/app_credentials.py
@@ -104,7 +104,11 @@ class AppCredentials(Authentication):
     def _should_authorize(
         self, session: requests.Session  # pylint: disable=unused-argument
     ) -> bool:
-        return True
+        # We don't set the token if the AppId is not set.
+        return (
+            self.microsoft_app_id != AuthenticationConstants.ANONYMOUS_SKILL_APP_ID
+            and self.microsoft_app_id is not None
+        )
 
     def get_access_token(self, force_refresh: bool = False) -> str:
         """

--- a/libraries/botframework-connector/botframework/connector/auth/app_credentials.py
+++ b/libraries/botframework-connector/botframework/connector/auth/app_credentials.py
@@ -104,7 +104,7 @@ class AppCredentials(Authentication):
     def _should_authorize(
         self, session: requests.Session  # pylint: disable=unused-argument
     ) -> bool:
-        # We don't set the token if the AppId is not set.
+        # We don't set the token if the AppId is not set, since it means that we are in an un-authenticated scenario.
         return (
             self.microsoft_app_id != AuthenticationConstants.ANONYMOUS_SKILL_APP_ID
             and self.microsoft_app_id is not None

--- a/libraries/botframework-connector/botframework/connector/auth/authentication_constants.py
+++ b/libraries/botframework-connector/botframework/connector/auth/authentication_constants.py
@@ -113,3 +113,5 @@ class AuthenticationConstants(ABC):
 
     # Service URL claim name. As used in Microsoft Bot Framework v3.1 auth.
     SERVICE_URL_CLAIM = "serviceurl"
+
+    ANONYMOUS_SKILL_APP_ID = "AnonymousSkill"

--- a/libraries/botframework-connector/botframework/connector/auth/authentication_constants.py
+++ b/libraries/botframework-connector/botframework/connector/auth/authentication_constants.py
@@ -114,4 +114,8 @@ class AuthenticationConstants(ABC):
     # Service URL claim name. As used in Microsoft Bot Framework v3.1 auth.
     SERVICE_URL_CLAIM = "serviceurl"
 
+    # AppId used for creating skill claims when there is no appId and password configured.
     ANONYMOUS_SKILL_APP_ID = "AnonymousSkill"
+
+    # Indicates that ClaimsIdentity.authentication_type is anonymous (no app Id and password were provided).
+    ANONYMOUS_AUTH_TYPE = "anonymous"

--- a/libraries/botframework-connector/botframework/connector/auth/claims_identity.py
+++ b/libraries/botframework-connector/botframework/connector/auth/claims_identity.py
@@ -5,9 +5,11 @@ class Claim:
 
 
 class ClaimsIdentity:
-    def __init__(self, claims: dict, is_authenticated: bool):
+    def __init__(self, claims: dict, is_authenticated: bool, authentication_type: str = None):
         self.claims = claims
         self.is_authenticated = is_authenticated
+        self.authentication_type = authentication_type
+
 
     def get_claim_value(self, claim_type: str):
         return self.claims.get(claim_type)

--- a/libraries/botframework-connector/botframework/connector/auth/claims_identity.py
+++ b/libraries/botframework-connector/botframework/connector/auth/claims_identity.py
@@ -5,11 +5,12 @@ class Claim:
 
 
 class ClaimsIdentity:
-    def __init__(self, claims: dict, is_authenticated: bool, authentication_type: str = None):
+    def __init__(
+        self, claims: dict, is_authenticated: bool, authentication_type: str = None
+    ):
         self.claims = claims
         self.is_authenticated = is_authenticated
         self.authentication_type = authentication_type
-
 
     def get_claim_value(self, claim_type: str):
         return self.claims.get(claim_type)

--- a/libraries/botframework-connector/botframework/connector/auth/jwt_token_validation.py
+++ b/libraries/botframework-connector/botframework/connector/auth/jwt_token_validation.py
@@ -59,12 +59,13 @@ class JwtTokenValidation:
                         AuthenticationConstants.APP_ID_CLAIM: AuthenticationConstants.ANONYMOUS_SKILL_APP_ID
                     },
                     True,
+                    AuthenticationConstants.ANONYMOUS_AUTH_TYPE
                 )
 
             # In the scenario where Auth is disabled, we still want to have the
             # IsAuthenticated flag set in the ClaimsIdentity. To do this requires
             # adding in an empty claim.
-            return ClaimsIdentity({}, True)
+            return ClaimsIdentity({}, True, AuthenticationConstants.ANONYMOUS_AUTH_TYPE)
 
         # Validate the header and extract claims.
         claims_identity = await JwtTokenValidation.validate_auth_header(

--- a/libraries/botframework-connector/botframework/connector/auth/jwt_token_validation.py
+++ b/libraries/botframework-connector/botframework/connector/auth/jwt_token_validation.py
@@ -52,14 +52,16 @@ class JwtTokenValidation:
             # Check if the activity is for a skill call and is coming from the Emulator.
             if (
                 activity.channel_id == Channels.emulator
-            ):  # TODO: UPDATE MEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE https://github.com/microsoft/botbuilder-dotnet/pull/4757/files#r500646769
+                and isinstance(activity, Activity)
+                and activity.relates_to is not None
+            ):  # TODO: UPDATE ME https://github.com/microsoft/botbuilder-dotnet/pull/4757/files#r500646769
                 # Return an anonymous claim with an anonymous skill AppId
                 return ClaimsIdentity(
                     {
                         AuthenticationConstants.APP_ID_CLAIM: AuthenticationConstants.ANONYMOUS_SKILL_APP_ID
                     },
                     True,
-                    AuthenticationConstants.ANONYMOUS_AUTH_TYPE
+                    AuthenticationConstants.ANONYMOUS_AUTH_TYPE,
                 )
 
             # In the scenario where Auth is disabled, we still want to have the

--- a/libraries/botframework-connector/botframework/connector/auth/skill_validation.py
+++ b/libraries/botframework-connector/botframework/connector/auth/skill_validation.py
@@ -66,6 +66,12 @@ class SkillValidation:
         if AuthenticationConstants.VERSION_CLAIM not in claims:
             return False
 
+        if (
+            claims.get(AuthenticationConstants.ANONYMOUS_SKILL_APP_ID, None)
+            == AuthenticationConstants.ANONYMOUS_SKILL_APP_ID
+        ):
+            return True
+
         audience = claims.get(AuthenticationConstants.AUDIENCE_CLAIM)
 
         # The audience is https://api.botframework.com and not an appId.

--- a/libraries/botframework-connector/botframework/connector/auth/skill_validation.py
+++ b/libraries/botframework-connector/botframework/connector/auth/skill_validation.py
@@ -67,7 +67,7 @@ class SkillValidation:
             return False
 
         if (
-            claims.get(AuthenticationConstants.ANONYMOUS_SKILL_APP_ID, None)
+            claims.get(AuthenticationConstants.APP_ID_CLAIM, None)
             == AuthenticationConstants.ANONYMOUS_SKILL_APP_ID
         ):
             return True
@@ -129,6 +129,20 @@ class SkillValidation:
         await SkillValidation._validate_identity(identity, credentials)
 
         return identity
+
+    @staticmethod
+    def create_anonymous_skill_claim():
+        """
+        Creates a ClaimsIdentity for an anonymous (unauthenticated) skill.
+        :return ClaimsIdentity:
+        """
+        return ClaimsIdentity(
+            {
+                AuthenticationConstants.APP_ID_CLAIM: AuthenticationConstants.ANONYMOUS_SKILL_APP_ID
+            },
+            True,
+            AuthenticationConstants.ANONYMOUS_AUTH_TYPE,
+        )
 
     @staticmethod
     async def _validate_identity(

--- a/libraries/botframework-connector/tests/test_app_credentials.py
+++ b/libraries/botframework-connector/tests/test_app_credentials.py
@@ -2,30 +2,29 @@
 # Licensed under the MIT License.
 
 import aiounittest
-import requests
 from botframework.connector.auth import AppCredentials, AuthenticationConstants
 
 
 class AppCredentialsTests(aiounittest.AsyncTestCase):
     @staticmethod
-    def test_constructor():
-        should_default_to_channel_scope = AppCredentials()
-        assert (
-            AuthenticationConstants.TO_CHANNEL_FROM_BOT_OAUTH_SCOPE
-            == should_default_to_channel_scope.oauth_scope
-        )
-
-        should_default_to_custom_scope = AppCredentials(oauth_scope="customScope")
-        assert "customScope" == should_default_to_custom_scope.oauth_scope
-
-    @staticmethod
     def test_should_not_send_token_for_anonymous():
         # AppID is None
         app_creds_none = AppCredentials(app_id=None)
-        assert app_creds_none._should_authorize(requests.Session()) is False
+        assert app_creds_none.signed_session().headers.get("Authorization") is None
 
         # AppID is anonymous skill
         app_creds_anon = AppCredentials(
             app_id=AuthenticationConstants.ANONYMOUS_SKILL_APP_ID
         )
-        assert app_creds_anon._should_authorize(requests.Session()) is False
+        assert app_creds_anon.signed_session().headers.get("Authorization") is None
+
+
+def test_constructor():
+    should_default_to_channel_scope = AppCredentials()
+    assert (
+        should_default_to_channel_scope.oauth_scope
+        == AuthenticationConstants.TO_CHANNEL_FROM_BOT_OAUTH_SCOPE
+    )
+
+    should_default_to_custom_scope = AppCredentials(oauth_scope="customScope")
+    assert should_default_to_custom_scope.oauth_scope == "customScope"

--- a/libraries/botframework-connector/tests/test_app_credentials.py
+++ b/libraries/botframework-connector/tests/test_app_credentials.py
@@ -1,0 +1,31 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+import aiounittest
+import requests
+from botframework.connector.auth import AppCredentials, AuthenticationConstants
+
+
+class AppCredentialsTests(aiounittest.AsyncTestCase):
+    @staticmethod
+    def test_constructor():
+        should_default_to_channel_scope = AppCredentials()
+        assert (
+            AuthenticationConstants.TO_CHANNEL_FROM_BOT_OAUTH_SCOPE
+            == should_default_to_channel_scope.oauth_scope
+        )
+
+        should_default_to_custom_scope = AppCredentials(oauth_scope="customScope")
+        assert "customScope" == should_default_to_custom_scope.oauth_scope
+
+    @staticmethod
+    def test_should_not_send_token_for_anonymous():
+        # AppID is None
+        app_creds_none = AppCredentials(app_id=None)
+        assert app_creds_none._should_authorize(requests.Session()) is False
+
+        # AppID is anonymous skill
+        app_creds_anon = AppCredentials(
+            app_id=AuthenticationConstants.ANONYMOUS_SKILL_APP_ID
+        )
+        assert app_creds_anon._should_authorize(requests.Session()) is False

--- a/libraries/botframework-connector/tests/test_auth.py
+++ b/libraries/botframework-connector/tests/test_auth.py
@@ -21,7 +21,8 @@ from botframework.connector.auth import (
     GovernmentConstants,
     GovernmentChannelValidation,
     SimpleChannelProvider,
-    ChannelProvider, AppCredentials,
+    ChannelProvider,
+    AppCredentials,
 )
 
 
@@ -293,31 +294,27 @@ class TestAuth:
     @pytest.mark.asyncio
     # Tests with a valid Token and invalid service url and ensures that Service url is NOT added to
     # Trusted service url list.
-    async def test_channel_authentication_disabled_should_be_anonymous(self):
-        activity = Activity(service_url="https://webchat.botframework.com/")
-        header = ""
-        credentials = SimpleCredentialProvider("", "")
-
-        claims_principal = await JwtTokenValidation.authenticate_request(activity, header, credentials)
-
-        assert claims_principal.authentication_type == AuthenticationConstants.ANONYMOUS_AUTH_TYPE
-
-    @pytest.mark.asyncio
-    # Tests with a valid Token and invalid service url and ensures that Service url is NOT added to
-    # Trusted service url list.
     async def test_channel_authentication_disabled_and_skill_should_be_anonymous(self):
         activity = Activity(
             channel_id=Channels.emulator,
             service_url="https://webchat.botframework.com/",
-            relates_to=ConversationReference()
+            relates_to=ConversationReference(),
         )
         header = ""
         credentials = SimpleCredentialProvider("", "")
 
-        claims_principal = await JwtTokenValidation.authenticate_request(activity, header, credentials)
+        claims_principal = await JwtTokenValidation.authenticate_request(
+            activity, header, credentials
+        )
 
-        assert claims_principal.authentication_type == AuthenticationConstants.ANONYMOUS_AUTH_TYPE
-        assert JwtTokenValidation.get_app_id_from_claims(claims_principal.claims) == AuthenticationConstants.ANONYMOUS_SKILL_APP_ID
+        assert (
+            claims_principal.authentication_type
+            == AuthenticationConstants.ANONYMOUS_AUTH_TYPE
+        )
+        assert (
+            JwtTokenValidation.get_app_id_from_claims(claims_principal.claims)
+            == AuthenticationConstants.ANONYMOUS_SKILL_APP_ID
+        )
 
     @pytest.mark.asyncio
     async def test_channel_msa_header_from_user_specified_tenant(self):
@@ -350,6 +347,10 @@ class TestAuth:
 
         assert claims_principal.is_authenticated
         assert not claims_principal.claims
+        assert (
+            claims_principal.authentication_type
+            == AuthenticationConstants.ANONYMOUS_AUTH_TYPE
+        )
 
     @pytest.mark.asyncio
     # Tests with no authentication header and makes sure the service URL is not added to the trusted list.

--- a/libraries/botframework-connector/tests/test_auth.py
+++ b/libraries/botframework-connector/tests/test_auth.py
@@ -6,7 +6,7 @@ from unittest.mock import Mock
 
 import pytest
 
-from botbuilder.schema import Activity, ConversationReference
+from botbuilder.schema import Activity, ConversationReference, ChannelAccount, RoleTypes
 from botframework.connector import Channels
 from botframework.connector.auth import (
     AuthenticationConfiguration,
@@ -299,6 +299,7 @@ class TestAuth:
             channel_id=Channels.emulator,
             service_url="https://webchat.botframework.com/",
             relates_to=ConversationReference(),
+            recipient=ChannelAccount(role=RoleTypes.skill),
         )
         header = ""
         credentials = SimpleCredentialProvider("", "")
@@ -345,8 +346,6 @@ class TestAuth:
             activity, header, credentials
         )
 
-        assert claims_principal.is_authenticated
-        assert not claims_principal.claims
         assert (
             claims_principal.authentication_type
             == AuthenticationConstants.ANONYMOUS_AUTH_TYPE

--- a/libraries/botframework-connector/tests/test_skill_validation.py
+++ b/libraries/botframework-connector/tests/test_skill_validation.py
@@ -46,10 +46,12 @@ class TestSkillValidation(aiounittest.AsyncTestCase):
         # AppId != Audience
         claims[AuthenticationConstants.APP_ID_CLAIM] = audience
         assert not SkillValidation.is_skill_claim(claims)
-        
+
         # Anonymous skill app id
         del claims[AuthenticationConstants.APP_ID_CLAIM]
-        claims[AuthenticationConstants.APP_ID_CLAIM] = AuthenticationConstants.ANONYMOUS_SKILL_APP_ID
+        claims[
+            AuthenticationConstants.APP_ID_CLAIM
+        ] = AuthenticationConstants.ANONYMOUS_SKILL_APP_ID
         assert SkillValidation.is_skill_claim(claims)
 
         # All checks pass, should be good now

--- a/libraries/botframework-connector/tests/test_skill_validation.py
+++ b/libraries/botframework-connector/tests/test_skill_validation.py
@@ -8,7 +8,8 @@ from botframework.connector.auth import (
     AuthenticationConstants,
     ClaimsIdentity,
     CredentialProvider,
-    SkillValidation, JwtTokenValidation,
+    SkillValidation,
+    JwtTokenValidation,
 )
 
 
@@ -168,5 +169,8 @@ class TestSkillValidation(aiounittest.AsyncTestCase):
     @staticmethod
     def test_create_anonymous_skill_claim():
         sut = SkillValidation.create_anonymous_skill_claim()
-        assert JwtTokenValidation.get_app_id_from_claims(sut.claims) == AuthenticationConstants.ANONYMOUS_SKILL_APP_ID
+        assert (
+            JwtTokenValidation.get_app_id_from_claims(sut.claims)
+            == AuthenticationConstants.ANONYMOUS_SKILL_APP_ID
+        )
         assert sut.authentication_type == AuthenticationConstants.ANONYMOUS_AUTH_TYPE

--- a/libraries/botframework-connector/tests/test_skill_validation.py
+++ b/libraries/botframework-connector/tests/test_skill_validation.py
@@ -46,6 +46,11 @@ class TestSkillValidation(aiounittest.AsyncTestCase):
         # AppId != Audience
         claims[AuthenticationConstants.APP_ID_CLAIM] = audience
         assert not SkillValidation.is_skill_claim(claims)
+        
+        # Anonymous skill app id
+        del claims[AuthenticationConstants.APP_ID_CLAIM]
+        claims[AuthenticationConstants.APP_ID_CLAIM] = AuthenticationConstants.ANONYMOUS_SKILL_APP_ID
+        assert SkillValidation.is_skill_claim(claims)
 
         # All checks pass, should be good now
         del claims[AuthenticationConstants.AUDIENCE_CLAIM]

--- a/libraries/botframework-connector/tests/test_skill_validation.py
+++ b/libraries/botframework-connector/tests/test_skill_validation.py
@@ -8,7 +8,7 @@ from botframework.connector.auth import (
     AuthenticationConstants,
     ClaimsIdentity,
     CredentialProvider,
-    SkillValidation,
+    SkillValidation, JwtTokenValidation,
 )
 
 
@@ -164,3 +164,9 @@ class TestSkillValidation(aiounittest.AsyncTestCase):
         # All checks pass (no exception)
         claims[AuthenticationConstants.APP_ID_CLAIM] = app_id
         await SkillValidation._validate_identity(mock_identity, mock_credentials)
+
+    @staticmethod
+    def test_create_anonymous_skill_claim():
+        sut = SkillValidation.create_anonymous_skill_claim()
+        assert JwtTokenValidation.get_app_id_from_claims(sut.claims) == AuthenticationConstants.ANONYMOUS_SKILL_APP_ID
+        assert sut.authentication_type == AuthenticationConstants.ANONYMOUS_AUTH_TYPE

--- a/libraries/swagger/ConnectorAPI.json
+++ b/libraries/swagger/ConnectorAPI.json
@@ -919,7 +919,7 @@
           },
           "role": {
             "$ref": "#/definitions/RoleTypes",
-            "description": "Role of the entity behind the account (Example: User, Bot, etc.)"
+            "description": "Role of the entity behind the account (Example: User, Bot, Skill, etc.)"
           }
         }
       },
@@ -1154,7 +1154,7 @@
           },
           "role": {
             "$ref": "#/definitions/RoleTypes",
-            "description": "Role of the entity behind the account (Example: User, Bot, etc.)"
+            "description": "Role of the entity behind the account (Example: User, Bot, Skill, etc.)"
           }
         }
       },
@@ -2277,10 +2277,11 @@
         }
       },
       "RoleTypes": {
-        "description": "Role of the entity behind the account (Example: User, Bot, etc.)",
+        "description": "Role of the entity behind the account (Example: User, Bot, Skill, etc.)",
         "enum": [
           "user",
-          "bot"
+          "bot",
+          "skill"
         ],
         "type": "string",
         "properties": {},


### PR DESCRIPTION
Fixes #1396

- Added new Skill constant to RoleTypes
- Updated BotframeworkHttpCllient to set the Role in the Recipient of the outgoing activity clone to RoleTypes.Skill
- Updated ChannelServiceHanlder to add an anonymous skill AppId claim when auth is disabled.
- Updated AppCredentials.ShouldSetToken() logic to avoid sending a token when the AppId is not set or when it is set to the anonymous skill appId.
- Updated SkillValidation.IsSkillClaim to return true for anonymous skills.
- Updated JwtTokenValidation.AuthenticateRequest to check the Role property in the incoming activity to determine if the request is coming from another bot or the channel. 
- Added AuthenticationConstants.AnonymousSkillAppId constant.
- Added AuthenticationConstants.AnonymousAuthType constant and updated related code to use it instead of using hardcoded "anonymous" 
- Added unit tests for new logic.

## Testing
Try any skill sample from the emulator without using AppIds and Passwords