### PR TITLE
fix formatDateTime function with "dd/MM/yyy" produces wrong results

### DIFF
--- a/libraries/adaptive-expressions/adaptive/expressions/builtin_functions/get_next_viable_time.py
+++ b/libraries/adaptive-expressions/adaptive/expressions/builtin_functions/get_next_viable_time.py
@@ -71,6 +71,9 @@ class GetNextViableTime(ExpressionEvaluator):
             else:
                 valid_hour = hour + 1
 
+            if valid_hour > 24:
+                valid_hour -= 24
+
             valid_minute = parsed.minute
             valid_second = parsed.second
 

--- a/libraries/adaptive-expressions/adaptive/expressions/builtin_functions/get_previous_viable_time.py
+++ b/libraries/adaptive-expressions/adaptive/expressions/builtin_functions/get_previous_viable_time.py
@@ -71,6 +71,9 @@ class GetPreviousViableTime(ExpressionEvaluator):
             else:
                 valid_hour = hour - 1
 
+            if valid_hour < 0:
+                valid_hour += 24
+
             valid_minute = parsed.minute
             valid_second = parsed.second
 

--- a/libraries/adaptive-expressions/adaptive/expressions/convert_format.py
+++ b/libraries/adaptive-expressions/adaptive/expressions/convert_format.py
@@ -341,7 +341,7 @@ class FormatDatetime:
                     fmt_state = State.none
                     ltoken_buffer = ""
                 elif character == "/":
-                    result += change_state(timestamp, fmt_state, ltoken_buffer) + ":"
+                    result += change_state(timestamp, fmt_state, ltoken_buffer) + "/"
                     fmt_state = State.none
                     ltoken_buffer = ""
                 elif character == r"\`":

--- a/libraries/adaptive-expressions/tests/test_expression_parser.py
+++ b/libraries/adaptive-expressions/tests/test_expression_parser.py
@@ -857,6 +857,8 @@ class ExpressionParserTests(aiounittest.AsyncTestCase):
         ["formatDateTime('2018-03-15')", "2018-03-15T00:00:00.000Z"],
         ["formatDateTime(notISOTimestamp)", "2018-03-15T13:00:00.000Z"],
         ["formatDateTime(notISOTimestamp, 'MM-dd-yy')", "03-15-18"],
+        ["formatDateTime(notISOTimestamp, 'MM/dd/yy')", "03/15/18"],
+        ["formatDateTime(notISOTimestamp, 'MM/dd/yyy')", "03/15/2018"],
         ["formatDateTime(timestampObj)", "2018-03-15T13:00:00.000Z"],
         # formatEpoch
         ["formatEpoch(unixTimestamp)", "2018-03-15T13:00:00.000Z"],


### PR DESCRIPTION
Now `formatDateTime('2018-02-15T12:12:12', \'dd/MM/yyy\')` will return `02/15/2018`