### PR TITLE
Only reassign waterfall step name only if the step doesn't have a name

### DIFF
--- a/libraries/botbuilder-applicationinsights/tests/test_telemetry_waterfall.py
+++ b/libraries/botbuilder-applicationinsights/tests/test_telemetry_waterfall.py
@@ -28,6 +28,7 @@ BEGIN_MESSAGE.type = "message"
 
 MOCK_TELEMETRY = "botbuilder.applicationinsights.ApplicationInsightsTelemetryClient"
 
+
 class TelemetryWaterfallTests(aiounittest.AsyncTestCase):
     def test_none_telemetry_client(self):
         # arrange
@@ -163,24 +164,22 @@ class TelemetryWaterfallTests(aiounittest.AsyncTestCase):
 
         dialog_instance = DialogInstance()
         dialog_instance.id = dialog_id
-        dialog_instance.state = { "instanceId": guid, "stepIndex": index }
+        dialog_instance.state = {"instanceId": guid, "stepIndex": index}
 
         # Act
         await dialog.end_dialog(
             TurnContext(TestAdapter(), Activity()),
             dialog_instance,
-            DialogReason.CancelCalled
+            DialogReason.CancelCalled,
         )
 
         # Assert
         telemetry_props = telemetry_client.track_event.call_args_list[0][0][1]
 
         self.assertEqual(3, len(telemetry_props))
-        self.assertEqual(dialog_id, telemetry_props['DialogId'])
-        self.assertEqual(
-            my_waterfall_step.__qualname__, telemetry_props['StepName']
-        )
-        self.assertEqual(guid, telemetry_props['InstanceId'])
+        self.assertEqual(dialog_id, telemetry_props["DialogId"])
+        self.assertEqual(my_waterfall_step.__qualname__, telemetry_props["StepName"])
+        self.assertEqual(guid, telemetry_props["InstanceId"])
         telemetry_client.track_event.assert_called_once()
 
     def assert_telemetry_call(

--- a/libraries/botbuilder-applicationinsights/tests/test_telemetry_waterfall.py
+++ b/libraries/botbuilder-applicationinsights/tests/test_telemetry_waterfall.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-from unittest.mock import MagicMock
+from unittest.mock import create_autospec, MagicMock
 from typing import Dict
 import aiounittest
 from botbuilder.core.adapters import TestAdapter, TestFlow
@@ -14,6 +14,8 @@ from botbuilder.core import (
 )
 from botbuilder.dialogs import (
     Dialog,
+    DialogInstance,
+    DialogReason,
     DialogSet,
     WaterfallDialog,
     DialogTurnResult,
@@ -25,7 +27,6 @@ BEGIN_MESSAGE.text = "begin"
 BEGIN_MESSAGE.type = "message"
 
 MOCK_TELEMETRY = "botbuilder.applicationinsights.ApplicationInsightsTelemetryClient"
-
 
 class TelemetryWaterfallTests(aiounittest.AsyncTestCase):
     def test_none_telemetry_client(self):
@@ -83,11 +84,10 @@ class TelemetryWaterfallTests(aiounittest.AsyncTestCase):
         await tf4.assert_reply("ending WaterfallDialog.")
 
         # assert
-
         telemetry_calls = [
             ("WaterfallStart", {"DialogId": "test"}),
-            ("WaterfallStep", {"DialogId": "test", "StepName": "Step1of2"}),
-            ("WaterfallStep", {"DialogId": "test", "StepName": "Step2of2"}),
+            ("WaterfallStep", {"DialogId": "test", "StepName": step1.__qualname__}),
+            ("WaterfallStep", {"DialogId": "test", "StepName": step2.__qualname__}),
         ]
         self.assert_telemetry_calls(telemetry, telemetry_calls)
 
@@ -138,14 +138,50 @@ class TelemetryWaterfallTests(aiounittest.AsyncTestCase):
         # assert
         telemetry_calls = [
             ("WaterfallStart", {"DialogId": "test"}),
-            ("WaterfallStep", {"DialogId": "test", "StepName": "Step1of2"}),
-            ("WaterfallStep", {"DialogId": "test", "StepName": "Step2of2"}),
+            ("WaterfallStep", {"DialogId": "test", "StepName": step1.__qualname__}),
+            ("WaterfallStep", {"DialogId": "test", "StepName": step2.__qualname__}),
             ("WaterfallComplete", {"DialogId": "test"}),
             ("WaterfallStart", {"DialogId": "test"}),
-            ("WaterfallStep", {"DialogId": "test", "StepName": "Step1of2"}),
+            ("WaterfallStep", {"DialogId": "test", "StepName": step1.__qualname__}),
         ]
-        print(str(telemetry.track_event.call_args_list))
         self.assert_telemetry_calls(telemetry, telemetry_calls)
+
+    async def test_cancelling_waterfall_telemetry(self):
+        # Arrange
+        dialog_id = "waterfall"
+        index = 0
+        guid = "(guid)"
+
+        async def my_waterfall_step(step) -> DialogTurnResult:
+            await step.context.send_activity("step1 response")
+            return Dialog.end_of_turn
+
+        dialog = WaterfallDialog(dialog_id, [my_waterfall_step])
+
+        telemetry_client = create_autospec(NullTelemetryClient)
+        dialog.telemetry_client = telemetry_client
+
+        dialog_instance = DialogInstance()
+        dialog_instance.id = dialog_id
+        dialog_instance.state = { "instanceId": guid, "stepIndex": index }
+
+        # Act
+        await dialog.end_dialog(
+            TurnContext(TestAdapter(), Activity()),
+            dialog_instance,
+            DialogReason.CancelCalled
+        )
+
+        # Assert
+        telemetry_props = telemetry_client.track_event.call_args_list[0][0][1]
+
+        self.assertEqual(3, len(telemetry_props))
+        self.assertEqual(dialog_id, telemetry_props['DialogId'])
+        self.assertEqual(
+            my_waterfall_step.__qualname__, telemetry_props['StepName']
+        )
+        self.assertEqual(guid, telemetry_props['InstanceId'])
+        telemetry_client.track_event.assert_called_once()
 
     def assert_telemetry_call(
         self, telemetry_mock, index: int, event_name: str, props: Dict[str, str]

--- a/libraries/botbuilder-dialogs/botbuilder/dialogs/waterfall_dialog.py
+++ b/libraries/botbuilder-dialogs/botbuilder/dialogs/waterfall_dialog.py
@@ -164,7 +164,7 @@ class WaterfallDialog(Dialog):
         """
         step_name = self._steps[index].__qualname__
 
-        if not step_name or ">" in step_name:
+        if not step_name or step_name.endswith("<lambda>"):
             step_name = f"Step{index + 1}of{len(self._steps)}"
 
         return step_name


### PR DESCRIPTION
Fixes #670 

## Description
In `WaterfallDialog.get_step_name` method, it uses `__qualname__` dunder method to get a unique name for the waterfall step

```python
    def get_step_name(self, index: int) -> str:
        """
        Give the waterfall step a unique name
        """
        step_name = self._steps[index].__qualname__

        if not step_name or ">" in step_name:
            step_name = f"Step{index + 1}of{len(self._steps)}"

        return step_name
```

The method's intention is to only create and assign a name if the waterfall step is anonymous, which commonplace in C# and JS SDKs. 

However, because the full qualname is given, "`>`" is present, even if waterfall steps defined with a name (i.e. no anonymous methods used to define steps). This results in an overapplication of renaming waterfall step names, even if the step already has a name to begin with.

<details>
     <summary>Click to see more detailed example</summary>

Create a waterfall dialog that has one step, which is defined by a function named get_user_name.
```python
async def get_user_name(step):
   # do stuff
   return Dialog.end_of_turn

dialog = WaterfallDialog("my_dialog", steps=[get_user_name])
```

#### Expected Step Name from `get_step_name`
<full_qualname_prefix>+ `.get_user_name`

#### Actual Name from `get_step_name`
`Step1of1` 
* It's been reassigned a name, even though the step already had a name
</details>

## Specific Changes

  - Will only create and assign a step name if waterfall `step_name` is not present or if ends with `<lambda>`

## Testing
- Test unit test added to verify telemetry works properly in waterfall dialogs