### PR TITLE
[#1218] [PORT] Emit better error messages for all dialogs

### DIFF
--- a/libraries/botbuilder-dialogs/tests/test_activity_prompt.py
+++ b/libraries/botbuilder-dialogs/tests/test_activity_prompt.py
@@ -241,9 +241,13 @@ class ActivityPromptTests(aiounittest.AsyncTestCase):
                     await dialog_context.prompt("EventActivityPrompt", options)
                     await dialog_context.prompt("Non existent id", options)
                 except Exception as err:
-                    self.assertIsNotNone(err.data["DialogContext"]) # pylint: disable=no-member
+                    self.assertIsNotNone(
+                        err.data["DialogContext"]  # pylint: disable=no-member
+                    )
                     self.assertEqual(
-                        err.data["DialogContext"]["active_dialog"], # pylint: disable=no-member
+                        err.data["DialogContext"][  # pylint: disable=no-member
+                            "active_dialog"
+                        ],
                         "EventActivityPrompt",
                     )
                 else:
@@ -284,7 +288,9 @@ class ActivityPromptTests(aiounittest.AsyncTestCase):
                     await dialog_context.prompt("EventActivityPrompt", options)
                     await dialog_context.replace_dialog("Non existent id", options)
                 except Exception as err:
-                    self.assertIsNotNone(err.data["DialogContext"]) # pylint: disable=no-member
+                    self.assertIsNotNone(
+                        err.data["DialogContext"]  # pylint: disable=no-member
+                    )
                 else:
                     raise Exception("Should have thrown an error.")
 

--- a/libraries/botbuilder-dialogs/tests/test_activity_prompt.py
+++ b/libraries/botbuilder-dialogs/tests/test_activity_prompt.py
@@ -215,3 +215,85 @@ class ActivityPromptTests(aiounittest.AsyncTestCase):
         step1 = await adapter.send("hello")
         step2 = await step1.assert_reply("please send an event.")
         await step2.assert_reply("please send an event.")
+
+    async def test_activity_prompt_onerror_should_return_dialogcontext(self):
+        # Create ConversationState with MemoryStorage and register the state as middleware.
+        convo_state = ConversationState(MemoryStorage())
+
+        # Create a DialogState property, DialogSet and AttachmentPrompt.
+        dialog_state = convo_state.create_property("dialog_state")
+        dialogs = DialogSet(dialog_state)
+        dialogs.add(SimpleActivityPrompt("EventActivityPrompt", validator))
+
+        async def exec_test(turn_context: TurnContext):
+            dialog_context = await dialogs.create_context(turn_context)
+
+            results = await dialog_context.continue_dialog()
+
+            if results.status == DialogTurnStatus.Empty:
+                options = PromptOptions(
+                    prompt=Activity(
+                        type=ActivityTypes.message, text="please send an event."
+                    )
+                )
+
+                try:
+                    await dialog_context.prompt("EventActivityPrompt", options)
+                    await dialog_context.prompt("Non existent id", options)
+                except Exception as err:
+                    self.assertIsNotNone(err.data["DialogContext"])
+                    self.assertEqual(
+                        err.data["DialogContext"]["active_dialog"],
+                        "EventActivityPrompt",
+                    )
+                else:
+                    raise Exception("Should have thrown an error.")
+
+            elif results.status == DialogTurnStatus.Complete:
+                await turn_context.send_activity(results.result)
+
+            await convo_state.save_changes(turn_context)
+
+        # Initialize TestAdapter.
+        adapter = TestAdapter(exec_test)
+
+        await adapter.send("hello")
+
+    async def test_activity_replace_dialog_onerror_should_return_dialogcontext(self):
+        # Create ConversationState with MemoryStorage and register the state as middleware.
+        convo_state = ConversationState(MemoryStorage())
+
+        # Create a DialogState property, DialogSet and AttachmentPrompt.
+        dialog_state = convo_state.create_property("dialog_state")
+        dialogs = DialogSet(dialog_state)
+        dialogs.add(SimpleActivityPrompt("EventActivityPrompt", validator))
+
+        async def exec_test(turn_context: TurnContext):
+            dialog_context = await dialogs.create_context(turn_context)
+
+            results = await dialog_context.continue_dialog()
+
+            if results.status == DialogTurnStatus.Empty:
+                options = PromptOptions(
+                    prompt=Activity(
+                        type=ActivityTypes.message, text="please send an event."
+                    )
+                )
+
+                try:
+                    await dialog_context.prompt("EventActivityPrompt", options)
+                    await dialog_context.replace_dialog("Non existent id", options)
+                except Exception as err:
+                    self.assertIsNotNone(err.data["DialogContext"])
+                else:
+                    raise Exception("Should have thrown an error.")
+
+            elif results.status == DialogTurnStatus.Complete:
+                await turn_context.send_activity(results.result)
+
+            await convo_state.save_changes(turn_context)
+
+        # Initialize TestAdapter.
+        adapter = TestAdapter(exec_test)
+
+        await adapter.send("hello")

--- a/libraries/botbuilder-dialogs/tests/test_activity_prompt.py
+++ b/libraries/botbuilder-dialogs/tests/test_activity_prompt.py
@@ -241,11 +241,11 @@ class ActivityPromptTests(aiounittest.AsyncTestCase):
                     await dialog_context.prompt("EventActivityPrompt", options)
                     await dialog_context.prompt("Non existent id", options)
                 except Exception as err:
-                    self.assertIsNotNone(err.data["DialogContext"])
+                    self.assertIsNotNone(err.data["DialogContext"]) # pylint: disable=no-member
                     self.assertEqual(
-                        err.data["DialogContext"]["active_dialog"],
+                        err.data["DialogContext"]["active_dialog"], # pylint: disable=no-member
                         "EventActivityPrompt",
-                    )
+                    ) 
                 else:
                     raise Exception("Should have thrown an error.")
 
@@ -284,7 +284,7 @@ class ActivityPromptTests(aiounittest.AsyncTestCase):
                     await dialog_context.prompt("EventActivityPrompt", options)
                     await dialog_context.replace_dialog("Non existent id", options)
                 except Exception as err:
-                    self.assertIsNotNone(err.data["DialogContext"])
+                    self.assertIsNotNone(err.data["DialogContext"]) # pylint: disable=no-member
                 else:
                     raise Exception("Should have thrown an error.")
 

--- a/libraries/botbuilder-dialogs/tests/test_activity_prompt.py
+++ b/libraries/botbuilder-dialogs/tests/test_activity_prompt.py
@@ -245,7 +245,7 @@ class ActivityPromptTests(aiounittest.AsyncTestCase):
                     self.assertEqual(
                         err.data["DialogContext"]["active_dialog"], # pylint: disable=no-member
                         "EventActivityPrompt",
-                    ) 
+                    )
                 else:
                     raise Exception("Should have thrown an error.")
 


### PR DESCRIPTION
Fixes #1218

## Description
Change `DialogContext` to capture exceptions and resolve information about context in each Exception error.
This change is PORTED from DotNet.

## Specific Changes
Add `try/catch` handlers to `DialogContext` class methods to set `Exception.data["DialogContext']` with metadata about the context.

> **Note:** The PORT does not include the state property in data, because in DotNet it gets it from the `State` property but in Python does not exist.

## Testing
In the following images there is a sneak peek about the information structure and the passing tests.
![imagen](https://user-images.githubusercontent.com/62260472/98865261-e64dc100-2449-11eb-9d74-81cbcc611adc.png)
![imagen](https://user-images.githubusercontent.com/62260472/98865270-e8178480-2449-11eb-8207-1b5cba27482f.png)