### PR TITLE
fix type annotation

### DIFF
--- a/libraries/botbuilder-ai/botbuilder/ai/qna/utils/qna_card_builder.py
+++ b/libraries/botbuilder-ai/botbuilder/ai/qna/utils/qna_card_builder.py
@@ -14,7 +14,7 @@ class QnACardBuilder:
 
     @staticmethod
     def get_suggestions_card(
-        suggestions: [str], card_title: str, card_no_match: str
+        suggestions: List[str], card_title: str, card_no_match: str
     ) -> Activity:
         """
         Get active learning suggestions card.


### PR DESCRIPTION
Fixes #<!-- If this addresses a specific issue, please provide the issue number here -->
#1458

## Description
VSCode's pylance complained about this, the message was:
```
List expression not allowed in type annotation
  Use List[T] instead
```
It'd be a good idea to scan all the code for other occurrences of the issue.

## Specific Changes
- Changed `[str]` to `List[str]` in the type annotation of `get_suggestions_card()`