### PR TITLE
Use version ranges 3rd party deps

### DIFF
--- a/libraries/botbuilder-ai/setup.py
+++ b/libraries/botbuilder-ai/setup.py
@@ -8,7 +8,7 @@ REQUIRES = [
     "azure-cognitiveservices-language-luis==0.2.0",
     "botbuilder-schema==4.12.0",
     "botbuilder-core==4.12.0",
-    "aiohttp==3.6.2",
+    "aiohttp>=3.6.2,<3.8.0",
 ]
 
 TESTS_REQUIRES = ["aiounittest>=1.1.0"]

--- a/libraries/botbuilder-ai/tests/requirements.txt
+++ b/libraries/botbuilder-ai/tests/requirements.txt
@@ -1,1 +1,1 @@
-aioresponses==0.6.3
+aioresponses>=0.7.1

--- a/libraries/botbuilder-azure/setup.py
+++ b/libraries/botbuilder-azure/setup.py
@@ -9,7 +9,7 @@ REQUIRES = [
     "azure-storage-blob==2.1.0",
     "botbuilder-schema==4.12.0",
     "botframework-connector==4.12.0",
-    "jsonpickle==1.2",
+    "jsonpickle>=1.2,<1.5",
 ]
 TEST_REQUIRES = ["aiounittest==1.3.0"]
 

--- a/libraries/botbuilder-core/setup.py
+++ b/libraries/botbuilder-core/setup.py
@@ -8,7 +8,7 @@ VERSION = os.environ["packageVersion"] if "packageVersion" in os.environ else "4
 REQUIRES = [
     "botbuilder-schema==4.12.0",
     "botframework-connector==4.12.0",
-    "jsonpickle==1.2",
+    "jsonpickle>=1.2,<1.5",
 ]
 
 root = os.path.abspath(os.path.dirname(__file__))

--- a/libraries/botbuilder-integration-aiohttp/setup.py
+++ b/libraries/botbuilder-integration-aiohttp/setup.py
@@ -9,7 +9,7 @@ REQUIRES = [
     "botbuilder-schema==4.12.0",
     "botframework-connector==4.12.0",
     "botbuilder-core==4.12.0",
-    "aiohttp==3.6.2",
+    "aiohttp>=3.6.2,<3.8.0",
 ]
 
 root = os.path.abspath(os.path.dirname(__file__))

--- a/libraries/botbuilder-integration-applicationinsights-aiohttp/setup.py
+++ b/libraries/botbuilder-integration-applicationinsights-aiohttp/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup
 
 REQUIRES = [
     "applicationinsights>=0.11.9",
-    "aiohttp==3.6.2",
+    "aiohttp>=3.6.2,<3.8.0",
     "botbuilder-schema==4.12.0",
     "botframework-connector==4.12.0",
     "botbuilder-core==4.12.0",

--- a/libraries/botframework-connector/setup.py
+++ b/libraries/botframework-connector/setup.py
@@ -7,9 +7,8 @@ NAME = "botframework-connector"
 VERSION = os.environ["packageVersion"] if "packageVersion" in os.environ else "4.12.0"
 REQUIRES = [
     "msrest==0.6.10",
-    "requests==2.23.0",
-    "cryptography==3.2",
-    "PyJWT==1.5.3",
+    "requests>=2.23.0,<2.26",
+    "PyJWT>=1.5.3,<2.0.0",
     "botbuilder-schema==4.12.0",
     "adal==1.2.1",
     "msal==1.6.0",


### PR DESCRIPTION
Fixes #1467

## Description
Allow apps that embed the BotBuilder Framework to use newer deps if they need it.

This PR is needed to allow BotFramework to be included in existing apps by reducing the likelihood of version conflicts.

## Specific Changes

Looking at changelogs, these version ranges should be safe:
- `PyJWT` has backwards incompatible changes in 2.0.0. so `~=1.5.3` (ie `>=1.5.3,<2.0.0`)
- `requests` has no major changes between 2.23.0 and 2.25.1 (by reading the code changes).
  As requests has had breaking changes in minor releases before, cap it at `<2.6`
- `aiohttp` has no major changes 

Drops `cryptography`, as `botframework-connector` does not use it directly.
These dependencies do use it, so let them specify their acceptable versions:
- `adal==1.2.1` requires `cryptography>=1.1.0`
- `msal==1.6.0` requires `cryptography>=0.6,<4`
- `PyJWT>=1.5.3,<2.0.0` requires `cryptography>=1.4.0,<4.0.0` (newer versions bump the min, but not the max)
- `requests>=2.23.0,<3.0.0` requires `cryptography>=1.3.4`

Looking at changelog, current versions of aiohttp (3.7.*) should also be
fairly compatible with 3.6.*, so allow `aiohttp>=3.6.2,<3.8.0`.

`jsonpickle` added python 3.8 support in 1.4, so allow `jsonpickle>=1.2,<1.5`

## Testing
no new features. CI tests should pass.