### PR TITLE
Add PromptCultureModels, rework prompt locales

### DIFF
--- a/libraries/botbuilder-dialogs/botbuilder/dialogs/prompts/__init__.py
+++ b/libraries/botbuilder-dialogs/botbuilder/dialogs/prompts/__init__.py
@@ -14,6 +14,7 @@ from .datetime_resolution import DateTimeResolution
 from .number_prompt import NumberPrompt
 from .oauth_prompt import OAuthPrompt
 from .oauth_prompt_settings import OAuthPromptSettings
+from .prompt_culture_models import PromptCultureModel, PromptCultureModels
 from .prompt_options import PromptOptions
 from .prompt_recognizer_result import PromptRecognizerResult
 from .prompt_validator_context import PromptValidatorContext
@@ -30,6 +31,8 @@ __all__ = [
     "NumberPrompt",
     "OAuthPrompt",
     "OAuthPromptSettings",
+    "PromptCultureModel",
+    "PromptCultureModels",
     "PromptOptions",
     "PromptRecognizerResult",
     "PromptValidatorContext",

--- a/libraries/botbuilder-dialogs/botbuilder/dialogs/prompts/prompt_culture_models.py
+++ b/libraries/botbuilder-dialogs/botbuilder/dialogs/prompts/prompt_culture_models.py
@@ -1,0 +1,190 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+from typing import List
+
+from recognizers_text import Culture
+
+
+class PromptCultureModel:
+    """
+    Culture model used in Choice and Confirm Prompts.
+    """
+
+    def __init__(
+        self,
+        locale: str,
+        separator: str,
+        inline_or: str,
+        inline_or_more: str,
+        yes_in_language: str,
+        no_in_language: str,
+    ):
+        """
+
+        :param locale: Culture Model's Locale. Example: "en-US".
+        :param separator: Culture Model's Inline Separator. Example: ", ".
+        :param inline_or: Culture Model's Inline Or. Example: " or ".
+        :param inline_or_more Culture Model's Inline Or More. Example: ", or ".
+        :param yes_in_language: Equivalent of "Yes" in Culture Model's Language. Example: "Yes".
+        :param no_in_language: Equivalent of "No" in Culture Model's Language. Example: "No".
+        """
+        self.locale = locale
+        self.separator = separator
+        self.inline_or = inline_or
+        self.inline_or_more = inline_or_more
+        self.yes_in_language = yes_in_language
+        self.no_in_language = no_in_language
+
+
+class PromptCultureModels:
+    """
+    Class container for currently-supported Culture Models in Confirm and Choice Prompt.
+    """
+
+    Chinese = PromptCultureModel(
+        locale=Culture.Chinese,
+        inline_or=" 要么 ",
+        inline_or_more="， 要么 ",
+        separator="， ",
+        no_in_language="不",
+        yes_in_language="是的",
+    )
+
+    Dutch = PromptCultureModel(
+        locale=Culture.Dutch,
+        inline_or=" of ",
+        inline_or_more=", of ",
+        separator=", ",
+        no_in_language="Nee",
+        yes_in_language="Ja",
+    )
+
+    English = PromptCultureModel(
+        locale=Culture.English,
+        inline_or=" or ",
+        inline_or_more=", or ",
+        separator=", ",
+        no_in_language="No",
+        yes_in_language="Yes",
+    )
+
+    French = PromptCultureModel(
+        locale=Culture.French,
+        inline_or=" ou ",
+        inline_or_more=", ou ",
+        separator=", ",
+        no_in_language="Non",
+        yes_in_language="Oui",
+    )
+
+    German = PromptCultureModel(
+        # TODO: Replace with Culture.German after Recognizers-Text package updates.
+        locale="de-de",
+        inline_or=" oder ",
+        inline_or_more=", oder ",
+        separator=", ",
+        no_in_language="Nein",
+        yes_in_language="Ja",
+    )
+
+    Italian = PromptCultureModel(
+        locale=Culture.Italian,
+        inline_or=" o ",
+        inline_or_more=" o ",
+        separator=", ",
+        no_in_language="No",
+        yes_in_language="Si",
+    )
+
+    Japanese = PromptCultureModel(
+        locale=Culture.Japanese,
+        inline_or=" または ",
+        inline_or_more="、 または ",
+        separator="、 ",
+        no_in_language="いいえ",
+        yes_in_language="はい",
+    )
+
+    Korean = PromptCultureModel(
+        locale=Culture.Korean,
+        inline_or=" 또는 ",
+        inline_or_more=" 또는 ",
+        separator=", ",
+        no_in_language="아니",
+        yes_in_language="예",
+    )
+
+    Portuguese = PromptCultureModel(
+        locale=Culture.Portuguese,
+        inline_or=" ou ",
+        inline_or_more=", ou ",
+        separator=", ",
+        no_in_language="Não",
+        yes_in_language="Sim",
+    )
+
+    Spanish = PromptCultureModel(
+        locale=Culture.Spanish,
+        inline_or=" o ",
+        inline_or_more=", o ",
+        separator=", ",
+        no_in_language="No",
+        yes_in_language="Sí",
+    )
+
+    Turkish = PromptCultureModel(
+        locale=Culture.Turkish,
+        inline_or=" veya ",
+        inline_or_more=" veya ",
+        separator=", ",
+        no_in_language="Hayır",
+        yes_in_language="Evet",
+    )
+
+    @classmethod
+    def map_to_nearest_language(cls, culture_code: str) -> str:
+        """
+        Normalize various potential locale strings to a standard.
+        :param culture_code: Represents locale. Examples: "en-US, en-us, EN".
+        :return: Normalized locale.
+        :rtype: str
+
+        .. remarks::
+            In our other SDKs, this method is a copy/paste of the ones from the Recognizers-Text library.
+            However, that doesn't exist in Python.
+        """
+        if culture_code:
+            culture_code = culture_code.lower()
+            supported_culture_codes = cls._get_supported_locales()
+
+            if culture_code not in supported_culture_codes:
+                culture_prefix = culture_code.split("-")[0]
+
+                for supported_culture_code in supported_culture_codes:
+                    if supported_culture_code.startswith(culture_prefix):
+                        culture_code = supported_culture_code
+
+        return culture_code
+
+    @classmethod
+    def get_supported_cultures(cls) -> List[PromptCultureModel]:
+        """
+        Gets a list of the supported culture models.
+        """
+        return [
+            cls.Chinese,
+            cls.Dutch,
+            cls.English,
+            cls.French,
+            cls.Italian,
+            cls.Japanese,
+            cls.Korean,
+            cls.Portuguese,
+            cls.Spanish,
+            cls.Turkish,
+        ]
+
+    @classmethod
+    def _get_supported_locales(cls) -> List[str]:
+        return [c.locale for c in cls.get_supported_cultures()]

--- a/libraries/botbuilder-dialogs/tests/test_choice_prompt.py
+++ b/libraries/botbuilder-dialogs/tests/test_choice_prompt.py
@@ -437,8 +437,10 @@ class ChoicePromptTest(aiounittest.AsyncTestCase):
             # Hold the correct answer from when a valid locale is used
             expected_answer = None
 
-            def inspector(activity: Activity):
+            def inspector(activity: Activity, description: str):
                 nonlocal expected_answer
+
+                assert not description
 
                 if valid_locale == test_locale:
                     expected_answer = activity.text

--- a/libraries/botbuilder-dialogs/tests/test_confirm_prompt.py
+++ b/libraries/botbuilder-dialogs/tests/test_confirm_prompt.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
+from typing import List
 import aiounittest
 from botbuilder.core import (
     ConversationState,
@@ -10,9 +11,13 @@ from botbuilder.core import (
 )
 from botbuilder.core.adapters import TestAdapter
 from botbuilder.dialogs import DialogSet, DialogTurnResult, DialogTurnStatus
-from botbuilder.dialogs.choices import ChoiceFactoryOptions, ListStyle
-from botbuilder.dialogs.prompts import ConfirmPrompt
-from botbuilder.dialogs.prompts import PromptOptions
+from botbuilder.dialogs.choices import Choice, ChoiceFactoryOptions, ListStyle
+from botbuilder.dialogs.prompts import (
+    ConfirmPrompt,
+    PromptCultureModel,
+    PromptOptions,
+    PromptValidatorContext,
+)
 from botbuilder.schema import Activity, ActivityTypes
 
 
@@ -274,3 +279,219 @@ class ConfirmPromptTest(aiounittest.AsyncTestCase):
         )
         step5 = await step4.send("no")
         await step5.assert_reply("Not confirmed")
+
+    async def test_confirm_prompt_should_default_to_english_locale(self):
+        async def exec_test(turn_context: TurnContext):
+
+            dialog_context = await dialogs.create_context(turn_context)
+
+            results: DialogTurnResult = await dialog_context.continue_dialog()
+
+            if results.status == DialogTurnStatus.Empty:
+                options = PromptOptions(
+                    prompt=Activity(type=ActivityTypes.message, text="Please confirm."),
+                    retry_prompt=Activity(
+                        type=ActivityTypes.message,
+                        text="Please confirm, say 'yes' or 'no' or something like that.",
+                    ),
+                )
+                await dialog_context.prompt("ConfirmPrompt", options)
+            elif results.status == DialogTurnStatus.Complete:
+                message_text = "Confirmed" if results.result else "Not confirmed"
+                await turn_context.send_activity(MessageFactory.text(message_text))
+
+            await convo_state.save_changes(turn_context)
+
+        locales = [None, "", "not-supported"]
+
+        for locale in locales:
+            # Initialize TestAdapter.
+            adapter = TestAdapter(exec_test)
+
+            # Create new ConversationState with MemoryStorage and register the state as middleware.
+            convo_state = ConversationState(MemoryStorage())
+
+            # Create a DialogState property, DialogSet, and ChoicePrompt.
+            dialog_state = convo_state.create_property("dialogState")
+            dialogs = DialogSet(dialog_state)
+            confirm_prompt = ConfirmPrompt("ConfirmPrompt")
+            confirm_prompt.choice_options = ChoiceFactoryOptions(include_numbers=True)
+            dialogs.add(confirm_prompt)
+
+            step1 = await adapter.send(
+                Activity(type=ActivityTypes.message, text="Hello", locale=locale)
+            )
+            step2 = await step1.assert_reply("Please confirm. (1) Yes or (2) No")
+            step3 = await step2.send("lala")
+            step4 = await step3.assert_reply(
+                "Please confirm, say 'yes' or 'no' or something like that. (1) Yes or (2) No"
+            )
+            step5 = await step4.send("2")
+            await step5.assert_reply("Not confirmed")
+
+    async def test_should_recognize_locale_variations_of_correct_locales(self):
+        def cap_ending(locale: str) -> str:
+            return f"{locale.split('-')[0]}-{locale.split('-')[1].upper()}"
+
+        def title_ending(locale: str) -> str:
+            return locale[:3] + locale[3].upper() + locale[4:]
+
+        def cap_two_letter(locale: str) -> str:
+            return locale.split("-")[0].upper()
+
+        def lower_two_letter(locale: str) -> str:
+            return locale.split("-")[0].upper()
+
+        async def exec_test_for_locale(valid_locale: str, locale_variations: List):
+            # Hold the correct answer from when a valid locale is used
+            expected_answer = None
+
+            def inspector(activity: Activity):
+                nonlocal expected_answer
+
+                if valid_locale == test_locale:
+                    expected_answer = activity.text
+                else:
+                    # Ensure we're actually testing a variation.
+                    assert activity.locale != valid_locale
+
+                assert activity.text == expected_answer
+                return True
+
+            async def exec_test(turn_context: TurnContext):
+                dialog_context = await dialogs.create_context(turn_context)
+
+                results: DialogTurnResult = await dialog_context.continue_dialog()
+
+                if results.status == DialogTurnStatus.Empty:
+                    options = PromptOptions(
+                        prompt=Activity(
+                            type=ActivityTypes.message, text="Please confirm."
+                        )
+                    )
+                    await dialog_context.prompt("prompt", options)
+                elif results.status == DialogTurnStatus.Complete:
+                    confirmed = results.result
+                    if confirmed:
+                        await turn_context.send_activity("true")
+                    else:
+                        await turn_context.send_activity("false")
+
+                await convo_state.save_changes(turn_context)
+
+            async def validator(prompt: PromptValidatorContext) -> bool:
+                assert prompt
+
+                if not prompt.recognized.succeeded:
+                    await prompt.context.send_activity("Bad input.")
+
+                return prompt.recognized.succeeded
+
+            test_locale = None
+            for test_locale in locale_variations:
+                adapter = TestAdapter(exec_test)
+
+                convo_state = ConversationState(MemoryStorage())
+                dialog_state = convo_state.create_property("dialogState")
+                dialogs = DialogSet(dialog_state)
+
+                choice_prompt = ConfirmPrompt("prompt", validator)
+                dialogs.add(choice_prompt)
+
+                step1 = await adapter.send(
+                    Activity(
+                        type=ActivityTypes.message, text="Hello", locale=test_locale
+                    )
+                )
+                await step1.assert_reply(inspector)
+
+        locales = [
+            "zh-cn",
+            "nl-nl",
+            "en-us",
+            "fr-fr",
+            "de-de",
+            "it-it",
+            "ja-jp",
+            "ko-kr",
+            "pt-br",
+            "es-es",
+            "tr-tr",
+            "de-de",
+        ]
+
+        locale_tests = []
+        for locale in locales:
+            locale_tests.append(
+                [
+                    locale,
+                    cap_ending(locale),
+                    title_ending(locale),
+                    cap_two_letter(locale),
+                    lower_two_letter(locale),
+                ]
+            )
+
+        # Test each valid locale
+        for locale_tests in locale_tests:
+            await exec_test_for_locale(locale_tests[0], locale_tests)
+
+    async def test_should_recognize_and_use_custom_locale_dict(self,):
+        async def exec_test(turn_context: TurnContext):
+            dialog_context = await dialogs.create_context(turn_context)
+
+            results: DialogTurnResult = await dialog_context.continue_dialog()
+
+            if results.status == DialogTurnStatus.Empty:
+                options = PromptOptions(
+                    prompt=Activity(type=ActivityTypes.message, text="Please confirm.")
+                )
+                await dialog_context.prompt("prompt", options)
+            elif results.status == DialogTurnStatus.Complete:
+                selected_choice = results.result
+                await turn_context.send_activity(selected_choice.value)
+
+            await convo_state.save_changes(turn_context)
+
+        async def validator(prompt: PromptValidatorContext) -> bool:
+            assert prompt
+
+            if not prompt.recognized.succeeded:
+                await prompt.context.send_activity("Bad input.")
+
+            return prompt.recognized.succeeded
+
+        adapter = TestAdapter(exec_test)
+
+        convo_state = ConversationState(MemoryStorage())
+        dialog_state = convo_state.create_property("dialogState")
+        dialogs = DialogSet(dialog_state)
+
+        culture = PromptCultureModel(
+            locale="custom-locale",
+            no_in_language="customNo",
+            yes_in_language="customYes",
+            separator="customSeparator",
+            inline_or="customInlineOr",
+            inline_or_more="customInlineOrMore",
+        )
+
+        custom_dict = {
+            culture.locale: (
+                Choice(culture.yes_in_language),
+                Choice(culture.no_in_language),
+                ChoiceFactoryOptions(
+                    culture.separator, culture.inline_or, culture.inline_or_more, True
+                ),
+            )
+        }
+
+        confirm_prompt = ConfirmPrompt("prompt", validator, choice_defaults=custom_dict)
+        dialogs.add(confirm_prompt)
+
+        step1 = await adapter.send(
+            Activity(type=ActivityTypes.message, text="Hello", locale=culture.locale)
+        )
+        await step1.assert_reply(
+            "Please confirm. (1) customYescustomInlineOr(2) customNo"
+        )

--- a/libraries/botbuilder-dialogs/tests/test_confirm_prompt.py
+++ b/libraries/botbuilder-dialogs/tests/test_confirm_prompt.py
@@ -346,8 +346,10 @@ class ConfirmPromptTest(aiounittest.AsyncTestCase):
             # Hold the correct answer from when a valid locale is used
             expected_answer = None
 
-            def inspector(activity: Activity):
+            def inspector(activity: Activity, description: str):
                 nonlocal expected_answer
+
+                assert not description
 
                 if valid_locale == test_locale:
                     expected_answer = activity.text


### PR DESCRIPTION
Fixes #582 

## Description

This mainly adjusts Confirm and Choice prompts use of locale to:

1. Use English as default
2. Go away from hard-coding the cultures in each prompt to a single source of truth for supported cultures
3. Accept variations of locale strings ("EN", "en-US", "en-us", etc) (this was an issue in other SDKs for some channels)
4. Add tests for locales
5. Also adds support for Italian, Korean, and Turkish, to match published `recognizers-text` support.

This PR gets these prompts in line with .NET/JS.

## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->

![image](https://user-images.githubusercontent.com/40401643/110015551-d435ae00-7cd8-11eb-8788-61ed35628c64.png)
![image](https://user-images.githubusercontent.com/40401643/110015565-da2b8f00-7cd8-11eb-8c4c-46b22e9753e6.png)

![image](https://user-images.githubusercontent.com/40401643/110017494-1fe95700-7cdb-11eb-8ff9-697cbf555c0e.png)
![image](https://user-images.githubusercontent.com/40401643/110017529-2972bf00-7cdb-11eb-8aea-7c055d729fde.png)

