### PR TITLE
Only show "NO MATCH" response button if active learning is active

### DIFF
--- a/libraries/botbuilder-ai/botbuilder/ai/qna/utils/qna_card_builder.py
+++ b/libraries/botbuilder-ai/botbuilder/ai/qna/utils/qna_card_builder.py
@@ -67,13 +67,6 @@ class QnACardBuilder:
             for prompt in result.context.prompts
         ]
 
-        # Add No match text
-        button_list.append(
-            CardAction(
-                value=card_no_match_text, type="imBack", title=card_no_match_text,
-            )
-        )
-
         attachment = CardFactory.hero_card(HeroCard(buttons=button_list))
 
         return Activity(

--- a/libraries/botbuilder-ai/tests/qna/test_data/QnAMakerDialog_ActiveLearning.json
+++ b/libraries/botbuilder-ai/tests/qna/test_data/QnAMakerDialog_ActiveLearning.json
@@ -1,0 +1,65 @@
+{
+    "answers": [
+        {
+            "questions": [
+                "Esper seeks"
+            ],
+            "answer": "Esper seeks. She's a curious little explorer. Young toddlers seek out new adventures, expanding their knowledge base. It's their job to test limits, to learn about them. It's the adult's job to enforce the limits, while also allowing room for exploration",
+            "score": 79.65,
+            "id": 35,
+            "source": "Editorial",
+            "isDocumentText": false,
+            "metadata": [],
+            "context": {
+                "isContextOnly": false,
+                "prompts": []
+            }
+        },
+        {
+            "questions": [
+                "Esper sups"
+            ],
+            "answer": "Esper sups. She eats just about anything. She loves her broccoli. Anything that she sees her parents eating, she wants to part take in herself.\n\nCaution though. If she spots you eating dessert, you best be prepared to share with her. Best to wait until she goes down for bed and then sneak your favorite snack in, without her prying eyes.",
+            "score": 79.65,
+            "id": 36,
+            "source": "Editorial",
+            "isDocumentText": false,
+            "metadata": [],
+            "context": {
+                "isContextOnly": false,
+                "prompts": []
+            }
+        },
+        {
+            "questions": [
+                "Esper screams"
+            ],
+            "answer": "Esper screams. The currently 1-year old toddler has a brain that's rapidly developing, expanding to new abilities at an alarming rate. With it may come fright or possibly frustration as they understand what could be done, however they need to master how to do a task themselves",
+            "score": 66.89,
+            "id": 34,
+            "source": "Editorial",
+            "isDocumentText": false,
+            "metadata": [],
+            "context": {
+                "isContextOnly": false,
+                "prompts": []
+            }
+        },
+        {
+            "questions": [
+                "Esper sleeps"
+            ],
+            "answer": "Esper sleeps. Esper sleeps on her floor bed. She never had a crib, as her parents placed her directly on the floor bed since birth. With this comes the benefit of not having to have an awkward transition period from crib to bed, when she gets old enough.\n\nThe idea of using the bed is that it offers the child more freedom to move about--more autonomy. Downside is, they will definitely wander off the bed, when they don't want to sleep",
+            "score": 65.71,
+            "id": 33,
+            "source": "Editorial",
+            "isDocumentText": false,
+            "metadata": [],
+            "context": {
+                "isContextOnly": false,
+                "prompts": []
+            }
+        }
+    ],
+    "activeLearningEnabled": true
+}

--- a/libraries/botbuilder-ai/tests/qna/test_data/QnAMakerDialog_MultiTurn_Answer1.json
+++ b/libraries/botbuilder-ai/tests/qna/test_data/QnAMakerDialog_MultiTurn_Answer1.json
@@ -1,0 +1,32 @@
+{
+    "answers": [
+        {
+            "questions": [
+                "Tell me about birds",
+                "What do you know about birds"
+            ],
+            "answer": "Choose one of the following birds to get more info",
+            "score": 100.0,
+            "id": 37,
+            "source": "Editorial",
+            "isDocumentText": false,
+            "metadata": [],
+            "context": {
+                "isContextOnly": false,
+                "prompts": [
+                    {
+                        "displayOrder": 1,
+                        "qnaId": 38,
+                        "displayText": "Bald Eagle"
+                    },
+                    {
+                        "displayOrder": 2,
+                        "qnaId": 39,
+                        "displayText": "Hummingbird"
+                    }
+                ]
+            }
+        }
+    ],
+    "activeLearningEnabled": true
+}

--- a/libraries/botbuilder-ai/tests/qna/test_data/QnAMakerDialog_MultiTurn_Answer2.json
+++ b/libraries/botbuilder-ai/tests/qna/test_data/QnAMakerDialog_MultiTurn_Answer2.json
@@ -1,0 +1,20 @@
+{
+    "answers": [
+        {
+            "questions": [
+                "Bald Eagle"
+            ],
+            "answer": "Apparently these guys aren't actually bald!",
+            "score": 100.0,
+            "id": 38,
+            "source": "Editorial",
+            "isDocumentText": false,
+            "metadata": [],
+            "context": {
+                "isContextOnly": true,
+                "prompts": []
+            }
+        }
+    ],
+    "activeLearningEnabled": true
+}

--- a/libraries/botbuilder-ai/tests/qna/test_qna_dialog.py
+++ b/libraries/botbuilder-ai/tests/qna/test_qna_dialog.py
@@ -10,6 +10,7 @@ from botbuilder.core import ConversationState, MemoryStorage, TurnContext
 from botbuilder.core.adapters import TestAdapter, TestFlow
 from botbuilder.dialogs import DialogSet, DialogTurnStatus
 
+
 class QnaMakerDialogTest(aiounittest.AsyncTestCase):
     # Note this is NOT a real QnA Maker application ID nor a real QnA Maker subscription-key
     # theses are GUIDs edited to look right to the parsing and validation code.

--- a/libraries/botbuilder-ai/tests/qna/test_qna_dialog.py
+++ b/libraries/botbuilder-ai/tests/qna/test_qna_dialog.py
@@ -1,0 +1,100 @@
+import aiounittest
+import json
+import unittest
+from os import path
+from unittest.mock import patch
+
+# from botbuilder.ai.qna import QnAMakerEndpoint, QnAMaker, QnAMakerOptions
+from botbuilder.ai.qna.dialogs import QnAMakerDialog
+from botbuilder.core import ConversationState, MemoryStorage, TurnContext
+from botbuilder.core.adapters import TestAdapter, TestFlow
+from botbuilder.dialogs import (
+    # Dialog,
+    DialogSet,
+    # WaterfallDialog,
+    # WaterfallStepContext,
+    # DialogTurnResult,
+    DialogTurnStatus,
+)
+
+class QnaMakerDialogTest(aiounittest.AsyncTestCase):
+    # Note this is NOT a real QnA Maker application ID nor a real QnA Maker subscription-key
+    # theses are GUIDs edited to look right to the parsing and validation code.
+
+    _knowledge_base_id: str = "f028d9k3-7g9z-11d3-d300-2b8x98227q8w"
+    _endpoint_key: str = "1k997n7w-207z-36p3-j2u1-09tas20ci6011"
+    _host: str = "https://dummyqnahost.azurewebsites.net/qnamaker"
+
+    _tell_me_about_birds_text: str = "Tell me about birds"
+    _choose_bird_text: str = "Choose one of the following birds to get more info"
+    _bald_eagle_text: str = "Bald Eagle"
+    _not_bald_text: str = "Apparently these guys aren't actually bald!"
+
+    # tests_endpoint = QnAMakerEndpoint(_knowledge_base_id, _endpoint_key, _host)
+
+    # TODO - this is from test_waterfall.py -- update it to work for qna dialog
+    async def test_multiturn_qna_dialog(self):
+        convo_state = ConversationState(MemoryStorage())
+        dialog_state = convo_state.create_property("dialogState")
+        # TODO - verify whether or not we need UserState too like in sample 49, or just convo state
+        dialogs = DialogSet(dialog_state)
+
+        qna_dialog = QnAMakerDialog(
+            self._knowledge_base_id,
+            self._endpoint_key,
+            self._host
+        )
+        dialogs.add(qna_dialog)
+
+        async def execute_qna_dialog_test(turn_context: TurnContext) -> None:
+            if (turn_context.activity.type != 'message'):
+                raise TypeError('Failed to execute QnA dialog. Should have received a message activity.')
+
+            response_json = QnaMakerDialogTest._get_json_res(turn_context.activity.text)
+            dialog_context = await dialogs.create_context(turn_context)
+
+            with patch(
+                "aiohttp.ClientSession.post",
+                return_value=aiounittest.futurized(response_json),
+            ):
+                results = await dialog_context.continue_dialog()
+
+                if results.status == DialogTurnStatus.Empty:
+                    await dialog_context.begin_dialog("QnAMakerDialog")
+
+                await convo_state.save_changes(turn_context)
+
+        adapt = TestAdapter(execute_qna_dialog_test)
+
+        test_flow = TestFlow(None, adapt)
+        tf2 = await test_flow.send(self._tell_me_about_birds_text)
+        dialog_reply = tf2.adapter.activity_buffer[0]
+        tf3 = await tf2.assert_reply(self._choose_bird_text)
+        tf4 = await tf3.send(self._bald_eagle_text)
+        await tf4.assert_reply("Apparently these guys aren't actually bald!")
+    
+    # TODO - maybe this could be static
+    @classmethod
+    def _get_json_for_file(cls, response_file: str) -> object:
+        curr_dir = path.dirname(path.abspath(__file__))
+        response_path = path.join(curr_dir, "test_data", response_file)
+
+        with open(response_path, "r", encoding="utf-8-sig") as file:
+            response_str = file.read()
+        response_json = json.loads(response_str)
+
+        return response_json
+    
+    @classmethod
+    def _get_json_res(cls, text: str) -> object:
+        if (text == cls._tell_me_about_birds_text):
+            return QnaMakerDialogTest._get_json_for_file("QnAMakerDialog_MultiTurn_Answer1.json")
+        
+        if (text == cls._bald_eagle_text):
+            # file_name = cls._not_bald_text
+            return QnaMakerDialogTest._get_json_for_file("QnAMakerDialog_MultiTurn_Answer2.json")
+
+        
+        # QnaMakerDialogTest._get_json_for_file("QnAMakerDialog_MultiTurn_Answer2.json")
+
+        

--- a/libraries/botbuilder-ai/tests/qna/test_qna_dialog.py
+++ b/libraries/botbuilder-ai/tests/qna/test_qna_dialog.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 # from botbuilder.ai.qna import QnAMakerEndpoint, QnAMaker, QnAMakerOptions
 from botbuilder.ai.qna.dialogs import QnAMakerDialog
+from botbuilder.schema import Activity, ActivityTypes
 from botbuilder.core import ConversationState, MemoryStorage, TurnContext
 from botbuilder.core.adapters import TestAdapter, TestFlow
 from botbuilder.dialogs import (
@@ -28,15 +29,12 @@ class QnaMakerDialogTest(aiounittest.AsyncTestCase):
     _tell_me_about_birds_text: str = "Tell me about birds"
     _choose_bird_text: str = "Choose one of the following birds to get more info"
     _bald_eagle_text: str = "Bald Eagle"
+    _hummingbird_text: str = "Hummingbird"
     _not_bald_text: str = "Apparently these guys aren't actually bald!"
 
-    # tests_endpoint = QnAMakerEndpoint(_knowledge_base_id, _endpoint_key, _host)
-
-    # TODO - this is from test_waterfall.py -- update it to work for qna dialog
     async def test_multiturn_qna_dialog(self):
         convo_state = ConversationState(MemoryStorage())
         dialog_state = convo_state.create_property("dialogState")
-        # TODO - verify whether or not we need UserState too like in sample 49, or just convo state
         dialogs = DialogSet(dialog_state)
 
         qna_dialog = QnAMakerDialog(
@@ -47,12 +45,11 @@ class QnaMakerDialogTest(aiounittest.AsyncTestCase):
         dialogs.add(qna_dialog)
 
         async def execute_qna_dialog_test(turn_context: TurnContext) -> None:
-            if (turn_context.activity.type != 'message'):
+            if (turn_context.activity.type != ActivityTypes.message):
                 raise TypeError('Failed to execute QnA dialog. Should have received a message activity.')
 
             response_json = QnaMakerDialogTest._get_json_res(turn_context.activity.text)
             dialog_context = await dialogs.create_context(turn_context)
-
             with patch(
                 "aiohttp.ClientSession.post",
                 return_value=aiounittest.futurized(response_json),
@@ -68,22 +65,21 @@ class QnaMakerDialogTest(aiounittest.AsyncTestCase):
 
         test_flow = TestFlow(None, adapt)
         tf2 = await test_flow.send(self._tell_me_about_birds_text)
-        dialog_reply = tf2.adapter.activity_buffer[0]
+        dialog_reply: Activity = tf2.adapter.activity_buffer[0]
+        self.assertIsNotNone(dialog_reply)
+        self.assertIsInstance(dialog_reply, Activity)
+        attachments = dialog_reply.attachments
+        self.assertTrue(attachments)
+        self.assertEqual(len(attachments), 1)
+        buttons = attachments[0].content.buttons
+        self.assertEqual(
+            len(buttons), 2, 'Should have only received 2 buttons in multi-turn prompt'
+        )
+        self.assertEqual(buttons[0].value, self._bald_eagle_text)
+        self.assertEqual(buttons[1].value, self._hummingbird_text)
         tf3 = await tf2.assert_reply(self._choose_bird_text)
         tf4 = await tf3.send(self._bald_eagle_text)
-        await tf4.assert_reply("Apparently these guys aren't actually bald!")
-    
-    # TODO - maybe this could be static
-    @classmethod
-    def _get_json_for_file(cls, response_file: str) -> object:
-        curr_dir = path.dirname(path.abspath(__file__))
-        response_path = path.join(curr_dir, "test_data", response_file)
-
-        with open(response_path, "r", encoding="utf-8-sig") as file:
-            response_str = file.read()
-        response_json = json.loads(response_str)
-
-        return response_json
+        await tf4.assert_reply(self._not_bald_text)
     
     @classmethod
     def _get_json_res(cls, text: str) -> object:
@@ -93,8 +89,17 @@ class QnaMakerDialogTest(aiounittest.AsyncTestCase):
         if (text == cls._bald_eagle_text):
             # file_name = cls._not_bald_text
             return QnaMakerDialogTest._get_json_for_file("QnAMakerDialog_MultiTurn_Answer2.json")
-
         
-        # QnaMakerDialogTest._get_json_for_file("QnAMakerDialog_MultiTurn_Answer2.json")
+        return None
 
+    @staticmethod
+    def _get_json_for_file(response_file: str) -> object:
+        curr_dir = path.dirname(path.abspath(__file__))
+        response_path = path.join(curr_dir, "test_data", response_file)
+
+        with open(response_path, "r", encoding="utf-8-sig") as file:
+            response_str = file.read()
+        response_json = json.loads(response_str)
+
+        return response_json
         

--- a/libraries/botbuilder-ai/tests/qna/test_qna_dialog.py
+++ b/libraries/botbuilder-ai/tests/qna/test_qna_dialog.py
@@ -1,8 +1,7 @@
-import aiounittest
 import json
-import unittest
 from os import path
 from unittest.mock import patch
+import aiounittest
 
 # from botbuilder.ai.qna import QnAMakerEndpoint, QnAMaker, QnAMakerOptions
 from botbuilder.ai.qna.dialogs import QnAMakerDialog
@@ -35,16 +34,16 @@ class QnaMakerDialogTest(aiounittest.AsyncTestCase):
         dialogs = DialogSet(dialog_state)
 
         qna_dialog = QnAMakerDialog(
-            self._knowledge_base_id,
-            self._endpoint_key,
-            self._host
+            self._knowledge_base_id, self._endpoint_key, self._host
         )
         dialogs.add(qna_dialog)
 
         # Callback that runs the dialog
         async def execute_qna_dialog(turn_context: TurnContext) -> None:
-            if (turn_context.activity.type != ActivityTypes.message):
-                raise TypeError('Failed to execute QnA dialog. Should have received a message activity.')
+            if turn_context.activity.type != ActivityTypes.message:
+                raise TypeError(
+                    "Failed to execute QnA dialog. Should have received a message activity."
+                )
 
             response_json = self._get_json_res(turn_context.activity.text)
             dialog_context = await dialogs.create_context(turn_context)
@@ -68,7 +67,7 @@ class QnaMakerDialogTest(aiounittest.AsyncTestCase):
         tf3 = await tf2.assert_reply(self._choose_bird)
         tf4 = await tf3.send(self._bald_eagle)
         await tf4.assert_reply("Apparently these guys aren't actually bald!")
-    
+
     async def test_active_learning(self):
         # Set Up QnAMakerDialog
         convo_state = ConversationState(MemoryStorage())
@@ -76,16 +75,16 @@ class QnaMakerDialogTest(aiounittest.AsyncTestCase):
         dialogs = DialogSet(dialog_state)
 
         qna_dialog = QnAMakerDialog(
-            self._knowledge_base_id,
-            self._endpoint_key,
-            self._host
+            self._knowledge_base_id, self._endpoint_key, self._host
         )
         dialogs.add(qna_dialog)
 
         # Callback that runs the dialog
         async def execute_qna_dialog(turn_context: TurnContext) -> None:
-            if (turn_context.activity.type != ActivityTypes.message):
-                raise TypeError('Failed to execute QnA dialog. Should have received a message activity.')
+            if turn_context.activity.type != ActivityTypes.message:
+                raise TypeError(
+                    "Failed to execute QnA dialog. Should have received a message activity."
+                )
 
             response_json = self._get_json_res(turn_context.activity.text)
             dialog_context = await dialogs.create_context(turn_context)
@@ -112,38 +111,44 @@ class QnaMakerDialogTest(aiounittest.AsyncTestCase):
 
         print(tf2)
 
-    def _assert_has_valid_hero_card_buttons(self, activity: Activity, button_count: int):
+    def _assert_has_valid_hero_card_buttons(
+        self, activity: Activity, button_count: int
+    ):
         self.assertIsInstance(activity, Activity)
         attachments = activity.attachments
         self.assertTrue(attachments)
         self.assertEqual(len(attachments), 1)
         buttons = attachments[0].content.buttons
-        button_count_err = f"Should have only received {button_count} buttons in multi-turn prompt"
+        button_count_err = (
+            f"Should have only received {button_count} buttons in multi-turn prompt"
+        )
 
-        if (activity.text == self._choose_bird):
-            self.assertEqual(
-                len(buttons), button_count, button_count_err
-            )
+        if activity.text == self._choose_bird:
+            self.assertEqual(len(buttons), button_count, button_count_err)
             self.assertEqual(buttons[0].value, self._bald_eagle)
             self.assertEqual(buttons[1].value, "Hummingbird")
-        
-        if (activity.text == self.DEFAULT_ACTIVE_LEARNING_TITLE):
-            self.assertEqual(
-                len(buttons), button_count, button_count_err
-            )
+
+        if activity.text == self.DEFAULT_ACTIVE_LEARNING_TITLE:
+            self.assertEqual(len(buttons), button_count, button_count_err)
             self.assertEqual(buttons[0].value, "Esper seeks")
             self.assertEqual(buttons[1].value, "Esper sups")
             self.assertEqual(buttons[2].value, self.DEFAULT_NO_MATCH_TEXT)
 
     def _get_json_res(self, text: str) -> object:
-        if (text == self._tell_me_about_birds):
-            return QnaMakerDialogTest._get_json_for_file("QnAMakerDialog_MultiTurn_Answer1.json")
-        
-        if (text == self._bald_eagle):
-            return QnaMakerDialogTest._get_json_for_file("QnAMakerDialog_MultiTurn_Answer2.json")
-        
-        if (text == self._esper):
-            return QnaMakerDialogTest._get_json_for_file("QnAMakerDialog_ActiveLearning.json")
+        if text == self._tell_me_about_birds:
+            return QnaMakerDialogTest._get_json_for_file(
+                "QnAMakerDialog_MultiTurn_Answer1.json"
+            )
+
+        if text == self._bald_eagle:
+            return QnaMakerDialogTest._get_json_for_file(
+                "QnAMakerDialog_MultiTurn_Answer2.json"
+            )
+
+        if text == self._esper:
+            return QnaMakerDialogTest._get_json_for_file(
+                "QnAMakerDialog_ActiveLearning.json"
+            )
 
         return None
 
@@ -157,4 +162,3 @@ class QnaMakerDialogTest(aiounittest.AsyncTestCase):
         response_json = json.loads(response_str)
 
         return response_json
-    

--- a/libraries/botbuilder-ai/tests/qna/test_qna_dialog.py
+++ b/libraries/botbuilder-ai/tests/qna/test_qna_dialog.py
@@ -9,14 +9,7 @@ from botbuilder.ai.qna.dialogs import QnAMakerDialog
 from botbuilder.schema import Activity, ActivityTypes
 from botbuilder.core import ConversationState, MemoryStorage, TurnContext
 from botbuilder.core.adapters import TestAdapter, TestFlow
-from botbuilder.dialogs import (
-    # Dialog,
-    DialogSet,
-    # WaterfallDialog,
-    # WaterfallStepContext,
-    # DialogTurnResult,
-    DialogTurnStatus,
-)
+from botbuilder.dialogs import DialogSet, DialogTurnStatus
 
 class QnaMakerDialogTest(aiounittest.AsyncTestCase):
     # Note this is NOT a real QnA Maker application ID nor a real QnA Maker subscription-key
@@ -26,13 +19,12 @@ class QnaMakerDialogTest(aiounittest.AsyncTestCase):
     _endpoint_key: str = "1k997n7w-207z-36p3-j2u1-09tas20ci6011"
     _host: str = "https://dummyqnahost.azurewebsites.net/qnamaker"
 
-    _tell_me_about_birds_text: str = "Tell me about birds"
-    _choose_bird_text: str = "Choose one of the following birds to get more info"
-    _bald_eagle_text: str = "Bald Eagle"
-    _hummingbird_text: str = "Hummingbird"
-    _not_bald_text: str = "Apparently these guys aren't actually bald!"
+    _tell_me_about_birds: str = "Tell me about birds"
+    _bald_eagle: str = "Bald Eagle"
+    _esper: str = "Esper"
 
-    async def test_multiturn_qna_dialog(self):
+    async def test_multiturn_dialog(self):
+        # Set Up QnAMakerDialog
         convo_state = ConversationState(MemoryStorage())
         dialog_state = convo_state.create_property("dialogState")
         dialogs = DialogSet(dialog_state)
@@ -44,7 +36,8 @@ class QnaMakerDialogTest(aiounittest.AsyncTestCase):
         )
         dialogs.add(qna_dialog)
 
-        async def execute_qna_dialog_test(turn_context: TurnContext) -> None:
+        # Callback that runs the dialog
+        async def execute_qna_dialog(turn_context: TurnContext) -> None:
             if (turn_context.activity.type != ActivityTypes.message):
                 raise TypeError('Failed to execute QnA dialog. Should have received a message activity.')
 
@@ -61,10 +54,10 @@ class QnaMakerDialogTest(aiounittest.AsyncTestCase):
 
                 await convo_state.save_changes(turn_context)
 
-        adapt = TestAdapter(execute_qna_dialog_test)
-
-        test_flow = TestFlow(None, adapt)
-        tf2 = await test_flow.send(self._tell_me_about_birds_text)
+        # Send and receive messages from QnA dialog
+        test_adapter = TestAdapter(execute_qna_dialog)
+        test_flow = TestFlow(None, test_adapter)
+        tf2 = await test_flow.send(self._tell_me_about_birds)
         dialog_reply: Activity = tf2.adapter.activity_buffer[0]
         self.assertIsNotNone(dialog_reply)
         self.assertIsInstance(dialog_reply, Activity)
@@ -73,23 +66,62 @@ class QnaMakerDialogTest(aiounittest.AsyncTestCase):
         self.assertEqual(len(attachments), 1)
         buttons = attachments[0].content.buttons
         self.assertEqual(
-            len(buttons), 2, 'Should have only received 2 buttons in multi-turn prompt'
+            len(buttons), 2, "Should have only received 2 buttons in multi-turn prompt"
         )
-        self.assertEqual(buttons[0].value, self._bald_eagle_text)
-        self.assertEqual(buttons[1].value, self._hummingbird_text)
-        tf3 = await tf2.assert_reply(self._choose_bird_text)
-        tf4 = await tf3.send(self._bald_eagle_text)
-        await tf4.assert_reply(self._not_bald_text)
+        self.assertEqual(buttons[0].value, self._bald_eagle)
+        self.assertEqual(buttons[1].value, "Hummingbird")
+        tf3 = await tf2.assert_reply("Choose one of the following birds to get more info")
+        tf4 = await tf3.send("Bald Eagle")
+        await tf4.assert_reply("Apparently these guys aren't actually bald!")
     
+    async def test_active_learning(self):
+        # Set Up QnAMakerDialog
+        convo_state = ConversationState(MemoryStorage())
+        dialog_state = convo_state.create_property("dialogState")
+        dialogs = DialogSet(dialog_state)
+
+        qna_dialog = QnAMakerDialog(
+            self._knowledge_base_id,
+            self._endpoint_key,
+            self._host
+        )
+        dialogs.add(qna_dialog)
+
+        # Callback that runs the dialog
+        async def execute_qna_dialog(turn_context: TurnContext) -> None:
+            if (turn_context.activity.type != ActivityTypes.message):
+                raise TypeError('Failed to execute QnA dialog. Should have received a message activity.')
+
+            response_json = QnaMakerDialogTest._get_json_res(turn_context.activity.text)
+            dialog_context = await dialogs.create_context(turn_context)
+            with patch(
+                "aiohttp.ClientSession.post",
+                return_value=aiounittest.futurized(response_json),
+            ):
+                results = await dialog_context.continue_dialog()
+
+                if results.status == DialogTurnStatus.Empty:
+                    await dialog_context.begin_dialog("QnAMakerDialog")
+
+                await convo_state.save_changes(turn_context)
+
+        # Send and receive messages from QnA dialog
+        test_adapter = TestAdapter(execute_qna_dialog)
+        test_flow = TestFlow(None, test_adapter)
+        tf2 = await test_flow.send(self._esper)
+        print(tf2)
+
     @classmethod
     def _get_json_res(cls, text: str) -> object:
-        if (text == cls._tell_me_about_birds_text):
+        if (text == cls._tell_me_about_birds):
             return QnaMakerDialogTest._get_json_for_file("QnAMakerDialog_MultiTurn_Answer1.json")
         
-        if (text == cls._bald_eagle_text):
-            # file_name = cls._not_bald_text
+        if (text == cls._bald_eagle):
             return QnaMakerDialogTest._get_json_for_file("QnAMakerDialog_MultiTurn_Answer2.json")
         
+        if (text == cls._esper):
+            return QnaMakerDialogTest._get_json_for_file("QnAMakerDialog_ActiveLearning.json")
+
         return None
 
     @staticmethod


### PR DESCRIPTION
Fixes #1571 

## Description
Currently when using the multi-turn feature in QnAMakerDialog, it will show "None of the above" 

*Multi-turn prompt has a 3rd extra button, "None of the above"* (Incorrect behavior)
![image](https://user-images.githubusercontent.com/35248895/111828216-33ceb480-88a8-11eb-8d36-31a95516ed0d.png)

"None of the above" is the "NO MATCH" response for active learning when QnAMaker wants explicit feedback about which of the closely scored answers the user considers is the actual answer their question correctly (in "NO MATCH" case, it means that none of the suggestions that are offered answers the user's question)

This "NO MATCH" response is only supposed to show up in an active learning prompt, however it is incorrectly also showing up fo rmulti-turn as well. See below


## Testing
1. Ensure that multi-turn prompt **does not** have NO MATCH response present
    -  ![image](https://user-images.githubusercontent.com/35248895/111828950-4695b900-88a9-11eb-8eaf-645cc6f730ad.png)

2. Ensure that NO MATCH response **does** show up for active learning prompts:
    -  ![image](https://user-images.githubusercontent.com/35248895/111828870-29f98100-88a9-11eb-816d-9aac14c698ed.png)
