### PR TITLE
[#1683] Fix is_skill_claim validation for anonymous authentication

### DIFF
--- a/libraries/botframework-connector/botframework/connector/auth/skill_validation.py
+++ b/libraries/botframework-connector/botframework/connector/auth/skill_validation.py
@@ -65,14 +65,14 @@ class SkillValidation:
         :param claims: A dict of claims.
         :return bool:
         """
-        if AuthenticationConstants.VERSION_CLAIM not in claims:
-            return False
-
         if (
             claims.get(AuthenticationConstants.APP_ID_CLAIM, None)
             == AuthenticationConstants.ANONYMOUS_SKILL_APP_ID
         ):
             return True
+
+        if AuthenticationConstants.VERSION_CLAIM not in claims:
+            return False
 
         audience = claims.get(AuthenticationConstants.AUDIENCE_CLAIM)
 

--- a/libraries/botframework-connector/tests/test_auth.py
+++ b/libraries/botframework-connector/tests/test_auth.py
@@ -59,7 +59,7 @@ class TestAuth:
 
     @pytest.mark.asyncio
     async def test_claims_validation(self):
-        claims: List[Dict] = []
+        claims: List[Dict] = {}
         default_auth_config = AuthenticationConfiguration()
 
         # No validator should pass.


### PR DESCRIPTION
Fixes #1683

## Description
This PR fixes the order of the validations in the [is_skill_claim](https://github.com/microsoft/botbuilder-python/blob/main/libraries/botframework-connector/botframework/connector/auth/skill_validation.py#L62) method to allow using anonymous authentication.

## Specific Changes
- Updated `skill_validation` class to invert the order of the conditions that validate the VERSION_CLAIM and the ANONYMOUS_SKILL_APP_ID to keep consistency with [.NET](https://github.com/microsoft/botbuilder-dotnet/blob/main/libraries/Microsoft.Bot.Connector/Authentication/SkillValidation.cs#L87) and [JS](https://github.com/microsoft/botbuilder-js/blob/main/libraries/botframework-connector/src/auth/skillValidation.ts#L89) SDKs.
- Fixed bug in list initialization in `test_auth`.
 
## Testing
This image shows a bot with anonymous authentication working.
![image](https://user-images.githubusercontent.com/44245136/119891259-23bdfb80-bf0f-11eb-8fc1-190b32bff505.png)

And this image shows the test passing in the CI pipeline after the changes.
![image](https://user-images.githubusercontent.com/44245136/119891323-37696200-bf0f-11eb-8a16-cda3df19181e.png)