### PR TITLE
Fix get_conversation_reference in skill_handler_impl

### DIFF
--- a/libraries/botbuilder-core/botbuilder/core/skills/_skill_handler_impl.py
+++ b/libraries/botbuilder-core/botbuilder/core/skills/_skill_handler_impl.py
@@ -276,10 +276,13 @@ class _SkillHandlerImpl(SkillHandler):
             conversation_reference_result = await self._conversation_id_factory.get_conversation_reference(
                 conversation_id
             )
-            skill_conversation_reference: SkillConversationReference = SkillConversationReference(
-                conversation_reference=conversation_reference_result,
-                oauth_scope=self._get_oauth_scope(),
-            )
+            if isinstance(conversation_reference_result, SkillConversationReference):
+                skill_conversation_reference: SkillConversationReference = conversation_reference_result
+            else:
+                skill_conversation_reference: SkillConversationReference = SkillConversationReference(
+                    conversation_reference=conversation_reference_result,
+                    oauth_scope=self._get_oauth_scope(),
+                )
 
         if not skill_conversation_reference:
             raise KeyError("SkillConversationReference not found")


### PR DESCRIPTION
#minor

## Description
This PR adds a validation in `_skill_handler_impl.py` for the `get_skill_conversation_reference` method.
This missing validation was causing an error in bots with a custom `SkillConversationIdFactory` class, building the reference in the `get_conversation_reference` method, and being over nested.

This fix was introduced in PR #1728 and lost with the migration from `skill_handler.py` to `_skill_handler_impl.py` in PR #1707

With the change in this PR, the users can still use their previous implementation of the `SkillConversationIdFactory`.

The bots used to test are the [WaterfallHostBot Python](https://github.com/microsoft/BotFramework-FunctionalTests/tree/main/Bots/Python/Consumers/CodeFirst/WaterfallHostBot) and [WaterfallSkillBot Python](https://github.com/microsoft/BotFramework-FunctionalTests/tree/main/Bots/Python/Skills/CodeFirst/WaterfallSkillBot) from the [BotFramework-FunctionalTests](https://github.com/microsoft/BotFramework-FunctionalTests/) repo.

The BotBuilder version used for all the packages is the most recent as of today from the main branch of this repo.

## Specific Changes
<!-- Please list the changes in a concise manner. -->

  - Added an if to check if the conversation_reference_result is already a SkillConversationReference instance and return it.

## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->
Before the change the Host Bot throws the following errors in the step shown, using the current latest version of main from botbuilder-core.
![image](https://user-images.githubusercontent.com/38112957/122456627-2945b900-cf84-11eb-93e6-f4b99d0bd0ea.png)
![image](https://user-images.githubusercontent.com/38112957/124512200-30572e80-ddae-11eb-8ca4-e0fe8cc6ee58.png)

After applying the changes in this PR, the conversation works as expected.
![image](https://user-images.githubusercontent.com/38112957/124512249-48c74900-ddae-11eb-86c1-349a9878aab4.png)
