### PR TITLE
Fix Django Component Governance vulnerability.

### DIFF
--- a/libraries/botbuilder-applicationinsights/setup.py
+++ b/libraries/botbuilder-applicationinsights/setup.py
@@ -12,7 +12,7 @@ REQUIRES = [
 ]
 TESTS_REQUIRES = [
     "aiounittest==1.3.0",
-    "django==2.2.6",  # For samples
+    "django==2.2.10",  # For samples
     "djangorestframework==3.10.3",  # For samples
     "flask==1.1.1",  # For samples
 ]


### PR DESCRIPTION
Fixes #1803

Django 1.11 before 1.11.28, 2.2 before 2.2.10, and 3.0 before 3.0.3 allows SQL Injection if untrusted data is used as a StringAgg delimiter (e.g., in Django applications that offer downloads of data as a series of rows with a user-specified column delimiter). By passing a suitably crafted delimiter to a contrib.postgres.aggregates.StringAgg instance, it was possible to break escaping and inject malicious SQL.

https://dev.azure.com/FuseLabs/SDK_v4/_componentGovernance/112465/alert/2370216?typeId=4354877

Fix version spec in setup.py
