### PR TITLE
Avoid exceptions for request without Content-Type header

### DIFF
--- a/libraries/botbuilder-integration-applicationinsights-aiohttp/botbuilder/integration/applicationinsights/aiohttp/aiohttp_telemetry_middleware.py
+++ b/libraries/botbuilder-integration-applicationinsights-aiohttp/botbuilder/integration/applicationinsights/aiohttp/aiohttp_telemetry_middleware.py
@@ -19,7 +19,7 @@ def retrieve_aiohttp_body():
 @middleware
 async def bot_telemetry_middleware(request, handler):
     """Process the incoming Flask request."""
-    if "application/json" in request.headers["Content-Type"]:
+    if "Content-Type" in request.headers and request.headers["Content-Type"] == "application/json":
         body = await request.json()
         _REQUEST_BODIES[current_thread().ident] = body
 


### PR DESCRIPTION
## Description
If a non-bot request comes to the server, it raised an exception because some request may not have content-type header.

## Specific Changes
  - Improved the condition to check if the content-type header is present before checking its value.

## Testing
  - Nothing new added.