### PR TITLE
fix: DockerFile security analysis warning - Python

### DIFF
--- a/libraries/functional-tests/functionaltestbot/Dockerfile
+++ b/libraries/functional-tests/functionaltestbot/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-FROM  tiangolo/uwsgi-nginx-flask:python3.6
+FROM  mcr.microsoft.com/oryx/python:3.10
 
 
 RUN  mkdir /functionaltestbot 


### PR DESCRIPTION
Fixes #minor

## Description
The warning: 
##[warning]Container security analysis found 1 violations. This repo has one or more docker files having references to images from external registries.

Example: [BotBuilder-Python-CI-PR-yaml](https://dev.azure.com/FuseLabs/SDK_v4/_build/results?buildId=305837&view=logs&j=7533eaef-a325-552b-21cf-5b0ebc256c06&t=aed58e65-c6f4-5601-4415-570d60f85914)
## Specific Changes
Change the FROM in libraries/functional-tests/functionaltestbot/Dockerfile to reference the appropriate container image in the Microsoft Artifact Registry.
