### PR TITLE
Use latest PyJWT

### DIFF
--- a/libraries/botbuilder-core/requirements.txt
+++ b/libraries/botbuilder-core/requirements.txt
@@ -3,6 +3,6 @@ botframework-connector==4.15.0
 botbuilder-schema==4.15.0
 botframework-streaming==4.15.0
 requests==2.27.1
-PyJWT==1.5.3
+PyJWT==2.4.0
 cryptography==3.3.2
 aiounittest==1.3.0

--- a/libraries/botbuilder-dialogs/requirements.txt
+++ b/libraries/botbuilder-dialogs/requirements.txt
@@ -3,6 +3,6 @@ botframework-connector==4.15.0
 botbuilder-schema==4.15.0
 botbuilder-core==4.15.0
 requests==2.27.1
-PyJWT==1.5.3
+PyJWT==2.4.0
 cryptography==3.3.2
 aiounittest==1.3.0

--- a/libraries/botframework-connector/botframework/connector/auth/emulator_validation.py
+++ b/libraries/botframework-connector/botframework/connector/auth/emulator_validation.py
@@ -63,7 +63,7 @@ class EmulatorValidation:
         bearer_token = auth_header.split(" ")[1]
 
         # Parse the Big Long String into an actual token.
-        token = jwt.decode(bearer_token, verify=False)
+        token = jwt.decode(bearer_token, options={"verify_signature": False})
         if not token:
             return False
 

--- a/libraries/botframework-connector/botframework/connector/auth/jwt_token_extractor.py
+++ b/libraries/botframework-connector/botframework/connector/auth/jwt_token_extractor.py
@@ -68,7 +68,7 @@ class JwtTokenExtractor:
             raise error
 
     def _has_allowed_issuer(self, jwt_token: str) -> bool:
-        decoded = jwt.decode(jwt_token, verify=False)
+        decoded = jwt.decode(jwt_token, options={"verify_signature": False})
         issuer = decoded.get("iss", None)
         if issuer in self.validation_parameters.issuer:
             return True

--- a/libraries/botframework-connector/botframework/connector/auth/skill_validation.py
+++ b/libraries/botframework-connector/botframework/connector/auth/skill_validation.py
@@ -55,7 +55,7 @@ class SkillValidation:
         bearer_token = auth_header.split(" ")[1]
 
         # Parse the Big Long String into an actual token.
-        token = jwt.decode(bearer_token, verify=False)
+        token = jwt.decode(bearer_token, options={"verify_signature": False})
         return SkillValidation.is_skill_claim(token)
 
     @staticmethod

--- a/libraries/botframework-connector/requirements.txt
+++ b/libraries/botframework-connector/requirements.txt
@@ -1,6 +1,6 @@
 msrest==0.6.21
 botbuilder-schema==4.15.0
 requests==2.27.1
-PyJWT==1.5.3
+PyJWT==2.4.0
 cryptography==3.3.2
 msal==1.17.0

--- a/libraries/botframework-connector/setup.py
+++ b/libraries/botframework-connector/setup.py
@@ -9,9 +9,9 @@ VERSION = os.environ["packageVersion"] if "packageVersion" in os.environ else "4
 REQUIRES = [
     "msrest==0.6.19",
     "requests>=2.23.0,<2.26",
-    "PyJWT>=1.5.3,<2.0.0",
+    # "PyJWT>=1.5.3,<2.0.0",
     "botbuilder-schema==4.15.0",
-    "msal==1.6.0",
+    "msal==1.9.0",
 ]
 
 root = os.path.abspath(os.path.dirname(__file__))


### PR DESCRIPTION
Fixes #1837

## Description
Changes calls of `jwt.decode` to stop using dropped `verify` parameter
