### PR TITLE
Update requirements.txt

### DIFF
--- a/libraries/botbuilder-integration-aiohttp/requirements.txt
+++ b/libraries/botbuilder-integration-aiohttp/requirements.txt
@@ -1,4 +1,4 @@
 msrest==0.6.*
 botframework-connector==4.15.0
 botbuilder-schema==4.15.0
-aiohttp==3.7.4
+aiohttp==3.8.3


### PR DESCRIPTION
Fixes #1990

## Description
Upgrading the version of aiohttp allows the use of the lastest versions of langchain

## Specific Changes
change aiohttp==3.7.4 to aiohttp==3.8.3
