### PR TITLE
Fixes AttributeError: module 'urllib3.connectionpool' has no attribute 'VerifiedHTTPSConnection'

### DIFF
--- a/libraries/botbuilder-adapters-slack/requirements.txt
+++ b/libraries/botbuilder-adapters-slack/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp==3.7.4
+aiohttp==3.8.4
 pyslack
 botbuilder-core==4.15.0
 slackclient

--- a/libraries/botbuilder-ai/setup.py
+++ b/libraries/botbuilder-ai/setup.py
@@ -8,7 +8,7 @@ REQUIRES = [
     "azure-cognitiveservices-language-luis==0.2.0",
     "botbuilder-schema==4.15.0",
     "botbuilder-core==4.15.0",
-    "aiohttp>=3.6.2,<3.8.0",
+    "aiohttp==3.8.4",
 ]
 
 TESTS_REQUIRES = ["aiounittest>=1.1.0"]

--- a/libraries/botbuilder-integration-aiohttp/requirements.txt
+++ b/libraries/botbuilder-integration-aiohttp/requirements.txt
@@ -1,4 +1,4 @@
 msrest==0.6.*
 botframework-connector==4.15.0
 botbuilder-schema==4.15.0
-aiohttp==3.8.3
+aiohttp==3.8.4

--- a/libraries/botbuilder-integration-aiohttp/requirements.txt
+++ b/libraries/botbuilder-integration-aiohttp/requirements.txt
@@ -1,4 +1,4 @@
 msrest==0.6.*
 botframework-connector==4.15.0
 botbuilder-schema==4.15.0
-aiohttp==3.7.4
+aiohttp==3.8.3

--- a/libraries/botbuilder-integration-aiohttp/setup.py
+++ b/libraries/botbuilder-integration-aiohttp/setup.py
@@ -10,7 +10,7 @@ REQUIRES = [
     "botframework-connector==4.15.0",
     "botbuilder-core==4.15.0",
     "yarl<=1.4.2",
-    "aiohttp>=3.6.2,<3.8.0",
+    "aiohttp==3.8.4",
 ]
 
 root = os.path.abspath(os.path.dirname(__file__))

--- a/libraries/botbuilder-integration-applicationinsights-aiohttp/setup.py
+++ b/libraries/botbuilder-integration-applicationinsights-aiohttp/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup
 
 REQUIRES = [
     "applicationinsights>=0.11.9",
-    "aiohttp>=3.6.2,<3.8.0",
+    "aiohttp==3.8.4",
     "botbuilder-schema==4.15.0",
     "botframework-connector==4.15.0",
     "botbuilder-core==4.15.0",

--- a/libraries/botbuilder-schema/setup.py
+++ b/libraries/botbuilder-schema/setup.py
@@ -6,7 +6,8 @@ from setuptools import setup
 
 NAME = "botbuilder-schema"
 VERSION = os.environ["packageVersion"] if "packageVersion" in os.environ else "4.15.0"
-REQUIRES = ["msrest==0.6.*"]
+REQUIRES = ["msrest==0.6.*",
+            "urllib3<2.0.0"]
 
 root = os.path.abspath(os.path.dirname(__file__))
 


### PR DESCRIPTION
## Description
With the latest urllib3 2.0.0 release the vcrpy library throws this error
AttributeError: module 'urllib3.connectionpool' has no attribute 'VerifiedHTTPSConnection'


## Specific Changes
- Pinning urllib3 < 2.0.0 to solve the problem with tests
- change aiohttp everywhere to version 3.8.4 (allows the use of langchain)