### PR TITLE
Fix TeamsChannelAccount model

### DIFF
--- a/libraries/botbuilder-schema/botbuilder/schema/teams/_models_py3.py
+++ b/libraries/botbuilder-schema/botbuilder/schema/teams/_models_py3.py
@@ -1903,7 +1903,7 @@ class TeamsChannelAccount(ChannelAccount):
         "surname": {"key": "surname", "type": "str"},
         "email": {"key": "email", "type": "str"},
         "user_principal_name": {"key": "userPrincipalName", "type": "str"},
-        "aad_object_id": {"key": "objectId", "type": "str"},
+        "aad_object_id": {"key": "aadObjectId", "type": "str"},
         "tenant_id": {"key": "tenantId", "type": "str"},
         "user_role": {"key": "userRole", "type": "str"},
     }


### PR DESCRIPTION
Fixes #2084 

Fixes `TeamsChannelAccount.add_object_id` property.

The curent definition returns an additional property and a null `add_object_id`:

```python
{'additional_property': {'aadObjectId': <UUID>}, 'add_object_id`: None}
```

instead of:

```python
 {'additional_properties': {}, `add_object_id` <UUID>}
```

See: https://learn.microsoft.com/en-us/dotnet/api/microsoft.bot.schema.teams.teamschannelaccount?view=botbuilder-dotnet-stable