### PR TITLE
Remove the colon (':') from keywords such as "Parameters", "Remarks" and "Returns" in comments.

### DIFF
--- a/libraries/botbuilder-ai/botbuilder/ai/qna/models/join_operator.py
+++ b/libraries/botbuilder-ai/botbuilder/ai/qna/models/join_operator.py
@@ -8,7 +8,7 @@ class JoinOperator(str, Enum):
     """
     Join Operator for Strict Filters.
 
-    remarks:
+    remarks
     --------
     For example, when using multiple filters in a query, if you want results that
     have metadata that matches all filters, then use `AND` operator.

--- a/libraries/botbuilder-ai/botbuilder/ai/qna/models/qna_response_context.py
+++ b/libraries/botbuilder-ai/botbuilder/ai/qna/models/qna_response_context.py
@@ -17,7 +17,7 @@ class QnAResponseContext(Model):
 
     def __init__(self, **kwargs):
         """
-        Parameters:
+        Parameters
         -----------
 
         is_context_only: Whether this prompt is context only.

--- a/libraries/botbuilder-ai/botbuilder/ai/qna/models/qnamaker_trace_info.py
+++ b/libraries/botbuilder-ai/botbuilder/ai/qna/models/qnamaker_trace_info.py
@@ -27,7 +27,7 @@ class QnAMakerTraceInfo:
         ranker_type: str = RankerTypes.DEFAULT,
     ):
         """
-        Parameters:
+        Parameters
         -----------
 
         message: Message which instigated the query to QnA Maker.

--- a/libraries/botbuilder-ai/botbuilder/ai/qna/models/query_results.py
+++ b/libraries/botbuilder-ai/botbuilder/ai/qna/models/query_results.py
@@ -18,7 +18,7 @@ class QueryResults(Model):
         self, answers: List[QueryResult], active_learning_enabled: bool = None, **kwargs
     ):
         """
-        Parameters:
+        Parameters
         -----------
 
         answers: The answers for a user query.

--- a/libraries/botbuilder-ai/botbuilder/ai/qna/qnamaker_options.py
+++ b/libraries/botbuilder-ai/botbuilder/ai/qna/qnamaker_options.py
@@ -10,7 +10,7 @@ class QnAMakerOptions:
     """
     Defines options used to configure a `QnAMaker` instance.
 
-    remarks:
+    remarks
     --------
         All parameters are optional.
     """
@@ -28,7 +28,7 @@ class QnAMakerOptions:
         strict_filters_join_operator: str = JoinOperator.AND,
     ):
         """
-        Parameters:
+        Parameters
         -----------
         score_threshold (float):
             The minimum score threshold, used to filter returned results.

--- a/libraries/botbuilder-ai/botbuilder/ai/qna/utils/active_learning_utils.py
+++ b/libraries/botbuilder-ai/botbuilder/ai/qna/utils/active_learning_utils.py
@@ -22,7 +22,7 @@ class ActiveLearningUtils:
         """
         Returns a list of QnA search results, which have low score variation.
 
-        Parameters:
+        Parameters
         -----------
 
         qna_serach_results: A list of QnA QueryResults returned from the QnA GenerateAnswer API call.

--- a/libraries/botbuilder-ai/botbuilder/ai/qna/utils/generate_answer_utils.py
+++ b/libraries/botbuilder-ai/botbuilder/ai/qna/utils/generate_answer_utils.py
@@ -41,7 +41,7 @@ class GenerateAnswerUtils:
         http_client: ClientSession,
     ):
         """
-        Parameters:
+        Parameters
         -----------
 
         telemetry_client: Telemetry client.

--- a/libraries/botbuilder-ai/botbuilder/ai/qna/utils/http_request_utils.py
+++ b/libraries/botbuilder-ai/botbuilder/ai/qna/utils/http_request_utils.py
@@ -16,7 +16,7 @@ from ..qnamaker_endpoint import QnAMakerEndpoint
 class HttpRequestUtils:
     """HTTP request utils class.
 
-    Parameters:
+    Parameters
     -----------
 
     http_client: Client to make HTTP requests with. Default client used in the SDK is `aiohttp.ClientSession`.
@@ -35,7 +35,7 @@ class HttpRequestUtils:
         """
         Execute HTTP request.
 
-        Parameters:
+        Parameters
         -----------
 
         request_url: HTTP request URL.

--- a/libraries/botbuilder-ai/botbuilder/ai/qna/utils/train_utils.py
+++ b/libraries/botbuilder-ai/botbuilder/ai/qna/utils/train_utils.py
@@ -17,7 +17,7 @@ class TrainUtils:
         """
         Initializes a new instance for active learning train utils.
 
-        Parameters:
+        Parameters
         -----------
 
         endpoint: QnA Maker Endpoint of the knowledge base to query.

--- a/libraries/botbuilder-dialogs/botbuilder/dialogs/choices/choice_factory.py
+++ b/libraries/botbuilder-dialogs/botbuilder/dialogs/choices/choice_factory.py
@@ -26,7 +26,7 @@ class ChoiceFactory:
         Creates a message activity that includes a list of choices formatted based on the
          capabilities of a given channel.
 
-        Parameters:
+        Parameters
         ----------
         channel_id: A channel ID.
         choices: List of choices to render
@@ -81,7 +81,7 @@ class ChoiceFactory:
         """
         Creates a message activity that includes a list of choices formatted as an inline list.
 
-        Parameters:
+        Parameters
         ----------
         choices: The list of choices to render.
         text: (Optional) The text of the message to send.
@@ -140,7 +140,7 @@ class ChoiceFactory:
         """
         Creates a message activity that includes a list of choices formatted as a numbered or bulleted list.
 
-        Parameters:
+        Parameters
         ----------
 
         choices: The list of choices to render.

--- a/libraries/botbuilder-dialogs/botbuilder/dialogs/choices/choice_recognizers.py
+++ b/libraries/botbuilder-dialogs/botbuilder/dialogs/choices/choice_recognizers.py
@@ -34,7 +34,7 @@ class ChoiceRecognizers:
         - By 1's based ordinal position.
         - By 1's based index position.
 
-        Parameters:
+        Parameters
         -----------
 
         utterance: The input.
@@ -43,7 +43,7 @@ class ChoiceRecognizers:
 
         options: (Optional) Options to control the recognition strategy.
 
-        Returns:
+        Returns
         --------
         A list of found choices, sorted by most relevant first.
         """

--- a/libraries/botbuilder-dialogs/botbuilder/dialogs/choices/find_choices_options.py
+++ b/libraries/botbuilder-dialogs/botbuilder/dialogs/choices/find_choices_options.py
@@ -16,7 +16,7 @@ class FindChoicesOptions(FindValuesOptions):
         **kwargs,
     ):
         """
-        Parameters:
+        Parameters
         -----------
 
         no_value: (Optional) If `True`, the choices `value` field will NOT be search over. Defaults to `False`.

--- a/libraries/botbuilder-dialogs/botbuilder/dialogs/choices/find_values_options.py
+++ b/libraries/botbuilder-dialogs/botbuilder/dialogs/choices/find_values_options.py
@@ -17,7 +17,7 @@ class FindValuesOptions:
         tokenizer: Callable[[str, str], List[Token]] = None,
     ):
         """
-        Parameters:
+        Parameters
         ----------
 
         allow_partial_matches: (Optional) If `True`, then only some of the tokens in a value need to exist to

--- a/libraries/botbuilder-dialogs/botbuilder/dialogs/choices/found_choice.py
+++ b/libraries/botbuilder-dialogs/botbuilder/dialogs/choices/found_choice.py
@@ -7,7 +7,7 @@ class FoundChoice:
 
     def __init__(self, value: str, index: int, score: float, synonym: str = None):
         """
-        Parameters:
+        Parameters
         ----------
 
         value: The value of the choice that was matched.

--- a/libraries/botbuilder-dialogs/botbuilder/dialogs/choices/found_value.py
+++ b/libraries/botbuilder-dialogs/botbuilder/dialogs/choices/found_value.py
@@ -7,7 +7,7 @@ class FoundValue:
 
     def __init__(self, value: str, index: int, score: float):
         """
-        Parameters:
+        Parameters
         ----------
 
         value: The value that was matched.

--- a/libraries/botbuilder-dialogs/botbuilder/dialogs/choices/model_result.py
+++ b/libraries/botbuilder-dialogs/botbuilder/dialogs/choices/model_result.py
@@ -9,7 +9,7 @@ class ModelResult:
         self, text: str, start: int, end: int, type_name: str, resolution: object
     ):
         """
-        Parameters:
+        Parameters
         ----------
 
         text: Substring of the utterance that was recognized.

--- a/libraries/botbuilder-dialogs/botbuilder/dialogs/choices/sorted_value.py
+++ b/libraries/botbuilder-dialogs/botbuilder/dialogs/choices/sorted_value.py
@@ -7,7 +7,7 @@ class SortedValue:
 
     def __init__(self, value: str, index: int):
         """
-        Parameters:
+        Parameters
         -----------
 
         value: The value that will be sorted.

--- a/libraries/botbuilder-dialogs/botbuilder/dialogs/choices/token.py
+++ b/libraries/botbuilder-dialogs/botbuilder/dialogs/choices/token.py
@@ -7,7 +7,7 @@ class Token:
 
     def __init__(self, start: int, end: int, text: str, normalized: str):
         """
-        Parameters:
+        Parameters
         ----------
 
         start: The index of the first character of the token within the outer input string.

--- a/libraries/botbuilder-dialogs/botbuilder/dialogs/choices/tokenizer.py
+++ b/libraries/botbuilder-dialogs/botbuilder/dialogs/choices/tokenizer.py
@@ -75,7 +75,7 @@ class Tokenizer:
     @staticmethod
     def _is_between(value: int, from_val: int, to_val: int) -> bool:
         """
-        Parameters:
+        Parameters
         -----------
 
         value: number value


### PR DESCRIPTION
Fixes #1991 

## Description
To avoid generating unwanted H1 headers in API reference documents, remove the colon (':') from keywords such as "Parameters", "Remarks" and "Returns" in comments.

See the proper usage in: https://www.sphinx-doc.org/en/master/usage/extensions/example_numpy.html
