### PR TITLE
Port: [Teams] Add support for meeting participants added/removed events

### DIFF
--- a/libraries/botbuilder-core/botbuilder/core/teams/teams_activity_handler.py
+++ b/libraries/botbuilder-core/botbuilder/core/teams/teams_activity_handler.py
@@ -27,6 +27,7 @@ from botbuilder.schema.teams import (
     TaskModuleResponse,
     TabRequest,
     TabSubmit,
+    MeetingParticipantsEventDetails,
 )
 from botframework.connector import Channels
 from ..serializer_helper import deserializer_helper
@@ -913,6 +914,14 @@ class TeamsActivityHandler(ActivityHandler):
                 return await self.on_teams_meeting_end_event(
                     turn_context.activity.value, turn_context
                 )
+            if turn_context.activity.name == "application/vnd.microsoft.meetingParticipantJoin":
+                return await self.on_teams_meeting_participants_join_event(
+                    turn_context.activity.value, turn_context
+                )
+            if turn_context.activity.name == "application/vnd.microsoft.meetingParticipantLeave":
+                return await self.on_teams_meeting_participants_leave_event(
+                    turn_context.activity.value, turn_context
+                )
 
         return await super().on_event_activity(turn_context)
 
@@ -934,6 +943,32 @@ class TeamsActivityHandler(ActivityHandler):
     ):  # pylint: disable=unused-argument
         """
         Override this in a derived class to provide logic for when a Teams meeting end event is received.
+
+        :param meeting: The details of the meeting.
+        :param turn_context: A context object for this turn.
+
+        :returns: A task that represents the work queued to execute.
+        """
+        return
+
+async def on_teams_meeting_participants_join_event(
+        self, meeting: MeetingParticipantsEventDetails, turn_context: TurnContext
+    ):  # pylint: disable=unused-argument
+        """
+        Override this in a derived class to provide logic for when meeting participants are added.
+
+        :param meeting: The details of the meeting.
+        :param turn_context: A context object for this turn.
+
+        :returns: A task that represents the work queued to execute.
+        """
+        return
+
+async def on_teams_meeting_participants_leave_event(
+        self, meeting: MeetingParticipantsEventDetails, turn_context: TurnContext
+    ):  # pylint: disable=unused-argument
+        """
+        Override this in a derived class to provide logic for when meeting participants are removed.
 
         :param meeting: The details of the meeting.
         :param turn_context: A context object for this turn.

--- a/libraries/botbuilder-core/botbuilder/core/teams/teams_activity_handler.py
+++ b/libraries/botbuilder-core/botbuilder/core/teams/teams_activity_handler.py
@@ -914,11 +914,17 @@ class TeamsActivityHandler(ActivityHandler):
                 return await self.on_teams_meeting_end_event(
                     turn_context.activity.value, turn_context
                 )
-            if turn_context.activity.name == "application/vnd.microsoft.meetingParticipantJoin":
+            if (
+                turn_context.activity.name
+                == "application/vnd.microsoft.meetingParticipantJoin"
+            ):
                 return await self.on_teams_meeting_participants_join_event(
                     turn_context.activity.value, turn_context
                 )
-            if turn_context.activity.name == "application/vnd.microsoft.meetingParticipantLeave":
+            if (
+                turn_context.activity.name
+                == "application/vnd.microsoft.meetingParticipantLeave"
+            ):
                 return await self.on_teams_meeting_participants_leave_event(
                     turn_context.activity.value, turn_context
                 )
@@ -951,7 +957,7 @@ class TeamsActivityHandler(ActivityHandler):
         """
         return
 
-async def on_teams_meeting_participants_join_event(
+    async def on_teams_meeting_participants_join_event(
         self, meeting: MeetingParticipantsEventDetails, turn_context: TurnContext
     ):  # pylint: disable=unused-argument
         """
@@ -964,7 +970,7 @@ async def on_teams_meeting_participants_join_event(
         """
         return
 
-async def on_teams_meeting_participants_leave_event(
+    async def on_teams_meeting_participants_leave_event(
         self, meeting: MeetingParticipantsEventDetails, turn_context: TurnContext
     ):  # pylint: disable=unused-argument
         """

--- a/libraries/botbuilder-core/tests/teams/test_teams_activity_handler.py
+++ b/libraries/botbuilder-core/tests/teams/test_teams_activity_handler.py
@@ -333,7 +333,7 @@ class TestingTeamsActivityHandler(TeamsActivityHandler):
         return await super().on_teams_meeting_end_event(
             turn_context.activity.value, turn_context
         )
-    
+
     async def on_teams_meeting_participants_join_event(
         self, meeting: MeetingParticipantsEventDetails, turn_context: TurnContext
     ):
@@ -341,7 +341,7 @@ class TestingTeamsActivityHandler(TeamsActivityHandler):
         return await super().on_teams_meeting_participants_join_event(
             turn_context.activity.value, turn_context
         )
-    
+
     async def on_teams_meeting_participants_leave_event(
         self, meeting: MeetingParticipantsEventDetails, turn_context: TurnContext
     ):
@@ -1178,18 +1178,18 @@ class TestTeamsActivityHandler(aiounittest.AsyncTestCase):
     async def test_on_teams_meeting_participants_join_event(self):
         # arrange
         activity = Activity(
-            type=ActivityTypes.invoke, 
+            type=ActivityTypes.event,
             channel_id=Channels.ms_teams,
             name="application/vnd.microsoft.meetingParticipantJoin",
             value={
                 "members": [
                     {
-                        "user": {"id": "id", "name": "name"}, 
-                        "meeting": {"role": "role", "in_meeting": True}
-                     }]
-                     ,
+                        "user": {"id": "123", "name": "name"},
+                        "meeting": {"role": "role", "in_meeting": True},
+                    }
+                ],
             },
-            )
+        )
 
         turn_context = TurnContext(SimpleAdapter(), activity)
 
@@ -1199,24 +1199,24 @@ class TestTeamsActivityHandler(aiounittest.AsyncTestCase):
 
         # Assert
         assert len(bot.record) == 2
-        assert bot.record[0] == "on_invoke_activity"
+        assert bot.record[0] == "on_event_activity"
         assert bot.record[1] == "on_teams_meeting_participants_join_event"
 
     async def test_on_teams_meeting_participants_leave_event(self):
         # arrange
         activity = Activity(
-            type=ActivityTypes.invoke, 
+            type=ActivityTypes.event,
             channel_id=Channels.ms_teams,
             name="application/vnd.microsoft.meetingParticipantLeave",
             value={
                 "members": [
                     {
-                        "user": {"id": "id", "name": "name"}, 
-                        "meeting": {"role": "role", "in_meeting": True}
-                     }]
-                     ,
+                        "user": {"id": "id", "name": "name"},
+                        "meeting": {"role": "role", "in_meeting": True},
+                    }
+                ],
             },
-            )
+        )
 
         turn_context = TurnContext(SimpleAdapter(), activity)
 
@@ -1225,7 +1225,6 @@ class TestTeamsActivityHandler(aiounittest.AsyncTestCase):
         await bot.on_turn(turn_context)
 
         # Assert
-        print(bot.record)
         assert len(bot.record) == 2
-        assert bot.record[0] == "on_invoke_activity"
+        assert bot.record[0] == "on_event_activity"
         assert bot.record[1] == "on_teams_meeting_participants_leave_event"

--- a/libraries/botbuilder-core/tests/teams/test_teams_activity_handler.py
+++ b/libraries/botbuilder-core/tests/teams/test_teams_activity_handler.py
@@ -32,6 +32,7 @@ from botbuilder.schema.teams import (
     TabRequest,
     TabSubmit,
     TabContext,
+    MeetingParticipantsEventDetails,
 )
 from botframework.connector import Channels
 from simple_adapter import SimpleAdapter
@@ -330,6 +331,22 @@ class TestingTeamsActivityHandler(TeamsActivityHandler):
     ):
         self.record.append("on_teams_meeting_end_event")
         return await super().on_teams_meeting_end_event(
+            turn_context.activity.value, turn_context
+        )
+    
+    async def on_teams_meeting_participants_join_event(
+        self, meeting: MeetingParticipantsEventDetails, turn_context: TurnContext
+    ):
+        self.record.append("on_teams_meeting_participants_join_event")
+        return await super().on_teams_meeting_participants_join_event(
+            turn_context.activity.value, turn_context
+        )
+    
+    async def on_teams_meeting_participants_leave_event(
+        self, meeting: MeetingParticipantsEventDetails, turn_context: TurnContext
+    ):
+        self.record.append("on_teams_meeting_participants_leave_event")
+        return await super().on_teams_meeting_participants_leave_event(
             turn_context.activity.value, turn_context
         )
 
@@ -1157,3 +1174,58 @@ class TestTeamsActivityHandler(aiounittest.AsyncTestCase):
         assert len(bot.record) == 2
         assert bot.record[0] == "on_event_activity"
         assert bot.record[1] == "on_teams_meeting_end_event"
+
+    async def test_on_teams_meeting_participants_join_event(self):
+        # arrange
+        activity = Activity(
+            type=ActivityTypes.invoke, 
+            channel_id=Channels.ms_teams,
+            name="application/vnd.microsoft.meetingParticipantJoin",
+            value={
+                "members": [
+                    {
+                        "user": {"id": "id", "name": "name"}, 
+                        "meeting": {"role": "role", "in_meeting": True}
+                     }]
+                     ,
+            },
+            )
+
+        turn_context = TurnContext(SimpleAdapter(), activity)
+
+        # Act
+        bot = TestingTeamsActivityHandler()
+        await bot.on_turn(turn_context)
+
+        # Assert
+        assert len(bot.record) == 2
+        assert bot.record[0] == "on_invoke_activity"
+        assert bot.record[1] == "on_teams_meeting_participants_join_event"
+
+    async def test_on_teams_meeting_participants_leave_event(self):
+        # arrange
+        activity = Activity(
+            type=ActivityTypes.invoke, 
+            channel_id=Channels.ms_teams,
+            name="application/vnd.microsoft.meetingParticipantLeave",
+            value={
+                "members": [
+                    {
+                        "user": {"id": "id", "name": "name"}, 
+                        "meeting": {"role": "role", "in_meeting": True}
+                     }]
+                     ,
+            },
+            )
+
+        turn_context = TurnContext(SimpleAdapter(), activity)
+
+        # Act
+        bot = TestingTeamsActivityHandler()
+        await bot.on_turn(turn_context)
+
+        # Assert
+        print(bot.record)
+        assert len(bot.record) == 2
+        assert bot.record[0] == "on_invoke_activity"
+        assert bot.record[1] == "on_teams_meeting_participants_leave_event"

--- a/libraries/botbuilder-schema/botbuilder/schema/teams/__init__.py
+++ b/libraries/botbuilder-schema/botbuilder/schema/teams/__init__.py
@@ -77,6 +77,9 @@ from ._models_py3 import TabSubmit
 from ._models_py3 import TabSubmitData
 from ._models_py3 import TabSuggestedActions
 from ._models_py3 import TaskModuleCardResponse
+from ._models_py3 import UserMeetingDetails
+from ._models_py3 import TeamsMeetingMember
+from ._models_py3 import MeetingParticipantsEventDetails
 
 __all__ = [
     "AppBasedLinkQuery",
@@ -155,4 +158,7 @@ __all__ = [
     "TabSubmitData",
     "TabSuggestedActions",
     "TaskModuleCardResponse",
+    "UserMeetingDetails",
+    "TeamsMeetingMember",
+    "MeetingParticipantsEventDetails",
 ]

--- a/libraries/botbuilder-schema/botbuilder/schema/teams/_models_py3.py
+++ b/libraries/botbuilder-schema/botbuilder/schema/teams/_models_py3.py
@@ -2506,3 +2506,49 @@ class MeetingEndEventDetails(MeetingDetailsBase):
     def __init__(self, *, end_time: str = None, **kwargs):
         super(MeetingEndEventDetails, self).__init__(**kwargs)
         self.end_time = end_time
+
+class UserMeetingDetails(Model):
+    """Specific details of a user in a Teams meeting."""
+
+    def __init__(self, *, in_meeting: bool = None, role: str = None, **kwargs) -> None:
+        super(UserMeetingDetails, self).__init__(**kwargs)
+        self.in_meeting = in_meeting
+        self.role = role
+
+
+class TeamsMeetingMember(Model):
+    """Data about the meeting participants.
+
+    :param user: The channel user data.
+    :type user: ~botbuilder.schema.models.TeamsChannelAccount
+    :param meeting: The user meeting details.
+    :type meeting: ~botbuilder.schema.models.UserMeetingDetails
+    """
+
+    _attribute_map = {
+        "user": {"key": "TeamsChannelAccount", "type": "[TeamsChannelAccount]"},
+        "meeting": {"key": "UserMeetingDetails", "type": "[UserMeetingDetails]"}
+    }
+
+    def __init__(
+        self, *, user: TeamsChannelAccount = None, meeting: UserMeetingDetails = None, **kwargs
+    ) -> None:
+        super(TeamsMeetingMember, self).__init__(**kwargs)
+        self.user = user
+        self.meeting = meeting
+
+class MeetingParticipantsEventDetails(Model):
+    """Data about the meeting participants.
+
+    :param members: The members involved in the meeting event.
+    :type members: list[~botframework.connector.teams.models.TeamsMeetingMember]
+    """
+
+    _attribute_map = {
+        "conversations": {"key": "members", "type": "[TeamsMeetingMember]"},
+    }
+
+    def __init__(self, *, members=None, **kwargs) -> None:
+        super(MeetingParticipantsEventDetails, self).__init__(**kwargs)
+        self.members = members
+

--- a/libraries/botbuilder-schema/botbuilder/schema/teams/_models_py3.py
+++ b/libraries/botbuilder-schema/botbuilder/schema/teams/_models_py3.py
@@ -2507,10 +2507,22 @@ class MeetingEndEventDetails(MeetingDetailsBase):
         super(MeetingEndEventDetails, self).__init__(**kwargs)
         self.end_time = end_time
 
-class UserMeetingDetails(Model):
-    """Specific details of a user in a Teams meeting."""
 
-    def __init__(self, *, in_meeting: bool = None, role: str = None, **kwargs) -> None:
+class UserMeetingDetails(Model):
+    """Specific details of a user in a Teams meeting.
+
+    :param role: Role of the participant in the current meeting.
+    :type role: str
+    :param in_meeting: True, if the participant is in the meeting.
+    :type in_meeting: bool
+    """
+
+    _attribute_map = {
+        "role": {"key": "role", "type": "str"},
+        "in_meeting": {"key": "inMeeting", "type": "bool"},
+    }
+
+    def __init__(self, *, role: str = None, in_meeting: bool = None, **kwargs) -> None:
         super(UserMeetingDetails, self).__init__(**kwargs)
         self.in_meeting = in_meeting
         self.role = role
@@ -2520,35 +2532,39 @@ class TeamsMeetingMember(Model):
     """Data about the meeting participants.
 
     :param user: The channel user data.
-    :type user: ~botbuilder.schema.models.TeamsChannelAccount
+    :type user: TeamsChannelAccount
     :param meeting: The user meeting details.
-    :type meeting: ~botbuilder.schema.models.UserMeetingDetails
+    :type meeting: UserMeetingDetails
     """
 
     _attribute_map = {
-        "user": {"key": "TeamsChannelAccount", "type": "[TeamsChannelAccount]"},
-        "meeting": {"key": "UserMeetingDetails", "type": "[UserMeetingDetails]"}
+        "user": {"key": "user", "type": "TeamsChannelAccount"},
+        "meeting": {"key": "meeting", "type": "UserMeetingDetails"},
     }
 
     def __init__(
-        self, *, user: TeamsChannelAccount = None, meeting: UserMeetingDetails = None, **kwargs
+        self,
+        *,
+        user: TeamsChannelAccount = None,
+        meeting: UserMeetingDetails = None,
+        **kwargs
     ) -> None:
         super(TeamsMeetingMember, self).__init__(**kwargs)
         self.user = user
         self.meeting = meeting
 
+
 class MeetingParticipantsEventDetails(Model):
     """Data about the meeting participants.
 
     :param members: The members involved in the meeting event.
-    :type members: list[~botframework.connector.teams.models.TeamsMeetingMember]
+    :type members: list[~botframework.connector.models.TeamsMeetingMember]
     """
 
     _attribute_map = {
         "conversations": {"key": "members", "type": "[TeamsMeetingMember]"},
     }
 
-    def __init__(self, *, members=None, **kwargs) -> None:
+    def __init__(self, *, members: List[TeamsMeetingMember] = None, **kwargs) -> None:
         super(MeetingParticipantsEventDetails, self).__init__(**kwargs)
         self.members = members
-

--- a/libraries/botframework-connector/botframework/connector/auth/microsoft_app_credentials.py
+++ b/libraries/botframework-connector/botframework/connector/auth/microsoft_app_credentials.py
@@ -56,8 +56,14 @@ class MicrosoftAppCredentials(AppCredentials, ABC):
             return auth_token["access_token"]
         else:
             error = auth_token["error"] if "error" in auth_token else "Unknown error"
-            error_description = auth_token["error_description"] if "error_description" in auth_token else "Unknown error description"
-            raise PermissionError(f"Failed to get access token with error: {error}, error_description: {error_description}")
+            error_description = (
+                auth_token["error_description"]
+                if "error_description" in auth_token
+                else "Unknown error description"
+            )
+            raise PermissionError(
+                f"Failed to get access token with error: {error}, error_description: {error_description}"
+            )
 
     def __get_msal_app(self):
         if not self.app:

--- a/libraries/botframework-connector/botframework/connector/auth/microsoft_app_credentials.py
+++ b/libraries/botframework-connector/botframework/connector/auth/microsoft_app_credentials.py
@@ -54,16 +54,15 @@ class MicrosoftAppCredentials(AppCredentials, ABC):
             auth_token = self.__get_msal_app().acquire_token_for_client(scopes=scopes)
         if "access_token" in auth_token:
             return auth_token["access_token"]
-        else:
-            error = auth_token["error"] if "error" in auth_token else "Unknown error"
-            error_description = (
-                auth_token["error_description"]
-                if "error_description" in auth_token
-                else "Unknown error description"
-            )
-            raise PermissionError(
-                f"Failed to get access token with error: {error}, error_description: {error_description}"
-            )
+        error = auth_token["error"] if "error" in auth_token else "Unknown error"
+        error_description = (
+            auth_token["error_description"]
+            if "error_description" in auth_token
+            else "Unknown error description"
+        )
+        raise PermissionError(
+            f"Failed to get access token with error: {error}, error_description: {error_description}"
+        )
 
     def __get_msal_app(self):
         if not self.app:


### PR DESCRIPTION
Fixes #minor

## Description
Porting [[Teams] Add support for meeting participants added/removed events (#6677)](https://github.com/microsoft/botbuilder-dotnet/pull/6677) to maintain parity with `microsoft/botbuilder-dotnet`

## Specific Changes
- Added support for 2 new activity types - `application/vnd.microsoft.meetingParticipantJoin` and `application/vnd.microsoft.meetingParticipantLeave`.
- Added functions to register handlers for when teams meeting participants are joined/left.
- Added unit test
  
## Testing
![TeamsAddRemoveParticipant1](https://github.com/user-attachments/assets/a8271889-8aec-4b5b-bf17-951d96ea7857)