### PR TITLE
Raise PermissionError if access_token not available on auth_token object

### DIFF
--- a/libraries/botframework-connector/botframework/connector/auth/microsoft_app_credentials.py
+++ b/libraries/botframework-connector/botframework/connector/auth/microsoft_app_credentials.py
@@ -52,7 +52,12 @@ class MicrosoftAppCredentials(AppCredentials, ABC):
         if not auth_token:
             # No suitable token exists in cache. Let's get a new one from AAD.
             auth_token = self.__get_msal_app().acquire_token_for_client(scopes=scopes)
-        return auth_token["access_token"]
+        if "access_token" in auth_token:
+            return auth_token["access_token"]
+        else:
+            error = auth_token["error"] if "error" in auth_token else "Unknown error"
+            error_description = auth_token["error_description"] if "error_description" in auth_token else "Unknown error description"
+            raise PermissionError(f"Failed to get access token with error: {error}, error_description: {error_description}")
 
     def __get_msal_app(self):
         if not self.app:


### PR DESCRIPTION
Fixes #2139 

## Description
The `auth_token` object may not contain an access token due to auth failing. Raise an exception with helpful error message instead.