### PR TITLE
Remove urllib3 upper bound version constraint

### DIFF
--- a/libraries/botbuilder-schema/setup.py
+++ b/libraries/botbuilder-schema/setup.py
@@ -6,7 +6,10 @@ from setuptools import setup
 
 NAME = "botbuilder-schema"
 VERSION = os.environ["packageVersion"] if "packageVersion" in os.environ else "4.17.0"
-REQUIRES = ["msrest== 0.7.*", "urllib3<2.0.0"]
+REQUIRES = [
+    "msrest== 0.7.*",
+    "urllib3",
+]
 
 root = os.path.abspath(os.path.dirname(__file__))
 


### PR DESCRIPTION
Fixes #2142 

## Description

Remove the upper version bound constraint added in #2051. It’s unclear why it was added as @tracyboehrer left no notes. See [this mega blog post](https://iscinumpy.dev/post/bound-version-constraints/) for a long explanier on why libraries should avoid such constraints.

## Specific Changes

Per title

## Testing

Relying on CI.