### PR TITLE
port: Fix first activity from bot to user has fake replyToId value

### DIFF
--- a/libraries/botbuilder-core/botbuilder/core/adapters/test_adapter.py
+++ b/libraries/botbuilder-core/botbuilder/core/adapters/test_adapter.py
@@ -142,7 +142,9 @@ class TestAdapter(BotAdapter, ExtendedUserTokenProvider):
             if activity.type is None:
                 activity.type = ActivityTypes.message
 
-            activity.channel_id = self.template.channel_id
+            if activity.channel_id is None:
+                activity.channel_id = self.template.channel_id
+
             activity.from_property = self.template.from_property
             activity.recipient = self.template.recipient
             activity.conversation = self.template.conversation

--- a/libraries/botbuilder-schema/botbuilder/schema/_models_py3.py
+++ b/libraries/botbuilder-schema/botbuilder/schema/_models_py3.py
@@ -639,7 +639,12 @@ class Activity(Model):
                 id=self.from_property.id if self.from_property else None,
                 name=self.from_property.name if self.from_property else None,
             ),
-            reply_to_id=self.id,
+            reply_to_id=(
+                self.id
+                if not type == ActivityTypes.conversation_update
+                or self.channel_id not in ["directline", "webchat"]
+                else None
+            ),
             service_url=self.service_url,
             channel_id=self.channel_id,
             conversation=ConversationAccount(
@@ -681,7 +686,12 @@ class Activity(Model):
                 id=self.from_property.id if self.from_property else None,
                 name=self.from_property.name if self.from_property else None,
             ),
-            reply_to_id=self.id,
+            reply_to_id=(
+                self.id
+                if not type == ActivityTypes.conversation_update
+                or self.channel_id not in ["directline", "webchat"]
+                else None
+            ),
             service_url=self.service_url,
             channel_id=self.channel_id,
             conversation=ConversationAccount(
@@ -738,6 +748,12 @@ class Activity(Model):
         """
         return ConversationReference(
             activity_id=self.id,
+            activity_id=(
+                self.id
+                if not type == ActivityTypes.conversation_update
+                or self.channel_id not in ["directline", "webchat"]
+                else None
+            ),
             user=self.from_property,
             bot=self.recipient,
             conversation=self.conversation,

--- a/libraries/botbuilder-schema/botbuilder/schema/_models_py3.py
+++ b/libraries/botbuilder-schema/botbuilder/schema/_models_py3.py
@@ -747,7 +747,6 @@ class Activity(Model):
         :returns: A conversation reference for the conversation that contains this activity.
         """
         return ConversationReference(
-            activity_id=self.id,
             activity_id=(
                 self.id
                 if not type == ActivityTypes.conversation_update


### PR DESCRIPTION
Fixes #1695

## Description
Porting [Fix first activity from bot to user has fake replyToId value (#5313)](https://github.com/microsoft/botbuilder-dotnet/pull/5313) to maintain parity with `microsoft/botbuilder-dotnet`

When the activity is the first one of the conversation and it's sent from bot to user, the ReplyToId was assigned to the bogus ConversationUpdate activity's id. The fix is to not assign the bogus ReplyToId if previous activity is the ConversationUpdate activity

## Specific Changes

  - Do not assign ReplyToId if conversantionReference is from ConversationUpdate activity
  
Note: The test cases included in the porting PR are not added here, as they have been reverted to maintain 100% code coverage for Microsoft.Bot.Schema.