### PR TITLE
Fixed type hint in turn_context.py

### DIFF
--- a/libraries/botbuilder-core/botbuilder/core/turn_context.py
+++ b/libraries/botbuilder-core/botbuilder/core/turn_context.py
@@ -158,7 +158,7 @@ class TurnContext:
         activity_or_text: Union[Activity, str],
         speak: str = None,
         input_hint: str = None,
-    ) -> ResourceResponse:
+    ) -> Union[ResourceResponse, None]:
         """
         Sends a single activity or message to the user.
         :param activity_or_text:


### PR DESCRIPTION
Previous type hint implied that send_activity in turn_context.py will always return ResourceResponse, meanwhile it can also return None

Fixes #2146

## Description
The type hint is fixed to include possible None return, otherwise it might make the developers assume that there is no need to check for None.

## Specific Changes
 - Changed ResourceResponse to Union[ResourceResponse, None] type hint