### PR TITLE
Bump PyYAML 6.0 to 6.0.1

### DIFF
--- a/libraries/botframework-connector/tests/requirements.txt
+++ b/libraries/botframework-connector/tests/requirements.txt
@@ -1,5 +1,5 @@
 pytest-cov>=2.6.0
 pytest~=7.3.1
-pyyaml==6.0
+pyyaml==6.0.1
 pytest-asyncio==0.15.1
 ddt==1.2.1


### PR DESCRIPTION
Fixes #2150

## Description
Error installing PyYAML==6.0 with Python 3.12 and 3.13 from
`pip install -r ./libraries/botframework-connector/tests/requirements.txt`

## Specific Changes
Bump PyYAML 6.0 to 6.0.1 

## Testing
Successfully installed
`pip install -r ./libraries/botframework-connector/tests/requirements.txt`

