### PR TITLE
aiohttp 3.10.2

### DIFF
--- a/libraries/botbuilder-ai/botbuilder/ai/qna/qnamaker.py
+++ b/libraries/botbuilder-ai/botbuilder/ai/qna/qnamaker.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
+import asyncio
 import json
 from typing import Dict, List, NamedTuple, Union
 from aiohttp import ClientSession, ClientTimeout
@@ -52,8 +53,16 @@ class QnAMaker(QnAMakerTelemetryClient):
         opt = options or QnAMakerOptions()
         self._validate_options(opt)
 
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+
         instance_timeout = ClientTimeout(total=opt.timeout / 1000)
-        self._http_client = http_client or ClientSession(timeout=instance_timeout)
+        self._http_client = http_client or ClientSession(
+            timeout=instance_timeout, loop=loop
+        )
 
         self.telemetry_client: Union[BotTelemetryClient, NullTelemetryClient] = (
             telemetry_client or NullTelemetryClient()

--- a/libraries/botbuilder-ai/setup.py
+++ b/libraries/botbuilder-ai/setup.py
@@ -8,7 +8,7 @@ REQUIRES = [
     "azure-cognitiveservices-language-luis==0.2.0",
     "botbuilder-schema==4.17.0",
     "botbuilder-core==4.17.0",
-    "aiohttp==3.9.5",
+    "aiohttp==3.10.2",
 ]
 
 TESTS_REQUIRES = ["aiounittest>=1.1.0"]

--- a/libraries/botbuilder-applicationinsights/botbuilder/applicationinsights/flask/flask_telemetry_middleware.py
+++ b/libraries/botbuilder-applicationinsights/botbuilder/applicationinsights/flask/flask_telemetry_middleware.py
@@ -38,6 +38,8 @@ class BotTelemetryMiddleware:
 
     def process_request(self, environ) -> bool:
         """Process the incoming Flask request."""
+        body_unicode = None
+
         # Bot Service doesn't handle anything over 256k
         length = int(environ.get("CONTENT_LENGTH", "0"))
         if length > 256 * 1024:

--- a/libraries/botbuilder-dialogs/botbuilder/dialogs/choices/choice_factory.py
+++ b/libraries/botbuilder-dialogs/botbuilder/dialogs/choices/choice_factory.py
@@ -46,8 +46,7 @@ class ChoiceFactory:
             else:
                 size = len(choice.value)
 
-            if size > max_title_length:
-                max_title_length = size
+            max_title_length = max(max_title_length, size)
 
         # Determine list style
         supports_suggested_actions = Channel.supports_suggested_actions(

--- a/libraries/botbuilder-dialogs/botbuilder/dialogs/dialog.py
+++ b/libraries/botbuilder-dialogs/botbuilder/dialogs/dialog.py
@@ -176,7 +176,6 @@ class Dialog(ABC):
         Registers a SourceRange in the provided location.
         :param path: The path to the source file.
         :param line_number: The line number where the source will be located on the file.
-        :return:
         """
         if path:
             # This will be added when debbuging support is ported.
@@ -185,4 +184,4 @@ class Dialog(ABC):
             #     start_point = SourcePoint(line_index = line_number, char_index = 0 ),
             #     end_point = SourcePoint(line_index = line_number + 1, char_index = 0 ),
             # )
-            return
+            pass

--- a/libraries/botbuilder-integration-aiohttp/botbuilder/integration/aiohttp/streaming/aiohttp_web_socket.py
+++ b/libraries/botbuilder-integration-aiohttp/botbuilder/integration/aiohttp/streaming/aiohttp_web_socket.py
@@ -40,6 +40,8 @@ class AiohttpWebSocket(WebSocket):
         try:
             message = await self._aiohttp_ws.receive()
 
+            message_data = None
+
             if message.type == WSMsgType.TEXT:
                 message_data = list(str(message.data).encode("ascii"))
             elif message.type == WSMsgType.BINARY:

--- a/libraries/botbuilder-integration-aiohttp/setup.py
+++ b/libraries/botbuilder-integration-aiohttp/setup.py
@@ -10,7 +10,7 @@ REQUIRES = [
     "botframework-connector==4.17.0",
     "botbuilder-core==4.17.0",
     "yarl>=1.8.1",
-    "aiohttp==3.9.5",
+    "aiohttp==3.10.2",
 ]
 
 root = os.path.abspath(os.path.dirname(__file__))

--- a/libraries/botbuilder-integration-applicationinsights-aiohttp/setup.py
+++ b/libraries/botbuilder-integration-applicationinsights-aiohttp/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup
 
 REQUIRES = [
     "applicationinsights>=0.11.9",
-    "aiohttp==3.9.5",
+    "aiohttp==3.10.2",
     "botbuilder-schema==4.17.0",
     "botframework-connector==4.17.0",
     "botbuilder-core==4.17.0",

--- a/libraries/botbuilder-schema/botbuilder/schema/_models_py3.py
+++ b/libraries/botbuilder-schema/botbuilder/schema/_models_py3.py
@@ -641,7 +641,7 @@ class Activity(Model):
             ),
             reply_to_id=(
                 self.id
-                if not type == ActivityTypes.conversation_update
+                if type != ActivityTypes.conversation_update
                 or self.channel_id not in ["directline", "webchat"]
                 else None
             ),
@@ -688,7 +688,7 @@ class Activity(Model):
             ),
             reply_to_id=(
                 self.id
-                if not type == ActivityTypes.conversation_update
+                if type != ActivityTypes.conversation_update
                 or self.channel_id not in ["directline", "webchat"]
                 else None
             ),
@@ -749,7 +749,7 @@ class Activity(Model):
         return ConversationReference(
             activity_id=(
                 self.id
-                if not type == ActivityTypes.conversation_update
+                if type != ActivityTypes.conversation_update
                 or self.channel_id not in ["directline", "webchat"]
                 else None
             ),


### PR DESCRIPTION
#minor

Updates aiohttp from 3.9.5 to 3.10.2
- [libraries/botbuilder-ai/setup.py](https://github.com/microsoft/botbuilder-python/blob/main/libraries/botbuilder-ai/setup.py)
- [libraries/botbuilder-integration-aiohttp/setup.py](https://github.com/microsoft/botbuilder-python/blob/main/libraries/botbuilder-integration-aiohttp/setup.py)
- [libraries/botbuilder-integration-applicationinsights-aiohttp/setup.py](https://github.com/microsoft/botbuilder-python/blob/main/libraries/botbuilder-integration-applicationinsights-aiohttp/setup.py)

https://github.com/microsoft/botbuilder-python/pull/2152
