### PR TITLE
Add missing parameter in exchange_token() call

### DIFF
--- a/libraries/botbuilder-dialogs/botbuilder/dialogs/_user_token_access.py
+++ b/libraries/botbuilder-dialogs/botbuilder/dialogs/_user_token_access.py
@@ -104,6 +104,7 @@ class _UserTokenAccess(ABC):
             channel_id = turn_context.activity.channel_id
             return await user_token_client.exchange_token(
                 user_id,
+                settings.connection_name,
                 channel_id,
                 token_exchange_request,
             )


### PR DESCRIPTION
Fixes #2176

## Description
Add missing parameter: `connection_name` in `exchange_token()` call.

## Specific Changes
  - Added missing parameter: `connection_name` in `exchange_token()` call under [_user_token_access.py](https://github.com/microsoft/botbuilder-python/blob/main/libraries/botbuilder-dialogs/botbuilder/dialogs/_user_token_access.py) to enable proper token exchange flow.
