### PR TITLE
Port: Support Teams message edit, message soft delete, message undelete activities

### DIFF
--- a/libraries/botbuilder-core/botbuilder/core/activity_handler.py
+++ b/libraries/botbuilder-core/botbuilder/core/activity_handler.py
@@ -68,6 +68,10 @@ class ActivityHandler(Bot):
 
         if turn_context.activity.type == ActivityTypes.message:
             await self.on_message_activity(turn_context)
+        elif turn_context.activity.type == ActivityTypes.message_update:
+            await self.on_message_update_activity(turn_context)
+        elif turn_context.activity.type == ActivityTypes.message_delete:
+            await self.on_message_delete_activity(turn_context)
         elif turn_context.activity.type == ActivityTypes.conversation_update:
             await self.on_conversation_update_activity(turn_context)
         elif turn_context.activity.type == ActivityTypes.message_reaction:
@@ -94,6 +98,34 @@ class ActivityHandler(Bot):
             await self.on_unrecognized_activity_type(turn_context)
 
     async def on_message_activity(  # pylint: disable=unused-argument
+        self, turn_context: TurnContext
+    ):
+        """
+        Override this method in a derived class to provide logic specific to activities,
+        such as the conversational logic.
+
+        :param turn_context: The context object for this turn
+        :type turn_context: :class:`botbuilder.core.TurnContext`
+
+        :returns: A task that represents the work queued to execute
+        """
+        return
+
+    async def on_message_update_activity(  # pylint: disable=unused-argument
+        self, turn_context: TurnContext
+    ):
+        """
+        Override this method in a derived class to provide logic specific to activities,
+        such as the conversational logic.
+
+        :param turn_context: The context object for this turn
+        :type turn_context: :class:`botbuilder.core.TurnContext`
+
+        :returns: A task that represents the work queued to execute
+        """
+        return
+
+    async def on_message_delete_activity(  # pylint: disable=unused-argument
         self, turn_context: TurnContext
     ):
         """

--- a/libraries/botbuilder-core/botbuilder/core/teams/teams_activity_handler.py
+++ b/libraries/botbuilder-core/botbuilder/core/teams/teams_activity_handler.py
@@ -1042,3 +1042,73 @@ class TeamsActivityHandler(ActivityHandler):
         :returns: A task that represents the work queued to execute.
         """
         return
+
+    async def on_message_update_activity(self, turn_context: TurnContext):
+        """
+        Invoked when a message update activity is received, such as a message edit or undelete.
+
+        :param turn_context: A context object for this turn.
+
+        :returns: A task that represents the work queued to execute.
+        """
+        if turn_context.activity.channel_id == Channels.ms_teams:
+            channel_data = TeamsChannelData().deserialize(
+                turn_context.activity.channel_data
+            )
+
+            if channel_data:
+                if channel_data.event_type == "editMessage":
+                    return await self.on_teams_message_edit(turn_context)
+                if channel_data.event_type == "undeleteMessage":
+                    return await self.on_teams_message_undelete(turn_context)
+
+        return await super().on_message_update_activity(turn_context)
+
+    async def on_message_delete_activity(self, turn_context: TurnContext):
+        """
+        Invoked when a message delete activity is received, such as a soft delete message.
+
+        :param turn_context: A context object for this turn.
+
+        :returns: A task that represents the work queued to execute.
+        """
+        if turn_context.activity.channel_id == Channels.ms_teams:
+            channel_data = TeamsChannelData().deserialize(
+                turn_context.activity.channel_data
+            )
+
+            if channel_data:
+                if channel_data.event_type == "softDeleteMessage":
+                    return await self.on_teams_message_soft_delete(turn_context)
+
+        return await super().on_message_delete_activity(turn_context)
+
+    async def on_teams_message_edit(self, turn_context: TurnContext):
+        """
+        Invoked when a Teams edit message event activity is received.
+
+        :param turn_context: A context object for this turn.
+
+        :returns: A task that represents the work queued to execute.
+        """
+        return
+
+    async def on_teams_message_undelete(self, turn_context: TurnContext):
+        """
+        Invoked when a Teams undo soft delete message event activity is received.
+
+        :param turn_context: A context object for this turn.
+
+        :returns: A task that represents the work queued to execute.
+        """
+        return
+
+    async def on_teams_message_soft_delete(self, turn_context: TurnContext):
+        """
+        Invoked when a Teams soft delete message event activity is received.
+
+        :param turn_context: A context object for this turn.
+
+        :returns: A task that represents the work queued to execute.
+        """
+        return

--- a/libraries/botbuilder-core/tests/teams/test_teams_activity_handler.py
+++ b/libraries/botbuilder-core/tests/teams/test_teams_activity_handler.py
@@ -34,6 +34,7 @@ from botbuilder.schema.teams import (
     TabContext,
     MeetingParticipantsEventDetails,
     ReadReceiptInfo,
+    TeamsChannelData,
 )
 from botframework.connector import Channels
 from simple_adapter import SimpleAdapter
@@ -350,6 +351,26 @@ class TestingTeamsActivityHandler(TeamsActivityHandler):
         return await super().on_teams_meeting_end_event(
             turn_context.activity.value, turn_context
         )
+
+    async def on_message_update_activity(self, turn_context: TurnContext):
+        self.record.append("on_message_update_activity")
+        return await super().on_message_update_activity(turn_context)
+
+    async def on_teams_message_edit(self, turn_context: TurnContext):
+        self.record.append("on_teams_message_edit")
+        return await super().on_teams_message_edit(turn_context)
+
+    async def on_teams_message_undelete(self, turn_context: TurnContext):
+        self.record.append("on_teams_message_undelete")
+        return await super().on_teams_message_undelete(turn_context)
+
+    async def on_message_delete_activity(self, turn_context: TurnContext):
+        self.record.append("on_message_delete_activity")
+        return await super().on_message_delete_activity(turn_context)
+
+    async def on_teams_message_soft_delete(self, turn_context: TurnContext):
+        self.record.append("on_teams_message_soft_delete")
+        return await super().on_teams_message_soft_delete(turn_context)
 
     async def on_teams_meeting_participants_join_event(
         self, meeting: MeetingParticipantsEventDetails, turn_context: TurnContext
@@ -1253,6 +1274,124 @@ class TestTeamsActivityHandler(aiounittest.AsyncTestCase):
         assert len(bot.record) == 2
         assert bot.record[0] == "on_event_activity"
         assert bot.record[1] == "on_teams_meeting_end_event"
+
+    async def test_message_update_activity_teams_message_edit(self):
+        # Arrange
+        activity = Activity(
+            type=ActivityTypes.message_update,
+            channel_data=TeamsChannelData(event_type="editMessage"),
+            channel_id=Channels.ms_teams,
+        )
+        turn_context = TurnContext(SimpleAdapter(), activity)
+
+        # Act
+        bot = TestingTeamsActivityHandler()
+        await bot.on_turn(turn_context)
+
+        # Assert
+        self.assertEqual(2, len(bot.record))
+        self.assertEqual("on_message_update_activity", bot.record[0])
+        self.assertEqual("on_teams_message_edit", bot.record[1])
+
+    async def test_message_update_activity_teams_message_undelete(self):
+        # Arrange
+        activity = Activity(
+            type=ActivityTypes.message_update,
+            channel_data=TeamsChannelData(event_type="undeleteMessage"),
+            channel_id=Channels.ms_teams,
+        )
+        turn_context = TurnContext(SimpleAdapter(), activity)
+
+        # Act
+        bot = TestingTeamsActivityHandler()
+        await bot.on_turn(turn_context)
+
+        # Assert
+        self.assertEqual(2, len(bot.record))
+        self.assertEqual("on_message_update_activity", bot.record[0])
+        self.assertEqual("on_teams_message_undelete", bot.record[1])
+
+    async def test_message_update_activity_teams_message_undelete_no_msteams(self):
+        # Arrange
+        activity = Activity(
+            type=ActivityTypes.message_update,
+            channel_data=TeamsChannelData(event_type="undeleteMessage"),
+        )
+        turn_context = TurnContext(SimpleAdapter(), activity)
+
+        # Act
+        bot = TestingTeamsActivityHandler()
+        await bot.on_turn(turn_context)
+
+        # Assert
+        self.assertEqual(1, len(bot.record))
+        self.assertEqual("on_message_update_activity", bot.record[0])
+
+    async def test_message_update_activity_teams_no_channel_data(self):
+        # Arrange
+        activity = Activity(
+            type=ActivityTypes.message_update,
+            channel_id=Channels.ms_teams,
+        )
+        turn_context = TurnContext(SimpleAdapter(), activity)
+
+        # Act
+        bot = TestingTeamsActivityHandler()
+        await bot.on_turn(turn_context)
+
+        # Assert
+        self.assertEqual(1, len(bot.record))
+        self.assertEqual("on_message_update_activity", bot.record[0])
+
+    async def test_message_delete_activity_teams_message_soft_delete(self):
+        # Arrange
+        activity = Activity(
+            type=ActivityTypes.message_delete,
+            channel_data=TeamsChannelData(event_type="softDeleteMessage"),
+            channel_id=Channels.ms_teams,
+        )
+        turn_context = TurnContext(SimpleAdapter(), activity)
+
+        # Act
+        bot = TestingTeamsActivityHandler()
+        await bot.on_turn(turn_context)
+
+        # Assert
+        self.assertEqual(2, len(bot.record))
+        self.assertEqual("on_message_delete_activity", bot.record[0])
+        self.assertEqual("on_teams_message_soft_delete", bot.record[1])
+
+    async def test_message_delete_activity_teams_message_soft_delete_no_msteams(self):
+        # Arrange
+        activity = Activity(
+            type=ActivityTypes.message_delete,
+            channel_data=TeamsChannelData(event_type="softDeleteMessage"),
+        )
+        turn_context = TurnContext(SimpleAdapter(), activity)
+
+        # Act
+        bot = TestingTeamsActivityHandler()
+        await bot.on_turn(turn_context)
+
+        # Assert
+        self.assertEqual(1, len(bot.record))
+        self.assertEqual("on_message_delete_activity", bot.record[0])
+
+    async def test_message_delete_activity_teams_no_channel_data(self):
+        # Arrange
+        activity = Activity(
+            type=ActivityTypes.message_delete,
+            channel_id=Channels.ms_teams,
+        )
+        turn_context = TurnContext(SimpleAdapter(), activity)
+
+        # Act
+        bot = TestingTeamsActivityHandler()
+        await bot.on_turn(turn_context)
+
+        # Assert
+        self.assertEqual(1, len(bot.record))
+        self.assertEqual("on_message_delete_activity", bot.record[0])
 
     async def test_on_teams_meeting_participants_join_event(self):
         # arrange

--- a/libraries/botbuilder-core/tests/test_activity_handler.py
+++ b/libraries/botbuilder-core/tests/test_activity_handler.py
@@ -26,6 +26,14 @@ class TestingActivityHandler(ActivityHandler):
         self.record.append("on_message_activity")
         return await super().on_message_activity(turn_context)
 
+    async def on_message_update_activity(self, turn_context: TurnContext):
+        self.record.append("on_message_update_activity")
+        return await super().on_message_update_activity(turn_context)
+
+    async def on_message_delete_activity(self, turn_context: TurnContext):
+        self.record.append("on_message_delete_activity")
+        return await super().on_message_delete_activity(turn_context)
+
     async def on_members_added_activity(
         self, members_added: ChannelAccount, turn_context: TurnContext
     ):
@@ -207,6 +215,32 @@ class TestActivityHandler(aiounittest.AsyncTestCase):
         assert len(bot.record) == 1
         assert bot.record[0] == "on_invoke_activity"
         assert adapter.activity.value.status == int(HTTPStatus.NOT_IMPLEMENTED)
+
+    async def test_on_message_update_activity(self):
+        activity = Activity(type=ActivityTypes.message_update)
+
+        adapter = TestInvokeAdapter()
+        turn_context = TurnContext(adapter, activity)
+
+        # Act
+        bot = TestingActivityHandler()
+        await bot.on_turn(turn_context)
+
+        assert len(bot.record) == 1
+        assert bot.record[0] == "on_message_update_activity"
+
+    async def test_on_message_delete_activity(self):
+        activity = Activity(type=ActivityTypes.message_delete)
+
+        adapter = TestInvokeAdapter()
+        turn_context = TurnContext(adapter, activity)
+
+        # Act
+        bot = TestingActivityHandler()
+        await bot.on_turn(turn_context)
+
+        assert len(bot.record) == 1
+        assert bot.record[0] == "on_message_delete_activity"
 
     async def test_on_end_of_conversation_activity(self):
         activity = Activity(type=ActivityTypes.end_of_conversation)


### PR DESCRIPTION
Fixes #minor

## Description
This PR ports the changes from https://github.com/microsoft/botbuilder-dotnet/pull/6564 to maintain parity with `microsoft/botbuilder-dotnet`.

This PR aims to extend the Bot SDK so that developers can consume newly added events that Teams will emit to the bot. They are:
`TeamsMessageEdit `- a user editing a message in Teams.
`TeamsMessageUndelete `- a user undo a deleted message in Teams.
`TeamsMessageSoftDelete `- a user soft deleting a message in Teams.

## Specific Changes

1. Extended `ActivityHandler` to handle `MessageUpdate `and `MessageDelete` activity types and dispatch functions for activity types.
2. Extended `TeamsActivityHandler `to handle `MessageUpdate `(with subtypes `TeamsMessageEdit `and `TeamsMessageUndelete`) and `MessageDelete `(with subtype `TeamsMessageSoftDelete`) teams events.

**ActivityHandler Class**
  - Added `on_message_update_activity` method and `on_message_delete_activity` method
  
**TeamsActivityHandler Class**
  - Overrided the above two methods and add logic based to `event_type`
 - `on_message_update_activity` could call `on_teams_message_edit` or `on_teams_message_undelete`
 - `on_message_delete_activity` could call `on_teams_message_soft_delete`

## Testing
The following images shows the related unit test passing.
![testRes](https://github.com/user-attachments/assets/6b536896-0757-4152-a5c9-a089ca8d4019)
<img width="871" alt="image" src="https://github.com/user-attachments/assets/a7c56fcf-8144-49fb-b75e-ce1b3d53ed5b">
