### PR TITLE
Port: Add new handler for anonymous query link invoke

### DIFF
--- a/libraries/botbuilder-core/botbuilder/core/teams/teams_activity_handler.py
+++ b/libraries/botbuilder-core/botbuilder/core/teams/teams_activity_handler.py
@@ -90,6 +90,16 @@ class TeamsActivityHandler(ActivityHandler):
                     )
                 )
 
+            if turn_context.activity.name == "composeExtension/anonymousQueryLink":
+                return self._create_invoke_response(
+                    await self.on_teams_anonymous_app_based_link_query(
+                        turn_context,
+                        deserializer_helper(
+                            AppBasedLinkQuery, turn_context.activity.value
+                        ),
+                    )
+                )
+
             if turn_context.activity.name == "composeExtension/query":
                 return self._create_invoke_response(
                     await self.on_teams_messaging_extension_query(
@@ -323,6 +333,19 @@ class TeamsActivityHandler(ActivityHandler):
     ) -> MessagingExtensionResponse:
         """
         Invoked when an app based link query activity is received from the connector.
+
+        :param turn_context: A context object for this turn.
+        :param query: The invoke request body type for app-based link query.
+
+        :returns: The Messaging Extension Response for the query.
+        """
+        raise _InvokeResponseException(status_code=HTTPStatus.NOT_IMPLEMENTED)
+
+    async def on_teams_anonymous_app_based_link_query(  # pylint: disable=unused-argument
+        self, turn_context: TurnContext, query: AppBasedLinkQuery
+    ) -> MessagingExtensionResponse:
+        """
+        Invoked when an anonymous app based link query activity is received from the connector.
 
         :param turn_context: A context object for this turn.
         :param query: The invoke request body type for app-based link query.

--- a/libraries/botbuilder-core/tests/teams/test_teams_activity_handler.py
+++ b/libraries/botbuilder-core/tests/teams/test_teams_activity_handler.py
@@ -219,6 +219,14 @@ class TestingTeamsActivityHandler(TeamsActivityHandler):
         self.record.append("on_teams_messaging_extension_query")
         return await super().on_teams_messaging_extension_query(turn_context, query)
 
+    async def on_teams_anonymous_app_based_link_query(
+        self, turn_context: TurnContext, query: AppBasedLinkQuery
+    ):
+        self.record.append("on_teams_anonymous_app_based_link_query")
+        return await super().on_teams_anonymous_app_based_link_query(
+            turn_context, query
+        )
+
     async def on_teams_messaging_extension_submit_action_dispatch(
         self, turn_context: TurnContext, action: MessagingExtensionAction
     ):
@@ -815,6 +823,25 @@ class TestTeamsActivityHandler(aiounittest.AsyncTestCase):
         assert len(bot.record) == 2
         assert bot.record[0] == "on_invoke_activity"
         assert bot.record[1] == "on_teams_messaging_extension_query"
+
+    async def test_compose_extension_anonymous_query_link(self):
+        # arrange
+        activity = Activity(
+            type=ActivityTypes.invoke,
+            name="composeExtension/anonymousQueryLink",
+            value={"url": "http://www.test.com"},
+        )
+
+        turn_context = TurnContext(SimpleAdapter(), activity)
+
+        # Act
+        bot = TestingTeamsActivityHandler()
+        await bot.on_turn(turn_context)
+
+        # Assert
+        assert len(bot.record) == 2
+        assert bot.record[0] == "on_invoke_activity"
+        assert bot.record[1] == "on_teams_anonymous_app_based_link_query"
 
     async def test_on_teams_messaging_extension_bot_message_preview_edit_activity(self):
         # Arrange


### PR DESCRIPTION
Fixes #minor

## Description
This PR port the changes from https://github.com/microsoft/botbuilder-dotnet/pull/6524

This PR adds a new invoke handler for the invoke name `composeExtension/anonymousQueryLink`.
This invoke will get triggered when an user pastes a link for an app that has opted in to the zero install link unfurling feature. The interface is identical to existing handler for composeExtension/queryLink, but the user sensitive information will be anonymized for anonymousQueryLink.

## Specific Changes
  - Added new invoke handler for composeExtension/anonymousQueryLink

## Testing
The following image shows the related unit test passing.
![testRes](https://github.com/user-attachments/assets/5610aa08-7c9c-473b-bf07-6971a59bae4a)
