### PR TITLE
Port: Set TeamsNotifyUser alert to opposite of alert_in_meeting

### DIFF
--- a/libraries/botbuilder-core/botbuilder/core/teams/teams_activity_extensions.py
+++ b/libraries/botbuilder-core/botbuilder/core/teams/teams_activity_extensions.py
@@ -71,7 +71,7 @@ def teams_notify_user(
         activity.channel_data = {}
 
     channel_data = TeamsChannelData().deserialize(activity.channel_data)
-    channel_data.notification = NotificationInfo(alert=True)
+    channel_data.notification = NotificationInfo(alert=not alert_in_meeting)
     channel_data.notification.alert_in_meeting = alert_in_meeting
     channel_data.notification.external_resource_url = external_resource_url
     activity.channel_data = channel_data

--- a/libraries/botbuilder-core/tests/teams/test_teams_extension.py
+++ b/libraries/botbuilder-core/tests/teams/test_teams_extension.py
@@ -155,6 +155,17 @@ class TestTeamsActivityHandler(aiounittest.AsyncTestCase):
         # Assert
         assert activity.channel_data.notification.alert
 
+    def test_teams_notify_user_alert_in_meeting(self):
+        # Arrange
+        activity = Activity()
+
+        # Act
+        teams_notify_user(activity, alert_in_meeting=True)
+
+        # Assert
+        assert activity.channel_data.notification.alert_in_meeting is True
+        assert activity.channel_data.notification.alert is False
+
     def test_teams_notify_user_with_no_activity(self):
         # Arrange
         activity = None


### PR DESCRIPTION
Fixes #223 

## Description
Porting changes from https://github.com/microsoft/botbuilder-dotnet/pull/6136

The logic for `teams_notify_user` helper method is incorrect. It should set either alertInMeeting to true, or alert to true, but not both.
https://github.com/microsoft/botbuilder-python/blob/3e76e543477500b7e56f53ba20258b730ec4f924/libraries/botbuilder-core/botbuilder/core/teams/teams_activity_extensions.py#L74-L75

## Specific Changes
  - Set TeamsNotifyUser alert to opposite of alert_in_meeting

## Testing
The following image shows the related unit test passing.
<img width="796" alt="image" src="https://github.com/user-attachments/assets/29fd1611-342e-406a-b520-7cb5ff32db54">
