### PR TITLE
Bumped pytest

### DIFF
--- a/libraries/botbuilder-core/tests/teams/test_teams_activity_handler.py
+++ b/libraries/botbuilder-core/tests/teams/test_teams_activity_handler.py
@@ -5,6 +5,10 @@
 
 from typing import List
 import aiounittest
+import sys
+import os
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from botbuilder.core import BotAdapter, TurnContext
 from botbuilder.core.teams import TeamsActivityHandler
 from botbuilder.schema import (

--- a/libraries/botbuilder-dialogs/tests/choices/test_choice_recognizers.py
+++ b/libraries/botbuilder-dialogs/tests/choices/test_choice_recognizers.py
@@ -57,10 +57,9 @@ def assert_choice(result, value, index, score, synonym=None):
         resolution.score == score
     ), f"Invalid resolution.score of '{resolution.score}' for '{value}' choice."
     if synonym:
-        assert (  # pylint: disable=assert-on-tuple
-            resolution.synonym == synonym,
-            f"Invalid resolution.synonym of '{resolution.synonym}' for '{value}' choice.",
-        )
+        assert (
+            resolution.synonym == synonym
+        ), f"Invalid resolution.synonym of '{resolution.synonym}' for '{value}' choice."
 
 
 _color_choices: List[str] = ["red", "green", "blue"]

--- a/libraries/botbuilder-testing/setup.py
+++ b/libraries/botbuilder-testing/setup.py
@@ -9,7 +9,7 @@ REQUIRES = [
     "botbuilder-core==4.17.0",
     "botbuilder-dialogs==4.17.0",
     "botbuilder-azure==4.17.0",
-    "pytest~=7.3.1",
+    "pytest~=8.3.3",
 ]
 
 TESTS_REQUIRES = ["aiounittest==1.3.0"]

--- a/libraries/botframework-connector/tests/requirements.txt
+++ b/libraries/botframework-connector/tests/requirements.txt
@@ -1,6 +1,6 @@
-pytest-cov>=2.6.0
-pytest~=7.3.1
+pytest-cov>=5.0.0
+pytest~=8.3.3
 pyyaml==6.0.1
-pytest-asyncio==0.23.8
+pytest-asyncio==0.24.0
 ddt==1.2.1
 setuptools==72.1.0


### PR DESCRIPTION
Fixes #2168

## Description
[botbuilder.testing] Relax dependency to allow pytest 8

## Specific Changes
  - Updated `pytest `version to `8.3.3`
  - Updated `pytest-asyncio` version to `0.24.0`
  - Updated `pytest-cov` version to `>=5.0.0`
  - Fixed `ModuleNotFoundError: No module named 'simple_adapter'` in `test_teams_activity_handler.py`
  - Fixed `PytestAssertRewriteWarning: assertion is always true, perhaps remove parentheses?` in `test_choice_recognizers.py`

## Testing
Ran the `pip install commands` and `pytest` in the following Python versions, and they are working as expected
`Python 3.13.0, 3.12.5, 3.11.9, 3.10.11, 3.9.13, 3.8.10`