### PR TITLE
Added missing parameters to the ARM template for Python bot deployment.

### DIFF
--- a/generators/app/templates/core/{{cookiecutter.bot_name}}/deploymentTemplates/deployUseExistResourceGroup/parameters-for-template-AzureBot-with-rg.json
+++ b/generators/app/templates/core/{{cookiecutter.bot_name}}/deploymentTemplates/deployUseExistResourceGroup/parameters-for-template-AzureBot-with-rg.json
@@ -14,8 +14,20 @@
         "botEndpoint": {
             "value": ""
         },
+        "appType": {
+          "value": "MultiTenant"
+        },
         "appId": {
             "value": ""
+        },
+        "UMSIName": {
+            "value": ""
+        },
+        "UMSIResourceGroupName": {
+            "value": ""
+        },
+        "tenantId": {
+          "value": ""
         }
     }
 }

--- a/generators/app/templates/core/{{cookiecutter.bot_name}}/deploymentTemplates/deployUseExistResourceGroup/parameters-for-template-BotApp-with-rg.json
+++ b/generators/app/templates/core/{{cookiecutter.bot_name}}/deploymentTemplates/deployUseExistResourceGroup/parameters-for-template-BotApp-with-rg.json
@@ -15,7 +15,7 @@
             "value": ""
         },
         "newAppServicePlanLocation": {
-            "value": ""
+            "value": "West US"
         },
         "newAppServicePlanSku": {
             "value": {
@@ -26,10 +26,22 @@
                 "capacity": 1
             }
         },
+        "appType": {
+            "value": "MultiTenant"
+        },
         "appId": {
             "value": ""
         },
         "appSecret": {
+            "value": ""
+        },
+        "tenantId": {
+            "value": ""
+        },
+        "UMSIName": {
+            "value": ""
+        },
+        "UMSIResourceGroupName": {
             "value": ""
         }
     }

--- a/generators/app/templates/core/{{cookiecutter.bot_name}}/deploymentTemplates/deployUseExistResourceGroup/readme.md
+++ b/generators/app/templates/core/{{cookiecutter.bot_name}}/deploymentTemplates/deployUseExistResourceGroup/readme.md
@@ -1,28 +1,48 @@
-Need deploy BotAppService before AzureBot
----
-az login
-az deployment group create --resource-group <group-name> --template-file <template-file> --parameters @<parameters-file>
----
+# Usage
+BotApp must be deployed prior to AzureBot.
+
+### Command line:
+`az login`<br>
+`az deployment group create --resource-group <group-name> --template-file <template-file> --parameters @<parameters-file>`
 
 # parameters-for-template-BotApp-with-rg:
 
-**appServiceName**:(required)   The Name of the Bot App Service.
+- **appServiceName**:(required)   The Name of the Bot App Service.
 
-(choose an existingAppServicePlan or create a new AppServicePlan)
-**existingAppServicePlanName**:     The name of the App Service Plan.
-**existingAppServicePlanLocation**: The location of the App Service Plan.
-**newAppServicePlanName**:          The name of the App Service Plan.
-**newAppServicePlanLocation**:      The location of the App Service Plan.
-**newAppServicePlanSku**:           The SKU of the App Service Plan. Defaults to Standard values.
+- (choose an existingAppServicePlan or create a new AppServicePlan)
+  - **existingAppServicePlanName**:     The name of the App Service Plan.
+  - **existingAppServicePlanLocation**: The location of the App Service Plan.
+  - **newAppServicePlanName**:          The name of the App Service Plan.
+  - **newAppServicePlanLocation**:      The location of the App Service Plan.
+  - **newAppServicePlanSku**:           The SKU of the App Service Plan. Defaults to Standard values.
 
-**appId**:(required)                                        Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings.
-**appSecret**:(required)   Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings.
+- **appType**:    Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. **Allowed values are: MultiTenant(default), SingleTenant, UserAssignedMSI.**
+
+- **appId**:(required)                                        Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings.
+
+- **appSecret**:(required for MultiTenant and SingleTenant)   Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings.
+
+- **UMSIName**:(required for UserAssignedMSI)                 The User-Assigned Managed Identity Resource used for the Bot's Authentication.
+
+- **UMSIResourceGroupName**:(required for UserAssignedMSI)    The User-Assigned Managed Identity Resource Group used for the Bot's Authentication.
+
+- **tenantId**:   The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to <Subscription Tenant ID>.
+
+MoreInfo: https://docs.microsoft.com/en-us/azure/bot-service/tutorial-provision-a-bot?view=azure-bot-service-4.0&tabs=userassigned%2Cnewgroup#create-an-identity-resource
+
+
 
 # parameters-for-template-AzureBot-with-rg:
 
-**azureBotId**:(required)           The globally unique and immutable bot ID.
-**azureBotSku**:                    The pricing tier of the Bot Service Registration. **Allowed values are: F0, S1(default)**.
-**azureBotRegion**:                 Specifies the location of the new AzureBot. **Allowed values are: global(default), westeurope**.
-**botEndpoint**:                    Use to handle client messages, Such as https://<botappServiceName>.azurewebsites.net/api/messages.
+- **azureBotId**:(required)           The globally unique and immutable bot ID.
+- **azureBotSku**:                    The pricing tier of the Bot Service Registration. **Allowed values are: F0, S1(default)**.
+- **azureBotRegion**:                 Specifies the location of the new AzureBot. **Allowed values are: global(default), westeurope**.
+- **botEndpoint**:                    Use to handle client messages, Such as https://<botappServiceName>.azurewebsites.net/api/messages.
 
-**appId**:(required)                                        Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings.
+- **appType**:    Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. **Allowed values are: MultiTenant(default), SingleTenant, UserAssignedMSI.**
+- **appId**:(required)                                        Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings.
+- **UMSIName**:(required for UserAssignedMSI)                 The User-Assigned Managed Identity Resource used for the Bot's Authentication.
+- **UMSIResourceGroupName**:(required for UserAssignedMSI)    The User-Assigned Managed Identity Resource Group used for the Bot's Authentication.
+- **tenantId**:   The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to <Subscription Tenant ID>.
+
+MoreInfo: https://docs.microsoft.com/en-us/azure/bot-service/tutorial-provision-a-bot?view=azure-bot-service-4.0&tabs=userassigned%2Cnewgroup#create-an-identity-resource

--- a/generators/app/templates/core/{{cookiecutter.bot_name}}/deploymentTemplates/deployUseExistResourceGroup/template-AzureBot-with-rg.json
+++ b/generators/app/templates/core/{{cookiecutter.bot_name}}/deploymentTemplates/deployUseExistResourceGroup/template-AzureBot-with-rg.json
@@ -9,8 +9,8 @@
             }
         },
         "azureBotSku": {
-            "defaultValue": "S1",
             "type": "string",
+            "defaultValue": "S1",
             "metadata": {
                 "description": "The pricing tier of the Bot Service Registration. Allowed values are: F0, S1(default)."
             }
@@ -24,8 +24,21 @@
         },
         "botEndpoint": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
                 "description": "Use to handle client messages, Such as https://<botappServiceName>.azurewebsites.net/api/messages."
+            }
+        },
+        "appType": {
+            "type": "string",
+            "defaultValue": "MultiTenant",
+            "allowedValues": [
+                "MultiTenant",
+                "SingleTenant",
+                "UserAssignedMSI"
+            ],
+            "metadata": {
+                "description": "Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. Allowed values are: MultiTenant, SingleTenant, UserAssignedMSI. Defaults to \"MultiTenant\"."
             }
         },
         "appId": {
@@ -33,6 +46,50 @@
             "metadata": {
                 "description": "Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings."
             }
+        },
+        "UMSIName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource used for the Bot's Authentication."
+            }
+        },
+        "UMSIResourceGroupName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource Group used for the Bot's Authentication."
+            }
+        },
+        "tenantId": {
+            "type": "string",
+            "defaultValue": "[subscription().tenantId]",
+            "metadata": {
+                "description": "The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to \"Subscription Tenant ID\"."
+            }
+        }
+    },
+    "variables": {
+        "botEndpoint": "[if(empty(parameters('botEndpoint')), concat('https://', parameters('azureBotId'), '.azurewebsites.net/api/messages'), parameters('botEndpoint'))]",
+        "tenantId": "[if(empty(parameters('tenantId')), subscription().tenantId, parameters('tenantId'))]",
+        "msiResourceId": "[if(empty(parameters('UMSIName')), '', concat(subscription().id, '/resourceGroups/', parameters('UMSIResourceGroupName'), '/providers/', 'Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('UMSIName')))]",
+        "appTypeDef": {
+            "MultiTenant": {
+              "tenantId": "",
+              "msiResourceId": ""
+            },
+            "SingleTenant": {
+              "tenantId": "[variables('tenantId')]",
+              "msiResourceId": ""
+            },
+            "UserAssignedMSI": {
+              "tenantId": "[variables('tenantId')]",
+              "msiResourceId": "[variables('msiResourceId')]"
+            }
+        },
+        "appType": {
+            "tenantId": "[variables('appTypeDef')[parameters('appType')].tenantId]",
+            "msiResourceId": "[variables('appTypeDef')[parameters('appType')].msiResourceId]"
         }
     },
     "resources": [
@@ -49,8 +106,11 @@
                 "name": "[parameters('azureBotId')]",
                 "displayName": "[parameters('azureBotId')]",
                 "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
-                "endpoint": "[parameters('botEndpoint')]",
+                "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
+                "msaAppTenantId": "[variables('appType').tenantId]",
+                "msaAppMSIResourceId": "[variables('appType').msiResourceId]",
+                "msaAppType": "[parameters('appType')]",
                 "luisAppIds": [],
                 "schemaTransformationVersion": "1.3",
                 "isCmekEnabled": false,

--- a/generators/app/templates/core/{{cookiecutter.bot_name}}/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/generators/app/templates/core/{{cookiecutter.bot_name}}/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -4,7 +4,6 @@
     "parameters": {
         "appServiceName": {
             "type": "string",
-            "defaultValue": "",
             "metadata": {
                 "description": "The globally unique name of the Web App."
             }
@@ -18,18 +17,21 @@
         },
         "existingAppServicePlanLocation": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
                 "description": "The location of the App Service Plan."
             }
         },
         "newAppServicePlanName": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
                 "description": "The name of the new App Service Plan."
             }
         },
         "newAppServicePlanLocation": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
                 "description": "The location of the App Service Plan."
             }
@@ -47,6 +49,18 @@
                 "description": "The SKU of the App Service Plan. Defaults to Standard values."
             }
         },
+        "appType": {
+            "type": "string",
+            "defaultValue": "MultiTenant",
+            "allowedValues": [
+                "MultiTenant",
+                "SingleTenant",
+                "UserAssignedMSI"
+            ],
+            "metadata": {
+                "description": "Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. Allowed values are: MultiTenant, SingleTenant, UserAssignedMSI. Defaults to \"MultiTenant\"."
+            }
+        },
         "appId": {
             "type": "string",
             "metadata": {
@@ -59,13 +73,58 @@
             "metadata": {
                 "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Required for MultiTenant and SingleTenant app types. Defaults to \"\"."
             }
+        },
+        "UMSIName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource used for the Bot's Authentication. Defaults to \"\"."
+            }
+        },
+        "UMSIResourceGroupName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource Group used for the Bot's Authentication. Defaults to \"\"."
+            }
+        },
+        "tenantId": {
+            "type": "string",
+            "defaultValue": "[subscription().tenantId]",
+            "metadata": {
+                "description": "The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to \"Subscription Tenant ID\"."
+            }
         }
     },
     "variables": {
-        "defaultAppServicePlanName": "[if(empty(parameters('existingAppServicePlanName')), 'createNewAppServicePlan', parameters('existingAppServicePlanName'))]",
-        "useExistingServicePlan": "[not(equals(variables('defaultAppServicePlanName'), 'createNewAppServicePlan'))]",
+        "tenantId": "[if(empty(parameters('tenantId')), subscription().tenantId, parameters('tenantId'))]",
+        "useExistingServicePlan": "[not(empty(parameters('existingAppServicePlanName')))]",
         "servicePlanName": "[if(variables('useExistingServicePlan'), parameters('existingAppServicePlanName'), parameters('newAppServicePlanName'))]",
-        "servicePlanLocation": "[if(variables('useExistingServicePlan'), parameters('existingAppServicePlanLocation'), parameters('newAppServicePlanLocation'))]"
+        "servicePlanLocation": "[if(variables('useExistingServicePlan'), parameters('existingAppServicePlanLocation'), parameters('newAppServicePlanLocation'))]",
+        "msiResourceId": "[if(empty(parameters('UMSIName')), '', concat(subscription().id, '/resourceGroups/', parameters('UMSIResourceGroupName'), '/providers/', 'Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('UMSIName')))]",
+        "appTypeDef": {
+            "MultiTenant": {
+              "tenantId": "",
+              "identity": { "type": "None" }
+            },
+            "SingleTenant": {
+              "tenantId": "[variables('tenantId')]",
+              "identity": { "type": "None" }
+            },
+            "UserAssignedMSI": {
+              "tenantId": "[variables('tenantId')]",
+              "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentities": {
+                  "[variables('msiResourceId')]": {}
+                }
+              }
+            }
+        },
+        "appType": {
+            "tenantId": "[variables('appTypeDef')[parameters('appType')].tenantId]",
+            "identity": "[variables('appTypeDef')[parameters('appType')].identity]"
+        }
     },
     "resources": [
         {
@@ -89,13 +148,15 @@
             "comments": "Create a Web App using an App Service Plan",
             "type": "Microsoft.Web/sites",
             "apiVersion": "2015-08-01",
-            "name": "[parameters('appServiceName')]",
             "location": "[variables('servicePlanLocation')]",
             "kind": "app,linux",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
+              "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
+            "name": "[parameters('appServiceName')]",
+            "identity": "[variables('appType').identity]",
             "properties": {
+                "name": "[parameters('appServiceName')]",
                 "enabled": true,
                 "hostNameSslStates": [
                     {
@@ -125,12 +186,20 @@
                             "value": "true"
                         },
                         {
+                            "name": "MicrosoftAppType",
+                            "value": "[parameters('appType')]"
+                        },
+                        {
                             "name": "MicrosoftAppId",
                             "value": "[parameters('appId')]"
                         },
                         {
                             "name": "MicrosoftAppPassword",
                             "value": "[parameters('appSecret')]"
+                        },
+                        {
+                            "name": "MicrosoftAppTenantId",
+                            "value": "[variables('appType').tenantId]"
                         }
                     ],
                     "cors": {
@@ -167,7 +236,7 @@
                 "phpVersion": "",
                 "pythonVersion": "",
                 "nodeVersion": "",
-                "linuxFxVersion": "PYTHON|3.7",
+                "linuxFxVersion": "PYTHON|3.9",
                 "requestTracingEnabled": false,
                 "remoteDebuggingEnabled": false,
                 "remoteDebuggingVersion": "VS2017",
@@ -201,7 +270,7 @@
                 "autoHealEnabled": false,
                 "vnetName": "",
                 "minTlsVersion": "1.2",
-                "ftpsState": "AllAllowed",
+                "ftpsState": "Disabled",
                 "reservedInstanceCount": 0
             }
         }

--- a/generators/app/templates/core/{{cookiecutter.bot_name}}/deploymentTemplates/deployWithNewResourceGroup/parameters-for-template-AzureBot-new-rg.json
+++ b/generators/app/templates/core/{{cookiecutter.bot_name}}/deploymentTemplates/deployWithNewResourceGroup/parameters-for-template-AzureBot-new-rg.json
@@ -20,7 +20,19 @@
         "botEndpoint": {
             "value": ""
         },
+        "appType": {
+            "value": "MultiTenant"
+        },
         "appId": {
+            "value": ""
+        },
+        "UMSIName": {
+            "value": ""
+        },
+        "UMSIResourceGroupName": {
+            "value": ""
+        },
+        "tenantId": {
             "value": ""
         }
     }

--- a/generators/app/templates/core/{{cookiecutter.bot_name}}/deploymentTemplates/deployWithNewResourceGroup/parameters-for-template-BotApp-new-rg.json
+++ b/generators/app/templates/core/{{cookiecutter.bot_name}}/deploymentTemplates/deployWithNewResourceGroup/parameters-for-template-BotApp-new-rg.json
@@ -26,10 +26,22 @@
                 "capacity": 1
             }
         },
+        "appType": {
+            "value": "MultiTenant"
+        },
         "appId": {
             "value": ""
         },
         "appSecret": {
+            "value": ""
+        },
+        "tenantId": {
+            "value": ""
+        },
+        "UMSIName": {
+            "value": ""
+        },
+        "UMSIResourceGroupName": {
             "value": ""
         }
     }

--- a/generators/app/templates/core/{{cookiecutter.bot_name}}/deploymentTemplates/deployWithNewResourceGroup/readme.md
+++ b/generators/app/templates/core/{{cookiecutter.bot_name}}/deploymentTemplates/deployWithNewResourceGroup/readme.md
@@ -1,31 +1,45 @@
-Need deploy BotAppService before AzureBot
----
-az login
-az deployment sub create --template-file <template-file> --location <bot-region> --parameters @<parameters-file>
----
+# Usage
+BotApp must be deployed prior to AzureBot.
+
+### Command line:
+`az login`<br>
+`az deployment sub create --template-file <template-file> --location <bot-region> --parameters @<parameters-file>`
 
 # parameters-for-template-BotApp-new-rg:
 
-**groupName**:(required)                Specifies the name of the new Resource Group.
-**groupLocation**:(required)            Specifies the location of the new Resource Group.
+- **groupName**:(required)                Specifies the name of the new Resource Group.
+- **groupLocation**:(required)            Specifies the location of the new Resource Group.
 
-**appServiceName**:(required)           The location of the App Service Plan.
-**appServicePlanName**:(required)       The name of the App Service Plan.
-**appServicePlanLocation**:             The location of the App Service Plan. Defaults to use groupLocation.
-**appServicePlanSku**:                  The SKU of the App Service Plan. Defaults to Standard values.
+- **appServiceName**:(required)           The location of the App Service Plan.
+- **appServicePlanName**:(required)       The name of the App Service Plan.
+- **appServicePlanLocation**:             The location of the App Service Plan. Defaults to use groupLocation.
+- **appServicePlanSku**:                  The SKU of the App Service Plan. Defaults to Standard values.
 
-**appId**:(required)                                        Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings.
-**appSecret**:(required for MultiTenant and SingleTenant)   Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings.
+- **appType**:    Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. **Allowed values are: MultiTenant(default), SingleTenant, UserAssignedMSI.**
+- **appId**:(required)                                        Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings.
+- **appSecret**:(required for MultiTenant and SingleTenant)   Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings.
+- **UMSIName**:(required for UserAssignedMSI)                 The User-Assigned Managed Identity Resource used for the Bot's Authentication.
+- **UMSIResourceGroupName**:(required for UserAssignedMSI)    The User-Assigned Managed Identity Resource Group used for the Bot's Authentication.
+- **tenantId**:   The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to <Subscription Tenant ID>.
+
+MoreInfo: https://docs.microsoft.com/en-us/azure/bot-service/tutorial-provision-a-bot?view=azure-bot-service-4.0&tabs=userassigned%2Cnewgroup#create-an-identity-resource
+
 
 
 # parameters-for-template-AzureBot-new-rg:
 
-**groupName**:(required)            Specifies the name of the new Resource Group.
-**groupLocation**:(required)        Specifies the location of the new Resource Group.
+- **groupName**:(required)            Specifies the name of the new Resource Group.
+- **groupLocation**:(required)        Specifies the location of the new Resource Group.
 
-**azureBotId**:(required)           The globally unique and immutable bot ID. Also used to configure the displayName of the bot, which is mutable.
-**azureBotSku**:                    The pricing tier of the Bot Service Registration. **Allowed values are: F0, S1(default)**.
-**azureBotRegion**:                 Specifies the location of the new AzureBot. **Allowed values are: global(default), westeurope**.
-**botEndpoint**:                    Use to handle client messages, Such as https://<botappServiceName>.azurewebsites.net/api/messages.
+- **azureBotId**:(required)           The globally unique and immutable bot ID. Also used to configure the displayName of the bot, which is mutable.
+- **azureBotSku**:                    The pricing tier of the Bot Service Registration. **Allowed values are: F0, S1(default)**.
+- **azureBotRegion**:                 Specifies the location of the new AzureBot. **Allowed values are: global(default), westeurope**.
+- **botEndpoint**:                    Use to handle client messages, Such as https://<botappServiceName>.azurewebsites.net/api/messages.
 
-**appId**:(required)                                        Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings.
+- **appType**:    Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. **Allowed values are: MultiTenant(default), SingleTenant, UserAssignedMSI.**
+- **appId**:(required)                                        Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings.
+- **UMSIName**:(required for UserAssignedMSI)                 The User-Assigned Managed Identity Resource used for the Bot's Authentication.
+- **UMSIResourceGroupName**:(required for UserAssignedMSI)    The User-Assigned Managed Identity Resource Group used for the Bot's Authentication.
+- **tenantId**:   The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to <Subscription Tenant ID>.
+
+MoreInfo: https://docs.microsoft.com/en-us/azure/bot-service/tutorial-provision-a-bot?view=azure-bot-service-4.0&tabs=userassigned%2Cnewgroup#create-an-identity-resource

--- a/generators/app/templates/core/{{cookiecutter.bot_name}}/deploymentTemplates/deployWithNewResourceGroup/template-AzureBot-new-rg.json
+++ b/generators/app/templates/core/{{cookiecutter.bot_name}}/deploymentTemplates/deployWithNewResourceGroup/template-AzureBot-new-rg.json
@@ -41,11 +41,47 @@
                 "description": "Use to handle client messages, Such as https://<botappServiceName>.azurewebsites.net/api/messages."
             }
         },
+        "appType": {
+            "type": "string",
+            "defaultValue": "MultiTenant",
+            "allowedValues": [
+                "MultiTenant",
+                "SingleTenant"
+            ],
+            "metadata": {
+                "description": "Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. Allowed values are: MultiTenant, SingleTenant, UserAssignedMSI. Defaults to \"MultiTenant\"."
+            }
+        },
         "appId": {
             "type": "string",
             "metadata": {
                 "description": "Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings."
             }
+        },
+        "tenantId": {
+            "type": "string",
+            "defaultValue": "[subscription().tenantId]",
+            "metadata": {
+                "description": "The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to \"Subscription Tenant ID\"."
+            }
+        }
+      },
+      "variables": {
+        "botEndpoint": "[if(empty(parameters('botEndpoint')), concat('https://', parameters('azureBotId'), '.azurewebsites.net/api/messages'), parameters('botEndpoint'))]",
+        "tenantId": "[if(empty(parameters('tenantId')), subscription().tenantId, parameters('tenantId'))]",
+        "msiResourceId": "[if(empty(parameters('UMSIName')), '', concat(subscription().id, '/resourceGroups/', parameters('UMSIResourceGroupName'), '/providers/', 'Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('UMSIName')))]",
+        "appTypeDef": {
+            "MultiTenant": {
+              "tenantId": "",
+              "msiResourceId": ""
+            },
+            "SingleTenant": {
+              "tenantId": "[variables('tenantId')]",
+              "msiResourceId": ""
+            }
+        },
+        "appType": {
+            "tenantId": "[variables('appTypeDef')[parameters('appType')].tenantId]"
         }
     },
     "resources": [
@@ -85,8 +121,10 @@
                                 "name": "[parameters('azureBotId')]",
                                 "displayName": "[parameters('azureBotId')]",
                                 "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
-                                "endpoint": "[parameters('botEndpoint')]",
+                                "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
+                                "msaAppTenantId": "[variables('appType').tenantId]",
+                                "msaAppType": "[parameters('appType')]",
                                 "luisAppIds": [],
                                 "schemaTransformationVersion": "1.3",
                                 "isCmekEnabled": false,

--- a/generators/app/templates/core/{{cookiecutter.bot_name}}/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/generators/app/templates/core/{{cookiecutter.bot_name}}/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -28,6 +28,7 @@
         },
         "appServicePlanLocation": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
                 "description": "The location of the App Service Plan."
             }
@@ -45,6 +46,25 @@
                 "description": "The SKU of the App Service Plan. Defaults to Standard values."
             }
         },
+        "tenantId": {
+            "type": "string",
+            "defaultValue": "[subscription().tenantId]",
+            "metadata": {
+                "description": "The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to \"Subscription Tenant ID\"."
+            }
+        },
+        "appType": {
+            "type": "string",
+            "defaultValue": "MultiTenant",
+            "allowedValues": [
+                "MultiTenant",
+                "SingleTenant",
+                "UserAssignedMSI"
+            ],
+            "metadata": {
+                "description": "Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. Allowed values are: MultiTenant, SingleTenant, UserAssignedMSI. Defaults to \"MultiTenant\"."
+            }
+        },
         "appId": {
             "type": "string",
             "metadata": {
@@ -53,16 +73,56 @@
         },
         "appSecret": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
-                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Required for MultiTenant and SingleTenant app types."
+                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Required for MultiTenant and SingleTenant app types. Defaults to \"\"."
+            }
+        },
+        "UMSIName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource used for the Bot's Authentication. Defaults to \"\"."
+            }
+        },
+        "UMSIResourceGroupName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource Group used for the Bot's Authentication. Defaults to \"\"."
             }
         }
     },
     "variables": {
+        "tenantId": "[if(empty(parameters('tenantId')), subscription().tenantId, parameters('tenantId'))]",
         "appServicePlanName": "[parameters('appServicePlanName')]",
         "resourcesLocation": "[if(empty(parameters('appServicePlanLocation')), parameters('groupLocation'), parameters('appServicePlanLocation'))]",
         "appServiceName": "[parameters('appServiceName')]",
-        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]"        
+        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]",
+        "msiResourceId": "[if(empty(parameters('UMSIName')), '', concat(subscription().id, '/resourceGroups/', parameters('UMSIResourceGroupName'), '/providers/', 'Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('UMSIName')))]",
+        "appTypeDef": {
+            "MultiTenant": {
+                "tenantId": "",
+                "identity": { "type": "None" }
+            },
+            "SingleTenant": {
+                "tenantId": "[variables('tenantId')]",
+                "identity": { "type": "None" }
+            },
+            "UserAssignedMSI": {
+                "tenantId": "[variables('tenantId')]",
+                "identity": {
+                  "type": "UserAssigned",
+                  "userAssignedIdentities": {
+                    "[variables('msiResourceId')]": {}
+                  }
+                }
+            }
+        },
+        "appType": {
+            "tenantId": "[variables('appTypeDef')[parameters('appType')].tenantId]",
+            "identity": "[variables('appTypeDef')[parameters('appType')].identity]"
+        }
     },
     "resources": [
         {
@@ -114,6 +174,7 @@
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
                             ],
                             "name": "[variables('appServiceName')]",
+                            "identity": "[variables('appType').identity]",
                             "properties": {
                                 "name": "[variables('appServiceName')]",
                                 "hostNameSslStates": [
@@ -136,12 +197,19 @@
                                             "value": "true"
                                         },
                                         {
+                                            "name": "MicrosoftAppType",
+                                            "value": "[parameters('appType')]"
+                                        },                    {
                                             "name": "MicrosoftAppId",
                                             "value": "[parameters('appId')]"
                                         },
                                         {
                                             "name": "MicrosoftAppPassword",
                                             "value": "[parameters('appSecret')]"
+                                        },
+                                        {
+                                            "name": "MicrosoftAppTenantId",
+                                            "value": "[variables('appType').tenantId]"
                                         }
                                     ],
                                     "cors": {
@@ -179,7 +247,7 @@
                                 "phpVersion": "",
                                 "pythonVersion": "",
                                 "nodeVersion": "",
-                                "linuxFxVersion": "PYTHON|3.7",
+                                "linuxFxVersion": "PYTHON|3.9",
                                 "requestTracingEnabled": false,
                                 "remoteDebuggingEnabled": false,
                                 "remoteDebuggingVersion": "VS2017",
@@ -213,7 +281,7 @@
                                 "autoHealEnabled": false,
                                 "vnetName": "",
                                 "minTlsVersion": "1.2",
-                                "ftpsState": "AllAllowed",
+                                "ftpsState": "Disabled",
                                 "reservedInstanceCount": 0
                             }
                         }

--- a/generators/app/templates/echo/{{cookiecutter.bot_name}}/deploymentTemplates/deployUseExistResourceGroup/parameters-for-template-AzureBot-with-rg.json
+++ b/generators/app/templates/echo/{{cookiecutter.bot_name}}/deploymentTemplates/deployUseExistResourceGroup/parameters-for-template-AzureBot-with-rg.json
@@ -14,8 +14,20 @@
         "botEndpoint": {
             "value": ""
         },
+        "appType": {
+          "value": "MultiTenant"
+        },
         "appId": {
             "value": ""
+        },
+        "UMSIName": {
+            "value": ""
+        },
+        "UMSIResourceGroupName": {
+            "value": ""
+        },
+        "tenantId": {
+          "value": ""
         }
     }
 }

--- a/generators/app/templates/echo/{{cookiecutter.bot_name}}/deploymentTemplates/deployUseExistResourceGroup/parameters-for-template-BotApp-with-rg.json
+++ b/generators/app/templates/echo/{{cookiecutter.bot_name}}/deploymentTemplates/deployUseExistResourceGroup/parameters-for-template-BotApp-with-rg.json
@@ -15,7 +15,7 @@
             "value": ""
         },
         "newAppServicePlanLocation": {
-            "value": ""
+            "value": "West US"
         },
         "newAppServicePlanSku": {
             "value": {
@@ -26,10 +26,22 @@
                 "capacity": 1
             }
         },
+        "appType": {
+            "value": "MultiTenant"
+        },
         "appId": {
             "value": ""
         },
         "appSecret": {
+            "value": ""
+        },
+        "tenantId": {
+            "value": ""
+        },
+        "UMSIName": {
+            "value": ""
+        },
+        "UMSIResourceGroupName": {
             "value": ""
         }
     }

--- a/generators/app/templates/echo/{{cookiecutter.bot_name}}/deploymentTemplates/deployUseExistResourceGroup/readme.md
+++ b/generators/app/templates/echo/{{cookiecutter.bot_name}}/deploymentTemplates/deployUseExistResourceGroup/readme.md
@@ -1,28 +1,48 @@
-Need deploy BotAppService before AzureBot
----
-az login
-az deployment group create --resource-group <group-name> --template-file <template-file> --parameters @<parameters-file>
----
+# Usage
+BotApp must be deployed prior to AzureBot.
+
+### Command line:
+`az login`<br>
+`az deployment group create --resource-group <group-name> --template-file <template-file> --parameters @<parameters-file>`
 
 # parameters-for-template-BotApp-with-rg:
 
-**appServiceName**:(required)   The Name of the Bot App Service.
+- **appServiceName**:(required)   The Name of the Bot App Service.
 
-(choose an existingAppServicePlan or create a new AppServicePlan)
-**existingAppServicePlanName**:     The name of the App Service Plan.
-**existingAppServicePlanLocation**: The location of the App Service Plan.
-**newAppServicePlanName**:          The name of the App Service Plan.
-**newAppServicePlanLocation**:      The location of the App Service Plan.
-**newAppServicePlanSku**:           The SKU of the App Service Plan. Defaults to Standard values.
+- (choose an existingAppServicePlan or create a new AppServicePlan)
+  - **existingAppServicePlanName**:     The name of the App Service Plan.
+  - **existingAppServicePlanLocation**: The location of the App Service Plan.
+  - **newAppServicePlanName**:          The name of the App Service Plan.
+  - **newAppServicePlanLocation**:      The location of the App Service Plan.
+  - **newAppServicePlanSku**:           The SKU of the App Service Plan. Defaults to Standard values.
 
-**appId**:(required)                                        Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings.
-**appSecret**:(required)   Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings.
+- **appType**:    Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. **Allowed values are: MultiTenant(default), SingleTenant, UserAssignedMSI.**
+
+- **appId**:(required)                                        Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings.
+
+- **appSecret**:(required for MultiTenant and SingleTenant)   Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings.
+
+- **UMSIName**:(required for UserAssignedMSI)                 The User-Assigned Managed Identity Resource used for the Bot's Authentication.
+
+- **UMSIResourceGroupName**:(required for UserAssignedMSI)    The User-Assigned Managed Identity Resource Group used for the Bot's Authentication.
+
+- **tenantId**:   The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to <Subscription Tenant ID>.
+
+MoreInfo: https://docs.microsoft.com/en-us/azure/bot-service/tutorial-provision-a-bot?view=azure-bot-service-4.0&tabs=userassigned%2Cnewgroup#create-an-identity-resource
+
+
 
 # parameters-for-template-AzureBot-with-rg:
 
-**azureBotId**:(required)           The globally unique and immutable bot ID.
-**azureBotSku**:                    The pricing tier of the Bot Service Registration. **Allowed values are: F0, S1(default)**.
-**azureBotRegion**:                 Specifies the location of the new AzureBot. **Allowed values are: global(default), westeurope**.
-**botEndpoint**:                    Use to handle client messages, Such as https://<botappServiceName>.azurewebsites.net/api/messages.
+- **azureBotId**:(required)           The globally unique and immutable bot ID.
+- **azureBotSku**:                    The pricing tier of the Bot Service Registration. **Allowed values are: F0, S1(default)**.
+- **azureBotRegion**:                 Specifies the location of the new AzureBot. **Allowed values are: global(default), westeurope**.
+- **botEndpoint**:                    Use to handle client messages, Such as https://<botappServiceName>.azurewebsites.net/api/messages.
 
-**appId**:(required)                                        Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings.
+- **appType**:    Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. **Allowed values are: MultiTenant(default), SingleTenant, UserAssignedMSI.**
+- **appId**:(required)                                        Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings.
+- **UMSIName**:(required for UserAssignedMSI)                 The User-Assigned Managed Identity Resource used for the Bot's Authentication.
+- **UMSIResourceGroupName**:(required for UserAssignedMSI)    The User-Assigned Managed Identity Resource Group used for the Bot's Authentication.
+- **tenantId**:   The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to <Subscription Tenant ID>.
+
+MoreInfo: https://docs.microsoft.com/en-us/azure/bot-service/tutorial-provision-a-bot?view=azure-bot-service-4.0&tabs=userassigned%2Cnewgroup#create-an-identity-resource

--- a/generators/app/templates/echo/{{cookiecutter.bot_name}}/deploymentTemplates/deployUseExistResourceGroup/template-AzureBot-with-rg.json
+++ b/generators/app/templates/echo/{{cookiecutter.bot_name}}/deploymentTemplates/deployUseExistResourceGroup/template-AzureBot-with-rg.json
@@ -9,8 +9,8 @@
             }
         },
         "azureBotSku": {
-            "defaultValue": "S1",
             "type": "string",
+            "defaultValue": "S1",
             "metadata": {
                 "description": "The pricing tier of the Bot Service Registration. Allowed values are: F0, S1(default)."
             }
@@ -24,8 +24,21 @@
         },
         "botEndpoint": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
                 "description": "Use to handle client messages, Such as https://<botappServiceName>.azurewebsites.net/api/messages."
+            }
+        },
+        "appType": {
+            "type": "string",
+            "defaultValue": "MultiTenant",
+            "allowedValues": [
+                "MultiTenant",
+                "SingleTenant",
+                "UserAssignedMSI"
+            ],
+            "metadata": {
+                "description": "Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. Allowed values are: MultiTenant, SingleTenant, UserAssignedMSI. Defaults to \"MultiTenant\"."
             }
         },
         "appId": {
@@ -33,6 +46,50 @@
             "metadata": {
                 "description": "Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings."
             }
+        },
+        "UMSIName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource used for the Bot's Authentication."
+            }
+        },
+        "UMSIResourceGroupName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource Group used for the Bot's Authentication."
+            }
+        },
+        "tenantId": {
+            "type": "string",
+            "defaultValue": "[subscription().tenantId]",
+            "metadata": {
+                "description": "The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to \"Subscription Tenant ID\"."
+            }
+        }
+    },
+    "variables": {
+        "botEndpoint": "[if(empty(parameters('botEndpoint')), concat('https://', parameters('azureBotId'), '.azurewebsites.net/api/messages'), parameters('botEndpoint'))]",
+        "tenantId": "[if(empty(parameters('tenantId')), subscription().tenantId, parameters('tenantId'))]",
+        "msiResourceId": "[if(empty(parameters('UMSIName')), '', concat(subscription().id, '/resourceGroups/', parameters('UMSIResourceGroupName'), '/providers/', 'Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('UMSIName')))]",
+        "appTypeDef": {
+            "MultiTenant": {
+              "tenantId": "",
+              "msiResourceId": ""
+            },
+            "SingleTenant": {
+              "tenantId": "[variables('tenantId')]",
+              "msiResourceId": ""
+            },
+            "UserAssignedMSI": {
+              "tenantId": "[variables('tenantId')]",
+              "msiResourceId": "[variables('msiResourceId')]"
+            }
+        },
+        "appType": {
+            "tenantId": "[variables('appTypeDef')[parameters('appType')].tenantId]",
+            "msiResourceId": "[variables('appTypeDef')[parameters('appType')].msiResourceId]"
         }
     },
     "resources": [
@@ -49,8 +106,11 @@
                 "name": "[parameters('azureBotId')]",
                 "displayName": "[parameters('azureBotId')]",
                 "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
-                "endpoint": "[parameters('botEndpoint')]",
+                "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
+                "msaAppTenantId": "[variables('appType').tenantId]",
+                "msaAppMSIResourceId": "[variables('appType').msiResourceId]",
+                "msaAppType": "[parameters('appType')]",
                 "luisAppIds": [],
                 "schemaTransformationVersion": "1.3",
                 "isCmekEnabled": false,

--- a/generators/app/templates/echo/{{cookiecutter.bot_name}}/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/generators/app/templates/echo/{{cookiecutter.bot_name}}/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -4,7 +4,6 @@
     "parameters": {
         "appServiceName": {
             "type": "string",
-            "defaultValue": "",
             "metadata": {
                 "description": "The globally unique name of the Web App."
             }
@@ -18,18 +17,21 @@
         },
         "existingAppServicePlanLocation": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
                 "description": "The location of the App Service Plan."
             }
         },
         "newAppServicePlanName": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
                 "description": "The name of the new App Service Plan."
             }
         },
         "newAppServicePlanLocation": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
                 "description": "The location of the App Service Plan."
             }
@@ -47,6 +49,18 @@
                 "description": "The SKU of the App Service Plan. Defaults to Standard values."
             }
         },
+        "appType": {
+            "type": "string",
+            "defaultValue": "MultiTenant",
+            "allowedValues": [
+                "MultiTenant",
+                "SingleTenant",
+                "UserAssignedMSI"
+            ],
+            "metadata": {
+                "description": "Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. Allowed values are: MultiTenant, SingleTenant, UserAssignedMSI. Defaults to \"MultiTenant\"."
+            }
+        },
         "appId": {
             "type": "string",
             "metadata": {
@@ -59,13 +73,58 @@
             "metadata": {
                 "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Required for MultiTenant and SingleTenant app types. Defaults to \"\"."
             }
+        },
+        "UMSIName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource used for the Bot's Authentication. Defaults to \"\"."
+            }
+        },
+        "UMSIResourceGroupName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource Group used for the Bot's Authentication. Defaults to \"\"."
+            }
+        },
+        "tenantId": {
+            "type": "string",
+            "defaultValue": "[subscription().tenantId]",
+            "metadata": {
+                "description": "The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to \"Subscription Tenant ID\"."
+            }
         }
     },
     "variables": {
-        "defaultAppServicePlanName": "[if(empty(parameters('existingAppServicePlanName')), 'createNewAppServicePlan', parameters('existingAppServicePlanName'))]",
-        "useExistingServicePlan": "[not(equals(variables('defaultAppServicePlanName'), 'createNewAppServicePlan'))]",
+        "tenantId": "[if(empty(parameters('tenantId')), subscription().tenantId, parameters('tenantId'))]",
+        "useExistingServicePlan": "[not(empty(parameters('existingAppServicePlanName')))]",
         "servicePlanName": "[if(variables('useExistingServicePlan'), parameters('existingAppServicePlanName'), parameters('newAppServicePlanName'))]",
-        "servicePlanLocation": "[if(variables('useExistingServicePlan'), parameters('existingAppServicePlanLocation'), parameters('newAppServicePlanLocation'))]"
+        "servicePlanLocation": "[if(variables('useExistingServicePlan'), parameters('existingAppServicePlanLocation'), parameters('newAppServicePlanLocation'))]",
+        "msiResourceId": "[if(empty(parameters('UMSIName')), '', concat(subscription().id, '/resourceGroups/', parameters('UMSIResourceGroupName'), '/providers/', 'Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('UMSIName')))]",
+        "appTypeDef": {
+            "MultiTenant": {
+              "tenantId": "",
+              "identity": { "type": "None" }
+            },
+            "SingleTenant": {
+              "tenantId": "[variables('tenantId')]",
+              "identity": { "type": "None" }
+            },
+            "UserAssignedMSI": {
+              "tenantId": "[variables('tenantId')]",
+              "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentities": {
+                  "[variables('msiResourceId')]": {}
+                }
+              }
+            }
+        },
+        "appType": {
+            "tenantId": "[variables('appTypeDef')[parameters('appType')].tenantId]",
+            "identity": "[variables('appTypeDef')[parameters('appType')].identity]"
+        }
     },
     "resources": [
         {
@@ -89,13 +148,15 @@
             "comments": "Create a Web App using an App Service Plan",
             "type": "Microsoft.Web/sites",
             "apiVersion": "2015-08-01",
-            "name": "[parameters('appServiceName')]",
             "location": "[variables('servicePlanLocation')]",
             "kind": "app,linux",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
+              "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
+            "name": "[parameters('appServiceName')]",
+            "identity": "[variables('appType').identity]",
             "properties": {
+                "name": "[parameters('appServiceName')]",
                 "enabled": true,
                 "hostNameSslStates": [
                     {
@@ -125,12 +186,20 @@
                             "value": "true"
                         },
                         {
+                            "name": "MicrosoftAppType",
+                            "value": "[parameters('appType')]"
+                        },
+                        {
                             "name": "MicrosoftAppId",
                             "value": "[parameters('appId')]"
                         },
                         {
                             "name": "MicrosoftAppPassword",
                             "value": "[parameters('appSecret')]"
+                        },
+                        {
+                            "name": "MicrosoftAppTenantId",
+                            "value": "[variables('appType').tenantId]"
                         }
                     ],
                     "cors": {
@@ -167,7 +236,7 @@
                 "phpVersion": "",
                 "pythonVersion": "",
                 "nodeVersion": "",
-                "linuxFxVersion": "PYTHON|3.7",
+                "linuxFxVersion": "PYTHON|3.9",
                 "requestTracingEnabled": false,
                 "remoteDebuggingEnabled": false,
                 "remoteDebuggingVersion": "VS2017",
@@ -201,7 +270,7 @@
                 "autoHealEnabled": false,
                 "vnetName": "",
                 "minTlsVersion": "1.2",
-                "ftpsState": "AllAllowed",
+                "ftpsState": "Disabled",
                 "reservedInstanceCount": 0
             }
         }

--- a/generators/app/templates/echo/{{cookiecutter.bot_name}}/deploymentTemplates/deployWithNewResourceGroup/parameters-for-template-AzureBot-new-rg.json
+++ b/generators/app/templates/echo/{{cookiecutter.bot_name}}/deploymentTemplates/deployWithNewResourceGroup/parameters-for-template-AzureBot-new-rg.json
@@ -20,7 +20,19 @@
         "botEndpoint": {
             "value": ""
         },
+        "appType": {
+            "value": "MultiTenant"
+        },
         "appId": {
+            "value": ""
+        },
+        "UMSIName": {
+            "value": ""
+        },
+        "UMSIResourceGroupName": {
+            "value": ""
+        },
+        "tenantId": {
             "value": ""
         }
     }

--- a/generators/app/templates/echo/{{cookiecutter.bot_name}}/deploymentTemplates/deployWithNewResourceGroup/parameters-for-template-BotApp-new-rg.json
+++ b/generators/app/templates/echo/{{cookiecutter.bot_name}}/deploymentTemplates/deployWithNewResourceGroup/parameters-for-template-BotApp-new-rg.json
@@ -26,10 +26,22 @@
                 "capacity": 1
             }
         },
+        "appType": {
+            "value": "MultiTenant"
+        },
         "appId": {
             "value": ""
         },
         "appSecret": {
+            "value": ""
+        },
+        "tenantId": {
+            "value": ""
+        },
+        "UMSIName": {
+            "value": ""
+        },
+        "UMSIResourceGroupName": {
             "value": ""
         }
     }

--- a/generators/app/templates/echo/{{cookiecutter.bot_name}}/deploymentTemplates/deployWithNewResourceGroup/readme.md
+++ b/generators/app/templates/echo/{{cookiecutter.bot_name}}/deploymentTemplates/deployWithNewResourceGroup/readme.md
@@ -1,31 +1,45 @@
-Need deploy BotAppService before AzureBot
----
-az login
-az deployment sub create --template-file <template-file> --location <bot-region> --parameters @<parameters-file>
----
+# Usage
+BotApp must be deployed prior to AzureBot.
+
+### Command line:
+`az login`<br>
+`az deployment sub create --template-file <template-file> --location <bot-region> --parameters @<parameters-file>`
 
 # parameters-for-template-BotApp-new-rg:
 
-**groupName**:(required)                Specifies the name of the new Resource Group.
-**groupLocation**:(required)            Specifies the location of the new Resource Group.
+- **groupName**:(required)                Specifies the name of the new Resource Group.
+- **groupLocation**:(required)            Specifies the location of the new Resource Group.
 
-**appServiceName**:(required)           The location of the App Service Plan.
-**appServicePlanName**:(required)       The name of the App Service Plan.
-**appServicePlanLocation**:             The location of the App Service Plan. Defaults to use groupLocation.
-**appServicePlanSku**:                  The SKU of the App Service Plan. Defaults to Standard values.
+- **appServiceName**:(required)           The location of the App Service Plan.
+- **appServicePlanName**:(required)       The name of the App Service Plan.
+- **appServicePlanLocation**:             The location of the App Service Plan. Defaults to use groupLocation.
+- **appServicePlanSku**:                  The SKU of the App Service Plan. Defaults to Standard values.
 
-**appId**:(required)                                        Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings.
-**appSecret**:(required for MultiTenant and SingleTenant)   Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings.
+- **appType**:    Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. **Allowed values are: MultiTenant(default), SingleTenant, UserAssignedMSI.**
+- **appId**:(required)                                        Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings.
+- **appSecret**:(required for MultiTenant and SingleTenant)   Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings.
+- **UMSIName**:(required for UserAssignedMSI)                 The User-Assigned Managed Identity Resource used for the Bot's Authentication.
+- **UMSIResourceGroupName**:(required for UserAssignedMSI)    The User-Assigned Managed Identity Resource Group used for the Bot's Authentication.
+- **tenantId**:   The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to <Subscription Tenant ID>.
+
+MoreInfo: https://docs.microsoft.com/en-us/azure/bot-service/tutorial-provision-a-bot?view=azure-bot-service-4.0&tabs=userassigned%2Cnewgroup#create-an-identity-resource
+
 
 
 # parameters-for-template-AzureBot-new-rg:
 
-**groupName**:(required)            Specifies the name of the new Resource Group.
-**groupLocation**:(required)        Specifies the location of the new Resource Group.
+- **groupName**:(required)            Specifies the name of the new Resource Group.
+- **groupLocation**:(required)        Specifies the location of the new Resource Group.
 
-**azureBotId**:(required)           The globally unique and immutable bot ID. Also used to configure the displayName of the bot, which is mutable.
-**azureBotSku**:                    The pricing tier of the Bot Service Registration. **Allowed values are: F0, S1(default)**.
-**azureBotRegion**:                 Specifies the location of the new AzureBot. **Allowed values are: global(default), westeurope**.
-**botEndpoint**:                    Use to handle client messages, Such as https://<botappServiceName>.azurewebsites.net/api/messages.
+- **azureBotId**:(required)           The globally unique and immutable bot ID. Also used to configure the displayName of the bot, which is mutable.
+- **azureBotSku**:                    The pricing tier of the Bot Service Registration. **Allowed values are: F0, S1(default)**.
+- **azureBotRegion**:                 Specifies the location of the new AzureBot. **Allowed values are: global(default), westeurope**.
+- **botEndpoint**:                    Use to handle client messages, Such as https://<botappServiceName>.azurewebsites.net/api/messages.
 
-**appId**:(required)                                        Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings.
+- **appType**:    Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. **Allowed values are: MultiTenant(default), SingleTenant, UserAssignedMSI.**
+- **appId**:(required)                                        Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings.
+- **UMSIName**:(required for UserAssignedMSI)                 The User-Assigned Managed Identity Resource used for the Bot's Authentication.
+- **UMSIResourceGroupName**:(required for UserAssignedMSI)    The User-Assigned Managed Identity Resource Group used for the Bot's Authentication.
+- **tenantId**:   The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to <Subscription Tenant ID>.
+
+MoreInfo: https://docs.microsoft.com/en-us/azure/bot-service/tutorial-provision-a-bot?view=azure-bot-service-4.0&tabs=userassigned%2Cnewgroup#create-an-identity-resource

--- a/generators/app/templates/echo/{{cookiecutter.bot_name}}/deploymentTemplates/deployWithNewResourceGroup/template-AzureBot-new-rg.json
+++ b/generators/app/templates/echo/{{cookiecutter.bot_name}}/deploymentTemplates/deployWithNewResourceGroup/template-AzureBot-new-rg.json
@@ -41,11 +41,47 @@
                 "description": "Use to handle client messages, Such as https://<botappServiceName>.azurewebsites.net/api/messages."
             }
         },
+        "appType": {
+            "type": "string",
+            "defaultValue": "MultiTenant",
+            "allowedValues": [
+                "MultiTenant",
+                "SingleTenant"
+            ],
+            "metadata": {
+                "description": "Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. Allowed values are: MultiTenant, SingleTenant, UserAssignedMSI. Defaults to \"MultiTenant\"."
+            }
+        },
         "appId": {
             "type": "string",
             "metadata": {
                 "description": "Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings."
             }
+        },
+        "tenantId": {
+            "type": "string",
+            "defaultValue": "[subscription().tenantId]",
+            "metadata": {
+                "description": "The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to \"Subscription Tenant ID\"."
+            }
+        }
+      },
+      "variables": {
+        "botEndpoint": "[if(empty(parameters('botEndpoint')), concat('https://', parameters('azureBotId'), '.azurewebsites.net/api/messages'), parameters('botEndpoint'))]",
+        "tenantId": "[if(empty(parameters('tenantId')), subscription().tenantId, parameters('tenantId'))]",
+        "msiResourceId": "[if(empty(parameters('UMSIName')), '', concat(subscription().id, '/resourceGroups/', parameters('UMSIResourceGroupName'), '/providers/', 'Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('UMSIName')))]",
+        "appTypeDef": {
+            "MultiTenant": {
+              "tenantId": "",
+              "msiResourceId": ""
+            },
+            "SingleTenant": {
+              "tenantId": "[variables('tenantId')]",
+              "msiResourceId": ""
+            }
+        },
+        "appType": {
+            "tenantId": "[variables('appTypeDef')[parameters('appType')].tenantId]"
         }
     },
     "resources": [
@@ -85,8 +121,10 @@
                                 "name": "[parameters('azureBotId')]",
                                 "displayName": "[parameters('azureBotId')]",
                                 "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
-                                "endpoint": "[parameters('botEndpoint')]",
+                                "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
+                                "msaAppTenantId": "[variables('appType').tenantId]",
+                                "msaAppType": "[parameters('appType')]",
                                 "luisAppIds": [],
                                 "schemaTransformationVersion": "1.3",
                                 "isCmekEnabled": false,

--- a/generators/app/templates/echo/{{cookiecutter.bot_name}}/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/generators/app/templates/echo/{{cookiecutter.bot_name}}/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -28,6 +28,7 @@
         },
         "appServicePlanLocation": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
                 "description": "The location of the App Service Plan."
             }
@@ -45,6 +46,25 @@
                 "description": "The SKU of the App Service Plan. Defaults to Standard values."
             }
         },
+        "tenantId": {
+            "type": "string",
+            "defaultValue": "[subscription().tenantId]",
+            "metadata": {
+                "description": "The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to \"Subscription Tenant ID\"."
+            }
+        },
+        "appType": {
+            "type": "string",
+            "defaultValue": "MultiTenant",
+            "allowedValues": [
+                "MultiTenant",
+                "SingleTenant",
+                "UserAssignedMSI"
+            ],
+            "metadata": {
+                "description": "Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. Allowed values are: MultiTenant, SingleTenant, UserAssignedMSI. Defaults to \"MultiTenant\"."
+            }
+        },
         "appId": {
             "type": "string",
             "metadata": {
@@ -53,16 +73,56 @@
         },
         "appSecret": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
-                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Required for MultiTenant and SingleTenant app types."
+                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Required for MultiTenant and SingleTenant app types. Defaults to \"\"."
+            }
+        },
+        "UMSIName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource used for the Bot's Authentication. Defaults to \"\"."
+            }
+        },
+        "UMSIResourceGroupName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource Group used for the Bot's Authentication. Defaults to \"\"."
             }
         }
     },
     "variables": {
+        "tenantId": "[if(empty(parameters('tenantId')), subscription().tenantId, parameters('tenantId'))]",
         "appServicePlanName": "[parameters('appServicePlanName')]",
         "resourcesLocation": "[if(empty(parameters('appServicePlanLocation')), parameters('groupLocation'), parameters('appServicePlanLocation'))]",
         "appServiceName": "[parameters('appServiceName')]",
-        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]"        
+        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]",
+        "msiResourceId": "[if(empty(parameters('UMSIName')), '', concat(subscription().id, '/resourceGroups/', parameters('UMSIResourceGroupName'), '/providers/', 'Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('UMSIName')))]",
+        "appTypeDef": {
+            "MultiTenant": {
+                "tenantId": "",
+                "identity": { "type": "None" }
+            },
+            "SingleTenant": {
+                "tenantId": "[variables('tenantId')]",
+                "identity": { "type": "None" }
+            },
+            "UserAssignedMSI": {
+                "tenantId": "[variables('tenantId')]",
+                "identity": {
+                  "type": "UserAssigned",
+                  "userAssignedIdentities": {
+                    "[variables('msiResourceId')]": {}
+                  }
+                }
+            }
+        },
+        "appType": {
+            "tenantId": "[variables('appTypeDef')[parameters('appType')].tenantId]",
+            "identity": "[variables('appTypeDef')[parameters('appType')].identity]"
+        }
     },
     "resources": [
         {
@@ -114,6 +174,7 @@
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
                             ],
                             "name": "[variables('appServiceName')]",
+                            "identity": "[variables('appType').identity]",
                             "properties": {
                                 "name": "[variables('appServiceName')]",
                                 "hostNameSslStates": [
@@ -136,12 +197,19 @@
                                             "value": "true"
                                         },
                                         {
+                                            "name": "MicrosoftAppType",
+                                            "value": "[parameters('appType')]"
+                                        },                    {
                                             "name": "MicrosoftAppId",
                                             "value": "[parameters('appId')]"
                                         },
                                         {
                                             "name": "MicrosoftAppPassword",
                                             "value": "[parameters('appSecret')]"
+                                        },
+                                        {
+                                            "name": "MicrosoftAppTenantId",
+                                            "value": "[variables('appType').tenantId]"
                                         }
                                     ],
                                     "cors": {
@@ -179,7 +247,7 @@
                                 "phpVersion": "",
                                 "pythonVersion": "",
                                 "nodeVersion": "",
-                                "linuxFxVersion": "PYTHON|3.7",
+                                "linuxFxVersion": "PYTHON|3.9",
                                 "requestTracingEnabled": false,
                                 "remoteDebuggingEnabled": false,
                                 "remoteDebuggingVersion": "VS2017",
@@ -213,7 +281,7 @@
                                 "autoHealEnabled": false,
                                 "vnetName": "",
                                 "minTlsVersion": "1.2",
-                                "ftpsState": "AllAllowed",
+                                "ftpsState": "Disabled",
                                 "reservedInstanceCount": 0
                             }
                         }

--- a/generators/app/templates/empty/{{cookiecutter.bot_name}}/deploymentTemplates/deployUseExistResourceGroup/parameters-for-template-AzureBot-with-rg.json
+++ b/generators/app/templates/empty/{{cookiecutter.bot_name}}/deploymentTemplates/deployUseExistResourceGroup/parameters-for-template-AzureBot-with-rg.json
@@ -14,8 +14,20 @@
         "botEndpoint": {
             "value": ""
         },
+        "appType": {
+          "value": "MultiTenant"
+        },
         "appId": {
             "value": ""
+        },
+        "UMSIName": {
+            "value": ""
+        },
+        "UMSIResourceGroupName": {
+            "value": ""
+        },
+        "tenantId": {
+          "value": ""
         }
     }
 }

--- a/generators/app/templates/empty/{{cookiecutter.bot_name}}/deploymentTemplates/deployUseExistResourceGroup/parameters-for-template-BotApp-with-rg.json
+++ b/generators/app/templates/empty/{{cookiecutter.bot_name}}/deploymentTemplates/deployUseExistResourceGroup/parameters-for-template-BotApp-with-rg.json
@@ -15,7 +15,7 @@
             "value": ""
         },
         "newAppServicePlanLocation": {
-            "value": ""
+            "value": "West US"
         },
         "newAppServicePlanSku": {
             "value": {
@@ -26,10 +26,22 @@
                 "capacity": 1
             }
         },
+        "appType": {
+            "value": "MultiTenant"
+        },
         "appId": {
             "value": ""
         },
         "appSecret": {
+            "value": ""
+        },
+        "tenantId": {
+            "value": ""
+        },
+        "UMSIName": {
+            "value": ""
+        },
+        "UMSIResourceGroupName": {
             "value": ""
         }
     }

--- a/generators/app/templates/empty/{{cookiecutter.bot_name}}/deploymentTemplates/deployUseExistResourceGroup/readme.md
+++ b/generators/app/templates/empty/{{cookiecutter.bot_name}}/deploymentTemplates/deployUseExistResourceGroup/readme.md
@@ -1,28 +1,48 @@
-Need deploy BotAppService before AzureBot
----
-az login
-az deployment group create --resource-group <group-name> --template-file <template-file> --parameters @<parameters-file>
----
+# Usage
+BotApp must be deployed prior to AzureBot.
+
+### Command line:
+`az login`<br>
+`az deployment group create --resource-group <group-name> --template-file <template-file> --parameters @<parameters-file>`
 
 # parameters-for-template-BotApp-with-rg:
 
-**appServiceName**:(required)   The Name of the Bot App Service.
+- **appServiceName**:(required)   The Name of the Bot App Service.
 
-(choose an existingAppServicePlan or create a new AppServicePlan)
-**existingAppServicePlanName**:     The name of the App Service Plan.
-**existingAppServicePlanLocation**: The location of the App Service Plan.
-**newAppServicePlanName**:          The name of the App Service Plan.
-**newAppServicePlanLocation**:      The location of the App Service Plan.
-**newAppServicePlanSku**:           The SKU of the App Service Plan. Defaults to Standard values.
+- (choose an existingAppServicePlan or create a new AppServicePlan)
+  - **existingAppServicePlanName**:     The name of the App Service Plan.
+  - **existingAppServicePlanLocation**: The location of the App Service Plan.
+  - **newAppServicePlanName**:          The name of the App Service Plan.
+  - **newAppServicePlanLocation**:      The location of the App Service Plan.
+  - **newAppServicePlanSku**:           The SKU of the App Service Plan. Defaults to Standard values.
 
-**appId**:(required)                                        Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings.
-**appSecret**:(required)   Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings.
+- **appType**:    Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. **Allowed values are: MultiTenant(default), SingleTenant, UserAssignedMSI.**
+
+- **appId**:(required)                                        Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings.
+
+- **appSecret**:(required for MultiTenant and SingleTenant)   Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings.
+
+- **UMSIName**:(required for UserAssignedMSI)                 The User-Assigned Managed Identity Resource used for the Bot's Authentication.
+
+- **UMSIResourceGroupName**:(required for UserAssignedMSI)    The User-Assigned Managed Identity Resource Group used for the Bot's Authentication.
+
+- **tenantId**:   The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to <Subscription Tenant ID>.
+
+MoreInfo: https://docs.microsoft.com/en-us/azure/bot-service/tutorial-provision-a-bot?view=azure-bot-service-4.0&tabs=userassigned%2Cnewgroup#create-an-identity-resource
+
+
 
 # parameters-for-template-AzureBot-with-rg:
 
-**azureBotId**:(required)           The globally unique and immutable bot ID.
-**azureBotSku**:                    The pricing tier of the Bot Service Registration. **Allowed values are: F0, S1(default)**.
-**azureBotRegion**:                 Specifies the location of the new AzureBot. **Allowed values are: global(default), westeurope**.
-**botEndpoint**:                    Use to handle client messages, Such as https://<botappServiceName>.azurewebsites.net/api/messages.
+- **azureBotId**:(required)           The globally unique and immutable bot ID.
+- **azureBotSku**:                    The pricing tier of the Bot Service Registration. **Allowed values are: F0, S1(default)**.
+- **azureBotRegion**:                 Specifies the location of the new AzureBot. **Allowed values are: global(default), westeurope**.
+- **botEndpoint**:                    Use to handle client messages, Such as https://<botappServiceName>.azurewebsites.net/api/messages.
 
-**appId**:(required)                                        Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings.
+- **appType**:    Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. **Allowed values are: MultiTenant(default), SingleTenant, UserAssignedMSI.**
+- **appId**:(required)                                        Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings.
+- **UMSIName**:(required for UserAssignedMSI)                 The User-Assigned Managed Identity Resource used for the Bot's Authentication.
+- **UMSIResourceGroupName**:(required for UserAssignedMSI)    The User-Assigned Managed Identity Resource Group used for the Bot's Authentication.
+- **tenantId**:   The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to <Subscription Tenant ID>.
+
+MoreInfo: https://docs.microsoft.com/en-us/azure/bot-service/tutorial-provision-a-bot?view=azure-bot-service-4.0&tabs=userassigned%2Cnewgroup#create-an-identity-resource

--- a/generators/app/templates/empty/{{cookiecutter.bot_name}}/deploymentTemplates/deployUseExistResourceGroup/template-AzureBot-with-rg.json
+++ b/generators/app/templates/empty/{{cookiecutter.bot_name}}/deploymentTemplates/deployUseExistResourceGroup/template-AzureBot-with-rg.json
@@ -9,8 +9,8 @@
             }
         },
         "azureBotSku": {
-            "defaultValue": "S1",
             "type": "string",
+            "defaultValue": "S1",
             "metadata": {
                 "description": "The pricing tier of the Bot Service Registration. Allowed values are: F0, S1(default)."
             }
@@ -24,8 +24,21 @@
         },
         "botEndpoint": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
                 "description": "Use to handle client messages, Such as https://<botappServiceName>.azurewebsites.net/api/messages."
+            }
+        },
+        "appType": {
+            "type": "string",
+            "defaultValue": "MultiTenant",
+            "allowedValues": [
+                "MultiTenant",
+                "SingleTenant",
+                "UserAssignedMSI"
+            ],
+            "metadata": {
+                "description": "Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. Allowed values are: MultiTenant, SingleTenant, UserAssignedMSI. Defaults to \"MultiTenant\"."
             }
         },
         "appId": {
@@ -33,6 +46,50 @@
             "metadata": {
                 "description": "Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings."
             }
+        },
+        "UMSIName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource used for the Bot's Authentication."
+            }
+        },
+        "UMSIResourceGroupName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource Group used for the Bot's Authentication."
+            }
+        },
+        "tenantId": {
+            "type": "string",
+            "defaultValue": "[subscription().tenantId]",
+            "metadata": {
+                "description": "The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to \"Subscription Tenant ID\"."
+            }
+        }
+    },
+    "variables": {
+        "botEndpoint": "[if(empty(parameters('botEndpoint')), concat('https://', parameters('azureBotId'), '.azurewebsites.net/api/messages'), parameters('botEndpoint'))]",
+        "tenantId": "[if(empty(parameters('tenantId')), subscription().tenantId, parameters('tenantId'))]",
+        "msiResourceId": "[if(empty(parameters('UMSIName')), '', concat(subscription().id, '/resourceGroups/', parameters('UMSIResourceGroupName'), '/providers/', 'Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('UMSIName')))]",
+        "appTypeDef": {
+            "MultiTenant": {
+              "tenantId": "",
+              "msiResourceId": ""
+            },
+            "SingleTenant": {
+              "tenantId": "[variables('tenantId')]",
+              "msiResourceId": ""
+            },
+            "UserAssignedMSI": {
+              "tenantId": "[variables('tenantId')]",
+              "msiResourceId": "[variables('msiResourceId')]"
+            }
+        },
+        "appType": {
+            "tenantId": "[variables('appTypeDef')[parameters('appType')].tenantId]",
+            "msiResourceId": "[variables('appTypeDef')[parameters('appType')].msiResourceId]"
         }
     },
     "resources": [
@@ -49,8 +106,11 @@
                 "name": "[parameters('azureBotId')]",
                 "displayName": "[parameters('azureBotId')]",
                 "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
-                "endpoint": "[parameters('botEndpoint')]",
+                "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
+                "msaAppTenantId": "[variables('appType').tenantId]",
+                "msaAppMSIResourceId": "[variables('appType').msiResourceId]",
+                "msaAppType": "[parameters('appType')]",
                 "luisAppIds": [],
                 "schemaTransformationVersion": "1.3",
                 "isCmekEnabled": false,

--- a/generators/app/templates/empty/{{cookiecutter.bot_name}}/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/generators/app/templates/empty/{{cookiecutter.bot_name}}/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -4,7 +4,6 @@
     "parameters": {
         "appServiceName": {
             "type": "string",
-            "defaultValue": "",
             "metadata": {
                 "description": "The globally unique name of the Web App."
             }
@@ -18,18 +17,21 @@
         },
         "existingAppServicePlanLocation": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
                 "description": "The location of the App Service Plan."
             }
         },
         "newAppServicePlanName": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
                 "description": "The name of the new App Service Plan."
             }
         },
         "newAppServicePlanLocation": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
                 "description": "The location of the App Service Plan."
             }
@@ -47,6 +49,18 @@
                 "description": "The SKU of the App Service Plan. Defaults to Standard values."
             }
         },
+        "appType": {
+            "type": "string",
+            "defaultValue": "MultiTenant",
+            "allowedValues": [
+                "MultiTenant",
+                "SingleTenant",
+                "UserAssignedMSI"
+            ],
+            "metadata": {
+                "description": "Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. Allowed values are: MultiTenant, SingleTenant, UserAssignedMSI. Defaults to \"MultiTenant\"."
+            }
+        },
         "appId": {
             "type": "string",
             "metadata": {
@@ -59,13 +73,58 @@
             "metadata": {
                 "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Required for MultiTenant and SingleTenant app types. Defaults to \"\"."
             }
+        },
+        "UMSIName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource used for the Bot's Authentication. Defaults to \"\"."
+            }
+        },
+        "UMSIResourceGroupName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource Group used for the Bot's Authentication. Defaults to \"\"."
+            }
+        },
+        "tenantId": {
+            "type": "string",
+            "defaultValue": "[subscription().tenantId]",
+            "metadata": {
+                "description": "The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to \"Subscription Tenant ID\"."
+            }
         }
     },
     "variables": {
-        "defaultAppServicePlanName": "[if(empty(parameters('existingAppServicePlanName')), 'createNewAppServicePlan', parameters('existingAppServicePlanName'))]",
-        "useExistingServicePlan": "[not(equals(variables('defaultAppServicePlanName'), 'createNewAppServicePlan'))]",
+        "tenantId": "[if(empty(parameters('tenantId')), subscription().tenantId, parameters('tenantId'))]",
+        "useExistingServicePlan": "[not(empty(parameters('existingAppServicePlanName')))]",
         "servicePlanName": "[if(variables('useExistingServicePlan'), parameters('existingAppServicePlanName'), parameters('newAppServicePlanName'))]",
-        "servicePlanLocation": "[if(variables('useExistingServicePlan'), parameters('existingAppServicePlanLocation'), parameters('newAppServicePlanLocation'))]"
+        "servicePlanLocation": "[if(variables('useExistingServicePlan'), parameters('existingAppServicePlanLocation'), parameters('newAppServicePlanLocation'))]",
+        "msiResourceId": "[if(empty(parameters('UMSIName')), '', concat(subscription().id, '/resourceGroups/', parameters('UMSIResourceGroupName'), '/providers/', 'Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('UMSIName')))]",
+        "appTypeDef": {
+            "MultiTenant": {
+              "tenantId": "",
+              "identity": { "type": "None" }
+            },
+            "SingleTenant": {
+              "tenantId": "[variables('tenantId')]",
+              "identity": { "type": "None" }
+            },
+            "UserAssignedMSI": {
+              "tenantId": "[variables('tenantId')]",
+              "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentities": {
+                  "[variables('msiResourceId')]": {}
+                }
+              }
+            }
+        },
+        "appType": {
+            "tenantId": "[variables('appTypeDef')[parameters('appType')].tenantId]",
+            "identity": "[variables('appTypeDef')[parameters('appType')].identity]"
+        }
     },
     "resources": [
         {
@@ -89,13 +148,15 @@
             "comments": "Create a Web App using an App Service Plan",
             "type": "Microsoft.Web/sites",
             "apiVersion": "2015-08-01",
-            "name": "[parameters('appServiceName')]",
             "location": "[variables('servicePlanLocation')]",
             "kind": "app,linux",
             "dependsOn": [
                 "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
+            "name": "[parameters('appServiceName')]",
+            "identity": "[variables('appType').identity]",
             "properties": {
+                "name": "[parameters('appServiceName')]",
                 "enabled": true,
                 "hostNameSslStates": [
                     {
@@ -125,12 +186,20 @@
                             "value": "true"
                         },
                         {
+                            "name": "MicrosoftAppType",
+                            "value": "[parameters('appType')]"
+                        },
+                        {
                             "name": "MicrosoftAppId",
                             "value": "[parameters('appId')]"
                         },
                         {
                             "name": "MicrosoftAppPassword",
                             "value": "[parameters('appSecret')]"
+                        },
+                        {
+                            "name": "MicrosoftAppTenantId",
+                            "value": "[variables('appType').tenantId]"
                         }
                     ],
                     "cors": {
@@ -167,7 +236,7 @@
                 "phpVersion": "",
                 "pythonVersion": "",
                 "nodeVersion": "",
-                "linuxFxVersion": "PYTHON|3.7",
+                "linuxFxVersion": "PYTHON|3.9",
                 "requestTracingEnabled": false,
                 "remoteDebuggingEnabled": false,
                 "remoteDebuggingVersion": "VS2017",
@@ -201,7 +270,7 @@
                 "autoHealEnabled": false,
                 "vnetName": "",
                 "minTlsVersion": "1.2",
-                "ftpsState": "AllAllowed",
+                "ftpsState": "Disabled",
                 "reservedInstanceCount": 0
             }
         }

--- a/generators/app/templates/empty/{{cookiecutter.bot_name}}/deploymentTemplates/deployWithNewResourceGroup/parameters-for-template-AzureBot-new-rg.json
+++ b/generators/app/templates/empty/{{cookiecutter.bot_name}}/deploymentTemplates/deployWithNewResourceGroup/parameters-for-template-AzureBot-new-rg.json
@@ -20,7 +20,19 @@
         "botEndpoint": {
             "value": ""
         },
+        "appType": {
+            "value": "MultiTenant"
+        },
         "appId": {
+            "value": ""
+        },
+        "UMSIName": {
+            "value": ""
+        },
+        "UMSIResourceGroupName": {
+            "value": ""
+        },
+        "tenantId": {
             "value": ""
         }
     }

--- a/generators/app/templates/empty/{{cookiecutter.bot_name}}/deploymentTemplates/deployWithNewResourceGroup/parameters-for-template-BotApp-new-rg.json
+++ b/generators/app/templates/empty/{{cookiecutter.bot_name}}/deploymentTemplates/deployWithNewResourceGroup/parameters-for-template-BotApp-new-rg.json
@@ -26,10 +26,22 @@
                 "capacity": 1
             }
         },
+        "appType": {
+            "value": "MultiTenant"
+        },
         "appId": {
             "value": ""
         },
         "appSecret": {
+            "value": ""
+        },
+        "tenantId": {
+            "value": ""
+        },
+        "UMSIName": {
+            "value": ""
+        },
+        "UMSIResourceGroupName": {
             "value": ""
         }
     }

--- a/generators/app/templates/empty/{{cookiecutter.bot_name}}/deploymentTemplates/deployWithNewResourceGroup/readme.md
+++ b/generators/app/templates/empty/{{cookiecutter.bot_name}}/deploymentTemplates/deployWithNewResourceGroup/readme.md
@@ -1,31 +1,45 @@
-Need deploy BotAppService before AzureBot
----
-az login
-az deployment sub create --template-file <template-file> --location <bot-region> --parameters @<parameters-file>
----
+# Usage
+BotApp must be deployed prior to AzureBot.
+
+### Command line:
+`az login`<br>
+`az deployment sub create --template-file <template-file> --location <bot-region> --parameters @<parameters-file>`
 
 # parameters-for-template-BotApp-new-rg:
 
-**groupName**:(required)                Specifies the name of the new Resource Group.
-**groupLocation**:(required)            Specifies the location of the new Resource Group.
+- **groupName**:(required)                Specifies the name of the new Resource Group.
+- **groupLocation**:(required)            Specifies the location of the new Resource Group.
 
-**appServiceName**:(required)           The location of the App Service Plan.
-**appServicePlanName**:(required)       The name of the App Service Plan.
-**appServicePlanLocation**:             The location of the App Service Plan. Defaults to use groupLocation.
-**appServicePlanSku**:                  The SKU of the App Service Plan. Defaults to Standard values.
+- **appServiceName**:(required)           The location of the App Service Plan.
+- **appServicePlanName**:(required)       The name of the App Service Plan.
+- **appServicePlanLocation**:             The location of the App Service Plan. Defaults to use groupLocation.
+- **appServicePlanSku**:                  The SKU of the App Service Plan. Defaults to Standard values.
 
-**appId**:(required)                                        Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings.
-**appSecret**:(required for MultiTenant and SingleTenant)   Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings.
+- **appType**:    Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. **Allowed values are: MultiTenant(default), SingleTenant, UserAssignedMSI.**
+- **appId**:(required)                                        Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings.
+- **appSecret**:(required for MultiTenant and SingleTenant)   Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings.
+- **UMSIName**:(required for UserAssignedMSI)                 The User-Assigned Managed Identity Resource used for the Bot's Authentication.
+- **UMSIResourceGroupName**:(required for UserAssignedMSI)    The User-Assigned Managed Identity Resource Group used for the Bot's Authentication.
+- **tenantId**:   The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to <Subscription Tenant ID>.
+
+MoreInfo: https://docs.microsoft.com/en-us/azure/bot-service/tutorial-provision-a-bot?view=azure-bot-service-4.0&tabs=userassigned%2Cnewgroup#create-an-identity-resource
+
 
 
 # parameters-for-template-AzureBot-new-rg:
 
-**groupName**:(required)            Specifies the name of the new Resource Group.
-**groupLocation**:(required)        Specifies the location of the new Resource Group.
+- **groupName**:(required)            Specifies the name of the new Resource Group.
+- **groupLocation**:(required)        Specifies the location of the new Resource Group.
 
-**azureBotId**:(required)           The globally unique and immutable bot ID. Also used to configure the displayName of the bot, which is mutable.
-**azureBotSku**:                    The pricing tier of the Bot Service Registration. **Allowed values are: F0, S1(default)**.
-**azureBotRegion**:                 Specifies the location of the new AzureBot. **Allowed values are: global(default), westeurope**.
-**botEndpoint**:                    Use to handle client messages, Such as https://<botappServiceName>.azurewebsites.net/api/messages.
+- **azureBotId**:(required)           The globally unique and immutable bot ID. Also used to configure the displayName of the bot, which is mutable.
+- **azureBotSku**:                    The pricing tier of the Bot Service Registration. **Allowed values are: F0, S1(default)**.
+- **azureBotRegion**:                 Specifies the location of the new AzureBot. **Allowed values are: global(default), westeurope**.
+- **botEndpoint**:                    Use to handle client messages, Such as https://<botappServiceName>.azurewebsites.net/api/messages.
 
-**appId**:(required)                                        Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings.
+- **appType**:    Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. **Allowed values are: MultiTenant(default), SingleTenant, UserAssignedMSI.**
+- **appId**:(required)                                        Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings.
+- **UMSIName**:(required for UserAssignedMSI)                 The User-Assigned Managed Identity Resource used for the Bot's Authentication.
+- **UMSIResourceGroupName**:(required for UserAssignedMSI)    The User-Assigned Managed Identity Resource Group used for the Bot's Authentication.
+- **tenantId**:   The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to <Subscription Tenant ID>.
+
+MoreInfo: https://docs.microsoft.com/en-us/azure/bot-service/tutorial-provision-a-bot?view=azure-bot-service-4.0&tabs=userassigned%2Cnewgroup#create-an-identity-resource

--- a/generators/app/templates/empty/{{cookiecutter.bot_name}}/deploymentTemplates/deployWithNewResourceGroup/template-AzureBot-new-rg.json
+++ b/generators/app/templates/empty/{{cookiecutter.bot_name}}/deploymentTemplates/deployWithNewResourceGroup/template-AzureBot-new-rg.json
@@ -41,11 +41,47 @@
                 "description": "Use to handle client messages, Such as https://<botappServiceName>.azurewebsites.net/api/messages."
             }
         },
+        "appType": {
+            "type": "string",
+            "defaultValue": "MultiTenant",
+            "allowedValues": [
+                "MultiTenant",
+                "SingleTenant"
+            ],
+            "metadata": {
+                "description": "Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. Allowed values are: MultiTenant, SingleTenant, UserAssignedMSI. Defaults to \"MultiTenant\"."
+            }
+        },
         "appId": {
             "type": "string",
             "metadata": {
                 "description": "Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings."
             }
+        },
+        "tenantId": {
+            "type": "string",
+            "defaultValue": "[subscription().tenantId]",
+            "metadata": {
+                "description": "The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to \"Subscription Tenant ID\"."
+            }
+        }
+      },
+      "variables": {
+        "botEndpoint": "[if(empty(parameters('botEndpoint')), concat('https://', parameters('azureBotId'), '.azurewebsites.net/api/messages'), parameters('botEndpoint'))]",
+        "tenantId": "[if(empty(parameters('tenantId')), subscription().tenantId, parameters('tenantId'))]",
+        "msiResourceId": "[if(empty(parameters('UMSIName')), '', concat(subscription().id, '/resourceGroups/', parameters('UMSIResourceGroupName'), '/providers/', 'Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('UMSIName')))]",
+        "appTypeDef": {
+            "MultiTenant": {
+              "tenantId": "",
+              "msiResourceId": ""
+            },
+            "SingleTenant": {
+              "tenantId": "[variables('tenantId')]",
+              "msiResourceId": ""
+            }
+        },
+        "appType": {
+            "tenantId": "[variables('appTypeDef')[parameters('appType')].tenantId]"
         }
     },
     "resources": [
@@ -85,8 +121,10 @@
                                 "name": "[parameters('azureBotId')]",
                                 "displayName": "[parameters('azureBotId')]",
                                 "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
-                                "endpoint": "[parameters('botEndpoint')]",
+                                "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
+                                "msaAppTenantId": "[variables('appType').tenantId]",
+                                "msaAppType": "[parameters('appType')]",
                                 "luisAppIds": [],
                                 "schemaTransformationVersion": "1.3",
                                 "isCmekEnabled": false,

--- a/generators/app/templates/empty/{{cookiecutter.bot_name}}/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/generators/app/templates/empty/{{cookiecutter.bot_name}}/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -28,6 +28,7 @@
         },
         "appServicePlanLocation": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
                 "description": "The location of the App Service Plan."
             }
@@ -45,6 +46,25 @@
                 "description": "The SKU of the App Service Plan. Defaults to Standard values."
             }
         },
+        "tenantId": {
+            "type": "string",
+            "defaultValue": "[subscription().tenantId]",
+            "metadata": {
+                "description": "The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to \"Subscription Tenant ID\"."
+            }
+        },
+        "appType": {
+            "type": "string",
+            "defaultValue": "MultiTenant",
+            "allowedValues": [
+                "MultiTenant",
+                "SingleTenant",
+                "UserAssignedMSI"
+            ],
+            "metadata": {
+                "description": "Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. Allowed values are: MultiTenant, SingleTenant, UserAssignedMSI. Defaults to \"MultiTenant\"."
+            }
+        },
         "appId": {
             "type": "string",
             "metadata": {
@@ -53,16 +73,56 @@
         },
         "appSecret": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
-                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Required for MultiTenant and SingleTenant app types."
+                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Required for MultiTenant and SingleTenant app types. Defaults to \"\"."
+            }
+        },
+        "UMSIName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource used for the Bot's Authentication. Defaults to \"\"."
+            }
+        },
+        "UMSIResourceGroupName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource Group used for the Bot's Authentication. Defaults to \"\"."
             }
         }
     },
     "variables": {
+        "tenantId": "[if(empty(parameters('tenantId')), subscription().tenantId, parameters('tenantId'))]",
         "appServicePlanName": "[parameters('appServicePlanName')]",
         "resourcesLocation": "[if(empty(parameters('appServicePlanLocation')), parameters('groupLocation'), parameters('appServicePlanLocation'))]",
         "appServiceName": "[parameters('appServiceName')]",
-        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]"        
+        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]",
+        "msiResourceId": "[if(empty(parameters('UMSIName')), '', concat(subscription().id, '/resourceGroups/', parameters('UMSIResourceGroupName'), '/providers/', 'Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('UMSIName')))]",
+        "appTypeDef": {
+            "MultiTenant": {
+                "tenantId": "",
+                "identity": { "type": "None" }
+            },
+            "SingleTenant": {
+                "tenantId": "[variables('tenantId')]",
+                "identity": { "type": "None" }
+            },
+            "UserAssignedMSI": {
+                "tenantId": "[variables('tenantId')]",
+                "identity": {
+                  "type": "UserAssigned",
+                  "userAssignedIdentities": {
+                    "[variables('msiResourceId')]": {}
+                  }
+                }
+            }
+        },
+        "appType": {
+            "tenantId": "[variables('appTypeDef')[parameters('appType')].tenantId]",
+            "identity": "[variables('appTypeDef')[parameters('appType')].identity]"
+        }
     },
     "resources": [
         {
@@ -114,6 +174,7 @@
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
                             ],
                             "name": "[variables('appServiceName')]",
+                            "identity": "[variables('appType').identity]",
                             "properties": {
                                 "name": "[variables('appServiceName')]",
                                 "hostNameSslStates": [
@@ -136,12 +197,19 @@
                                             "value": "true"
                                         },
                                         {
+                                            "name": "MicrosoftAppType",
+                                            "value": "[parameters('appType')]"
+                                        },                    {
                                             "name": "MicrosoftAppId",
                                             "value": "[parameters('appId')]"
                                         },
                                         {
                                             "name": "MicrosoftAppPassword",
                                             "value": "[parameters('appSecret')]"
+                                        },
+                                        {
+                                            "name": "MicrosoftAppTenantId",
+                                            "value": "[variables('appType').tenantId]"
                                         }
                                     ],
                                     "cors": {
@@ -179,7 +247,7 @@
                                 "phpVersion": "",
                                 "pythonVersion": "",
                                 "nodeVersion": "",
-                                "linuxFxVersion": "PYTHON|3.7",
+                                "linuxFxVersion": "PYTHON|3.9",
                                 "requestTracingEnabled": false,
                                 "remoteDebuggingEnabled": false,
                                 "remoteDebuggingVersion": "VS2017",
@@ -213,7 +281,7 @@
                                 "autoHealEnabled": false,
                                 "vnetName": "",
                                 "minTlsVersion": "1.2",
-                                "ftpsState": "AllAllowed",
+                                "ftpsState": "Disabled",
                                 "reservedInstanceCount": 0
                             }
                         }


### PR DESCRIPTION
Fixes #2187

## Description
Added missing parameters: `appType`, `UMSIName`, `UMSIResourceGroupName`, and `tenantId` to the ARM template for Python bot deployment.

## Specific Changes
  - Added missing parameters: `appType`, `UMSIName`, `UMSIResourceGroupName`, and `tenantId` in `parameters-for-template-AzureBot-with-rg.json`
  - Updated `readme.md`

