### PR TITLE
Port: feat: Support for SharePoint (Viva) Adaptive Card Extension

### DIFF
--- a/libraries/botbuilder-core/botbuilder/core/serializer_helper.py
+++ b/libraries/botbuilder-core/botbuilder/core/serializer_helper.py
@@ -9,6 +9,7 @@ from msrest.serialization import Model, Deserializer, Serializer
 
 import botbuilder.schema as schema
 import botbuilder.schema.teams as teams_schema
+import botbuilder.schema.sharepoint as sharepoint_schema
 
 DEPENDICIES = [
     schema_cls
@@ -18,6 +19,11 @@ DEPENDICIES = [
 DEPENDICIES += [
     schema_cls
     for key, schema_cls in getmembers(teams_schema)
+    if isinstance(schema_cls, type) and issubclass(schema_cls, (Model, Enum))
+]
+DEPENDICIES += [
+    schema_cls
+    for key, schema_cls in getmembers(sharepoint_schema)
     if isinstance(schema_cls, type) and issubclass(schema_cls, (Model, Enum))
 ]
 DEPENDICIES_DICT = {dependency.__name__: dependency for dependency in DEPENDICIES}

--- a/libraries/botbuilder-core/botbuilder/core/sharepoint/__init__.py
+++ b/libraries/botbuilder-core/botbuilder/core/sharepoint/__init__.py
@@ -1,0 +1,10 @@
+# coding=utf-8
+# --------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+
+from .sharepoint_activity_handler import SharePointActivityHandler
+
+__all__ = ["SharePointActivityHandler"]

--- a/libraries/botbuilder-core/botbuilder/core/sharepoint/sharepoint_activity_handler.py
+++ b/libraries/botbuilder-core/botbuilder/core/sharepoint/sharepoint_activity_handler.py
@@ -43,7 +43,6 @@ class SharePointActivityHandler(ActivityHandler):
                 raise NotImplementedError()
 
             if turn_context.activity.name == "cardExtension/getCardView":
-                print("Printing AceReq", turn_context.activity.value)
                 return self._create_invoke_response(
                     await self.on_sharepoint_task_get_card_view(
                         turn_context,

--- a/libraries/botbuilder-core/botbuilder/core/sharepoint/sharepoint_activity_handler.py
+++ b/libraries/botbuilder-core/botbuilder/core/sharepoint/sharepoint_activity_handler.py
@@ -1,0 +1,179 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+# pylint: disable=too-many-lines
+
+from http import HTTPStatus
+from botbuilder.core import ActivityHandler, InvokeResponse
+from botbuilder.core.activity_handler import _InvokeResponseException
+from botbuilder.core.turn_context import TurnContext
+from botbuilder.schema.sharepoint import (
+    AceRequest,
+    BaseHandleActionResponse,
+    CardViewResponse,
+    GetPropertyPaneConfigurationResponse,
+    QuickViewHandleActionResponse,
+    QuickViewResponse,
+)
+from ..serializer_helper import deserializer_helper
+
+
+class SharePointActivityHandler(ActivityHandler):
+    """
+    The SharePointActivityHandler is derived from ActivityHandler. It adds support for
+    SharePoint-specific events and interactions.
+    """
+
+    async def on_invoke_activity(self, turn_context: TurnContext) -> InvokeResponse:
+        """
+        Invoked when an invoke activity is received from the connector.
+        Invoke activities can be used to communicate many different things.
+
+        :param turn_context: A context object for this turn.
+
+        :returns: An InvokeResponse that represents the work queued to execute.
+
+        .. remarks::
+            Invoke activities communicate programmatic commands from a client or channel to a bot.
+            The meaning of an invoke activity is defined by the "invoke_activity.name" property,
+            which is meaningful within the scope of a channel.
+        """
+        try:
+            if not turn_context.activity.name:
+                raise NotImplementedError()
+
+            if turn_context.activity.name == "cardExtension/getCardView":
+                print("Printing AceReq", turn_context.activity.value)
+                return self._create_invoke_response(
+                    await self.on_sharepoint_task_get_card_view(
+                        turn_context,
+                        deserializer_helper(AceRequest, turn_context.activity.value),
+                    )
+                )
+
+            if turn_context.activity.name == "cardExtension/getQuickView":
+                return self._create_invoke_response(
+                    await self.on_sharepoint_task_get_quick_view(
+                        turn_context,
+                        deserializer_helper(AceRequest, turn_context.activity.value),
+                    )
+                )
+
+            if (
+                turn_context.activity.name
+                == "cardExtension/getPropertyPaneConfiguration"
+            ):
+                return self._create_invoke_response(
+                    await self.on_sharepoint_task_get_property_pane_configuration(
+                        turn_context,
+                        deserializer_helper(AceRequest, turn_context.activity.value),
+                    )
+                )
+
+            if (
+                turn_context.activity.name
+                == "cardExtension/setPropertyPaneConfiguration"
+            ):
+                ace_request = deserializer_helper(
+                    AceRequest, turn_context.activity.value
+                )
+                set_prop_pane_config_response = (
+                    await self.on_sharepoint_task_set_property_pane_configuration(
+                        turn_context, ace_request
+                    )
+                )
+                self.validate_set_property_pane_configuration_response(
+                    set_prop_pane_config_response
+                )
+                return self._create_invoke_response(set_prop_pane_config_response)
+
+            if turn_context.activity.name == "cardExtension/handleAction":
+                return self._create_invoke_response(
+                    await self.on_sharepoint_task_handle_action(
+                        turn_context,
+                        deserializer_helper(AceRequest, turn_context.activity.value),
+                    )
+                )
+
+            if turn_context.activity.name == "cardExtension/token":
+                await self.on_sign_in_invoke(turn_context)
+                return self._create_invoke_response()
+
+        except _InvokeResponseException as invoke_exception:
+            return invoke_exception.create_invoke_response()
+        return await super().on_invoke_activity(turn_context)
+
+    async def on_sharepoint_task_get_card_view(
+        self, turn_context: TurnContext, ace_request: AceRequest
+    ) -> CardViewResponse:
+        """
+        Override this in a derived class to provide logic for when a card view is fetched.
+
+        :param turn_context: A context object for this turn.
+        :param ace_request: The ACE invoke request value payload.
+        :returns: A Card View Response for the request.
+        """
+        raise _InvokeResponseException(status_code=HTTPStatus.NOT_IMPLEMENTED)
+
+    async def on_sharepoint_task_get_quick_view(
+        self, turn_context: TurnContext, ace_request: AceRequest
+    ) -> QuickViewResponse:
+        """
+        Override this in a derived class to provide logic for when a quick view is fetched.
+
+        :param turn_context: A strongly-typed context object for this turn.
+        :param ace_request: The ACE invoke request value payload.
+        :returns: A Quick View Response for the request
+        """
+        raise _InvokeResponseException(status_code=HTTPStatus.NOT_IMPLEMENTED)
+
+    async def on_sharepoint_task_get_property_pane_configuration(
+        self, turn_context: TurnContext, ace_request: AceRequest
+    ) -> GetPropertyPaneConfigurationResponse:
+        """
+        Override this in a derived class to provide logic for getting configuration pane properties.
+
+        :param turn_context: A strongly-typed context object for this turn.
+        :param ace_request: The ACE invoke request value payload.
+        :returns: A Property Pane Configuration Response for the request.
+        """
+        raise _InvokeResponseException(status_code=HTTPStatus.NOT_IMPLEMENTED)
+
+    async def on_sharepoint_task_set_property_pane_configuration(
+        self, turn_context: TurnContext, ace_request: AceRequest
+    ) -> BaseHandleActionResponse:
+        """
+        Override this in a derived class to provide logic for setting configuration pane properties.
+
+        :param turn_context: A strongly-typed context object for this turn.
+        :param ace_request: The ACE invoke request value payload.
+        :returns: Card view or no-op action response.
+        """
+        raise _InvokeResponseException(status_code=HTTPStatus.NOT_IMPLEMENTED)
+
+    async def on_sharepoint_task_handle_action(
+        self, turn_context: TurnContext, ace_request: AceRequest
+    ) -> BaseHandleActionResponse:
+        """
+        Override this in a derived class to provide logic for handling ACE actions.
+
+        :param turn_context: A strongly-typed context object for this turn.
+        :param ace_request: The ACE invoke request value payload.
+        :returns: A handle action response..
+        """
+        raise _InvokeResponseException(status_code=HTTPStatus.NOT_IMPLEMENTED)
+
+    def validate_set_property_pane_configuration_response(
+        self, response: BaseHandleActionResponse
+    ):
+        """
+        Validates the response for SetPropertyPaneConfiguration action.
+
+        :param response: The response object.
+        :raises ValueError: If response is of type QuickViewHandleActionResponse.
+        """
+        if isinstance(response, QuickViewHandleActionResponse):
+            raise _InvokeResponseException(
+                HTTPStatus.INTERNAL_SERVER_ERROR,
+                "Response for SetPropertyPaneConfiguration action can't be of QuickView type.",
+            )

--- a/libraries/botbuilder-core/tests/sharepoint/test_sharepoint_activity_handler.py
+++ b/libraries/botbuilder-core/tests/sharepoint/test_sharepoint_activity_handler.py
@@ -1,0 +1,151 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+# pylint: disable=too-many-lines
+import sys
+import os
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from typing import List
+import aiounittest
+from botbuilder.schema.sharepoint import AceRequest
+from botbuilder.core import TurnContext
+from botbuilder.core.sharepoint import SharePointActivityHandler
+from botbuilder.schema import (
+    Activity,
+    ActivityTypes,
+)
+from simple_adapter import SimpleAdapter
+
+
+class TestingSharePointActivityHandler(SharePointActivityHandler):
+    __test__ = False
+
+    def __init__(self):
+        self.record: List[str] = []
+
+    async def on_sharepoint_task_get_card_view(
+        self, turn_context: TurnContext, request: AceRequest
+    ):
+        self.record.append("on_sharepoint_task_get_card_view")
+        return await super().on_sharepoint_task_get_card_view(turn_context, request)
+
+    async def on_sharepoint_task_get_property_pane_configuration(
+        self, turn_context: TurnContext, request: AceRequest
+    ):
+        self.record.append("on_sharepoint_task_get_property_pane_configuration")
+        return await super().on_sharepoint_task_get_property_pane_configuration(
+            turn_context, request
+        )
+
+    async def on_sharepoint_task_get_quick_view(
+        self, turn_context: TurnContext, request: AceRequest
+    ):
+        self.record.append("on_sharepoint_task_get_quick_view")
+        return await super().on_sharepoint_task_get_quick_view(turn_context, request)
+
+    async def on_sharepoint_task_set_property_pane_configuration(
+        self, turn_context: TurnContext, request: AceRequest
+    ):
+        self.record.append("on_sharepoint_task_set_property_pane_configuration")
+        return await super().on_sharepoint_task_set_property_pane_configuration(
+            turn_context, request
+        )
+
+    async def on_sharepoint_task_handle_action(
+        self, turn_context: TurnContext, request: AceRequest
+    ):
+        self.record.append("on_sharepoint_task_handle_action")
+        return await super().on_sharepoint_task_handle_action(turn_context, request)
+
+
+class TestSharePointActivityHandler(aiounittest.AsyncTestCase):
+    async def test_on_sharepoint_task_get_card_view(self):
+        # Arrange
+        activity = Activity(
+            type=ActivityTypes.invoke,
+            name="cardExtension/getCardView",
+            value=AceRequest(),
+        )
+        turn_context = TurnContext(SimpleAdapter(), activity)
+
+        # Act
+        bot = TestingSharePointActivityHandler()
+        await bot.on_turn(turn_context)
+
+        # Assert
+        self.assertEqual(1, len(bot.record))
+        self.assertEqual(bot.record, ["on_sharepoint_task_get_card_view"])
+
+    async def test_on_sharepoint_task_get_property_pane_configuration(self):
+        # Arrange
+        activity = Activity(
+            type=ActivityTypes.invoke,
+            name="cardExtension/getPropertyPaneConfiguration",
+            value=AceRequest(),
+        )
+        turn_context = TurnContext(SimpleAdapter(), activity)
+
+        # Act
+        bot = TestingSharePointActivityHandler()
+        await bot.on_turn(turn_context)
+
+        # Assert
+        self.assertEqual(1, len(bot.record))
+        self.assertEqual(
+            bot.record, ["on_sharepoint_task_get_property_pane_configuration"]
+        )
+
+    async def test_on_sharepoint_task_get_quick_view(self):
+        # Arrange
+        activity = Activity(
+            type=ActivityTypes.invoke,
+            name="cardExtension/getQuickView",
+            value=AceRequest(),
+        )
+        turn_context = TurnContext(SimpleAdapter(), activity)
+
+        # Act
+        bot = TestingSharePointActivityHandler()
+        await bot.on_turn(turn_context)
+
+        # Assert
+        self.assertEqual(1, len(bot.record))
+        self.assertEqual(bot.record, ["on_sharepoint_task_get_quick_view"])
+
+    async def test_on_sharepoint_task_set_property_pane_configuration(self):
+        # Arrange
+        activity = Activity(
+            type=ActivityTypes.invoke,
+            name="cardExtension/setPropertyPaneConfiguration",
+            value=AceRequest(),
+        )
+        turn_context = TurnContext(SimpleAdapter(), activity)
+
+        # Act
+        bot = TestingSharePointActivityHandler()
+        await bot.on_turn(turn_context)
+
+        # Assert
+        self.assertEqual(1, len(bot.record))
+        self.assertEqual(
+            bot.record, ["on_sharepoint_task_set_property_pane_configuration"]
+        )
+
+    async def test_on_sharepoint_task_handle_action(self):
+        # Arrange
+        activity = Activity(
+            type=ActivityTypes.invoke,
+            name="cardExtension/handleAction",
+            value=AceRequest(),
+        )
+        turn_context = TurnContext(SimpleAdapter(), activity)
+
+        # Act
+        bot = TestingSharePointActivityHandler()
+        await bot.on_turn(turn_context)
+
+        # Assert
+        self.assertEqual(1, len(bot.record))
+        self.assertEqual(bot.record, ["on_sharepoint_task_handle_action"])

--- a/libraries/botbuilder-schema/botbuilder/schema/sharepoint/__init__.py
+++ b/libraries/botbuilder-schema/botbuilder/schema/sharepoint/__init__.py
@@ -1,0 +1,24 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+
+from .ace_data import AceData
+from .ace_request import AceRequest
+from .card_view_response import CardViewResponse
+from .quick_view_response import QuickViewResponse
+from .get_property_pane_configuration_response import (
+    GetPropertyPaneConfigurationResponse,
+)
+from .handle_action_response import BaseHandleActionResponse
+from .handle_action_response import QuickViewHandleActionResponse
+
+
+__all__ = [
+    "AceData",
+    "AceRequest",
+    "CardViewResponse",
+    "QuickViewResponse",
+    "GetPropertyPaneConfigurationResponse",
+    "BaseHandleActionResponse",
+    "QuickViewHandleActionResponse",
+]

--- a/libraries/botbuilder-schema/botbuilder/schema/sharepoint/ace_data.py
+++ b/libraries/botbuilder-schema/botbuilder/schema/sharepoint/ace_data.py
@@ -1,0 +1,74 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+from enum import Enum
+from typing import Optional
+from msrest.serialization import Model
+
+
+class AceCardSize(str, Enum):
+    """
+    This enum contains the different types of card templates available in the SPFx framework.
+    """
+
+    MEDIUM = "Medium"
+    LARGE = "Large"
+
+
+class AceData(Model):
+    """
+    SharePoint Ace Data object.
+
+    :param card_size: The size of the card.
+    :type card_size: AceCardSize
+    :param data_version: The version of the data.
+    :type data_version: str
+    :param id: The ID of the card.
+    :type id: str
+    :param title: The title of the card.
+    :type title: str
+    :param description: The description of the card.
+    :type description: str
+    :param icon_property: The icon property of the card.
+    :type icon_property: str
+    :param is_visible: A flag indicating whether the card is visible.
+    :type is_visible: bool
+    :param properties: The properties of the card.
+    :type properties: object
+
+
+    """
+
+    _attribute_map = {
+        "card_size": {"key": "cardSize", "type": "AceCardSize"},
+        "data_version": {"key": "dataVersion", "type": "str"},
+        "id": {"key": "id", "type": "str"},
+        "title": {"key": "title", "type": "str"},
+        "description": {"key": "description", "type": "str"},
+        "icon_property": {"key": "iconProperty", "type": "str"},
+        "is_visible": {"key": "isVisible", "type": "bool"},
+        "properties": {"key": "properties", "type": "object"},
+    }
+
+    def __init__(
+        self,
+        *,
+        card_size: AceCardSize = None,
+        data_version: str = None,
+        id: str = None,
+        title: str = None,
+        description: str = None,
+        icon_property: str = None,
+        is_visible: Optional[bool] = None,
+        properties: object = None,
+        **kwargs
+    ) -> None:
+        super(AceData, self).__init__(**kwargs)
+        self.card_size = card_size
+        self.data_version = data_version
+        self.id = id
+        self.title = title
+        self.description = description
+        self.icon_property = icon_property
+        self.is_visible = is_visible
+        self.properties = properties

--- a/libraries/botbuilder-schema/botbuilder/schema/sharepoint/ace_request.py
+++ b/libraries/botbuilder-schema/botbuilder/schema/sharepoint/ace_request.py
@@ -1,0 +1,27 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+from msrest.serialization import Model
+
+
+class AceRequest(Model):
+    """
+    SharePoint Ace Request object.
+
+    :param data: The data of the request.
+    :type data: object
+    :param properties: The properties of the card.
+    :type properties: object
+    """
+
+    _attribute_map = {
+        "data": {"key": "data", "type": "object"},
+        "properties": {"key": "properties", "type": "object"},
+    }
+
+    def __init__(
+        self, *, data: object = None, properties: object = None, **kwargs
+    ) -> None:
+        super(AceRequest, self).__init__(**kwargs)
+        self.data = data
+        self.properties = properties

--- a/libraries/botbuilder-schema/botbuilder/schema/sharepoint/actions/__init__.py
+++ b/libraries/botbuilder-schema/botbuilder/schema/sharepoint/actions/__init__.py
@@ -1,0 +1,6 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+from .card_action import CardAction, OnCardSelectionAction
+
+__all__ = ["CardAction", "OnCardSelectionAction"]

--- a/libraries/botbuilder-schema/botbuilder/schema/sharepoint/actions/card_action.py
+++ b/libraries/botbuilder-schema/botbuilder/schema/sharepoint/actions/card_action.py
@@ -1,0 +1,375 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+from enum import Enum
+from typing import Dict, List
+from msrest.serialization import Model
+
+
+class ConfirmationDialog(Model):
+    """
+    SharePoint Confirmation Dialog option that is passed through `Submit` Action is executed.
+
+    :param title: Title of the type.
+    :type title: str
+    :param message: Message of the type.
+    :type message: str
+    """
+
+    _attribute_map = {
+        "title": {"key": "title", "type": "str"},
+        "message": {"key": "message", "type": "str"},
+    }
+
+    def __init__(self, *, title: str = None, message: str = None, **kwargs) -> None:
+        super(ConfirmationDialog, self).__init__(**kwargs)
+        self.title = title
+        self.message = message
+
+
+class Location(Model):
+    """
+    Sharepoint Location object.
+
+    :param latitude: Latitude of the location of type.
+    :type latitude: int
+    :param longitude: Longitude of the location of type.
+    :type longitude: int
+    :param timestamp: Timestamp of the location of type.
+    :type timestamp: int
+    :param accuracy: Accuracy of the location of type.
+    :type accuracy: int
+    """
+
+    _attribute_map = {
+        "latitude": {"key": "latitude", "type": "int"},
+        "longitude": {"key": "longitude", "type": "int"},
+        "timestamp": {"key": "timestamp", "type": "int"},
+        "accuracy": {"key": "accuracy", "type": "int"},
+    }
+
+    def __init__(
+        self,
+        *,
+        latitude: int = None,
+        longitude: int = None,
+        timestamp: int = None,
+        accuracy: int = None,
+        **kwargs
+    ) -> None:
+        super(Location, self).__init__(**kwargs)
+        self.latitude = latitude
+        self.longitude = longitude
+        self.timestamp = timestamp
+        self.accuracy = accuracy
+
+
+class MediaTypeOption(Enum):
+    """
+    This enum contains the different types of media that can be selected.
+    """
+
+    Image = 1
+    Audio = 4
+    Document = 8
+
+
+class SelectMediaActionParameters(Model):
+    """
+    SharePoint parameters for a select media action.
+
+    :param media_type: The type of media to select.
+    :type media_type: MediaTypeOption
+    :param allow_multiple_capture: Whether to allow multiple files to be captured.
+    :type allow_multiple_capture: bool
+    :param max_size_per_file: The maximum size per file.
+    :type max_size_per_file: int
+    :param supported_file_formats: The supported file formats of select media action of type.
+    :type supported_file_formats: List[str]
+    """
+
+    _attribute_map = {
+        "media_type": {"key": "mediaType", "type": "MediaTypeOption"},
+        "allow_multiple_capture": {"key": "allowMultipleCapture", "type": "bool"},
+        "max_size_per_file": {"key": "maxSizePerFile", "type": "int"},
+        "supported_file_formats": {"key": "supportedFileFormats", "type": "[str]"},
+    }
+
+    def __init__(
+        self,
+        *,
+        media_type: MediaTypeOption = None,
+        allow_multiple_capture: bool = None,
+        max_size_per_file: int = None,
+        supported_file_formats: List[str] = None,
+        **kwargs
+    ) -> None:
+        super(SelectMediaActionParameters, self).__init__(**kwargs)
+        self.media_type = media_type
+        self.allow_multiple_capture = allow_multiple_capture
+        self.max_size_per_file = max_size_per_file
+        self.supported_file_formats = supported_file_formats
+
+
+class QuickViewActionParameters(Model):
+    """
+    SharePoint parameters for an quick view action.
+
+    :param view: The view of the Quick view to open.
+    :type title: str
+    """
+
+    _attribute_map = {
+        "view": {"key": "view", "type": "str"},
+    }
+
+    def __init__(self, *, view: str = None, **kwargs) -> None:
+        super(QuickViewActionParameters, self).__init__(**kwargs)
+        self.view = view
+
+
+class BaseAction(Model):
+    """
+    Base class for all actions.
+    """
+
+    _attribute_map = {
+        "type": {"key": "type", "type": "str"},
+    }
+
+    def __init__(self, *, type: str = None, **kwargs) -> None:
+        super(BaseAction, self).__init__(**kwargs)
+        self.type = type
+
+
+class CardAction(BaseAction):
+    """
+    Type of handler for when a card button is pressed.
+    """
+
+
+class OnCardSelectionAction(BaseAction):
+    """
+    Type of handler for when a card is selected.
+    """
+
+
+class QuickViewAction(CardAction, OnCardSelectionAction):
+    """
+    SharePoint Quick view action.
+
+    :param type: Type of the action.
+    :type type: str
+    :param parameters: Parameters for the quick view action.
+    :type parameters: QuickViewActionParameters
+    """
+
+    _attribute_map = {
+        "parameters": {"key": "parameters", "type": "QuickViewActionParameters"},
+    }
+
+    def __init__(
+        self, *, parameters: QuickViewActionParameters = None, **kwargs
+    ) -> None:
+        super(QuickViewAction, self).__init__(type="QuickView", **kwargs)
+        self.parameters = parameters
+
+
+class ExternalLinkActionParameters(Model):
+    """
+    SharePoint parameters for an external link action.
+
+    :param is_teams_deep_link: Whether the link is a Teams deep link.
+    :type is_teams_deep_link: bool
+    :param target: The target of the external link.
+    :type target: str
+    """
+
+    _attribute_map = {
+        "is_teams_deep_link": {"key": "isTeamsDeepLink", "type": "bool"},
+        "target": {"key": "target", "type": "str"},
+    }
+
+    def __init__(
+        self, *, is_teams_deep_link: bool = None, target: str = None, **kwargs
+    ) -> None:
+        super(ExternalLinkActionParameters, self).__init__(**kwargs)
+        self.is_teams_deep_link = is_teams_deep_link
+        self.target = target
+
+
+class ExternalLinkAction(CardAction, OnCardSelectionAction):
+    """
+    SharePoint External link action.
+
+    :param type: Type of the action.
+    :type type: str
+    :param parameters: Parameters for the external link action.
+    :type parameters: ExternalLinkActionParameters
+    """
+
+    _attribute_map = {
+        "parameters": {"key": "parameters", "type": "ExternalLinkActionParameters"},
+    }
+
+    def __init__(
+        self, *, parameters: ExternalLinkActionParameters = None, **kwargs
+    ) -> None:
+        super(ExternalLinkAction, self).__init__(type="ExternalLink", **kwargs)
+        self.parameters = parameters
+
+
+class SubmitAction(CardAction):
+    """
+    SharePoint Submit action.
+
+    :param type: Type of the action.
+    :type type: str
+    :param parameters: The action parameters of type
+    :type parameters: {object}
+    :param dialog: Dialog of the action.
+    :type dialog: ConfirmationDialog
+    """
+
+    _attribute_map = {
+        "parameters": {"key": "parameters", "type": "{object}"},
+        "confirmation_dialog": {
+            "key": "confirmationDialog",
+            "type": "ConfirmationDialog",
+        },
+    }
+
+    def __init__(
+        self,
+        *,
+        parameters: Dict[str, object] = None,
+        dialog: ConfirmationDialog = None,
+        **kwargs
+    ) -> None:
+        super(SubmitAction, self).__init__(type="Submit", **kwargs)
+        self.parameters = parameters
+        self.dialog = dialog
+
+
+class ExecuteAction(CardAction):
+    """
+    SharePoint Execute action.
+
+    :param type: Type of the action.
+    :type type: str
+    :param parameters: The action parameters of type
+    :type parameters: {object}
+    :param verb: The verb associated with this action of type.
+    :type verb: str
+    """
+
+    _attribute_map = {
+        "parameters": {"key": "parameters", "type": "{object}"},
+        "verb": {"key": "verb", "type": "str"},
+    }
+
+    def __init__(
+        self, *, parameters: Dict[str, object] = None, verb: str = None, **kwargs
+    ) -> None:
+        super(ExecuteAction, self).__init__(type="Execute", **kwargs)
+        self.parameters = parameters
+        self.verb = verb
+
+
+class SelectMediaAction(CardAction, OnCardSelectionAction):
+    """
+    SharePoint Select media action.
+
+    :param type: Type of the action.
+    :type type: str
+    :param parameters: Parameters for the select media action.
+    :type parameters: SelectMediaActionParameters
+    """
+
+    _attribute_map = {
+        "parameters": {"key": "parameters", "type": "SelectMediaActionParameters"},
+    }
+
+    def __init__(
+        self, *, parameters: SelectMediaActionParameters = None, **kwargs
+    ) -> None:
+        super(SelectMediaAction, self).__init__(type="VivaAction.SelectMedia", **kwargs)
+        self.parameters = parameters
+
+
+class ShowLocationActionParameters(Model):
+    """
+    SharePoint parameters for a show location action.
+
+    :param location: The location coordinates of type.
+    :type location: Location
+    """
+
+    _attribute_map = {
+        "location_coordinates": {"key": "locationCoordinates", "type": "Location"},
+    }
+
+    def __init__(self, *, location: Location = None, **kwargs) -> None:
+        super(ShowLocationActionParameters, self).__init__(**kwargs)
+        self.location = location
+
+
+class ShowLocationAction(CardAction, OnCardSelectionAction):
+    """
+    SharePoint Show location action.
+
+    :param type: Type of the action.
+    :type type: str
+    :param parameters: Parameters for the show location action.
+    :type parameters: ShowLocationActionParameters
+    """
+
+    _attribute_map = {
+        "parameters": {"key": "parameters", "type": "ShowLocationActionParameters"},
+    }
+
+    def __init__(
+        self, *, parameters: ShowLocationActionParameters = None, **kwargs
+    ) -> None:
+        super(ShowLocationAction, self).__init__(
+            type="VivaAction.ShowLocation", **kwargs
+        )
+        self.parameters = parameters
+
+
+class GetLocationActionParameters(Model):
+    """
+    SharePoint parameters for a get location action.
+
+    :param choose_location_on_map: Whether the location on the map can be chosen of type.
+    :type choose_location_on_map: bool
+    """
+
+    _attribute_map = {
+        "choose_location_on_map": {"key": "chooseLocationOnMap", "type": "bool"},
+    }
+
+    def __init__(self, *, choose_location_on_map: bool = None, **kwargs) -> None:
+        super(GetLocationActionParameters, self).__init__(**kwargs)
+        self.choose_location_on_map = choose_location_on_map
+
+
+class GetLocationAction(CardAction, OnCardSelectionAction):
+    """
+    SharePoint Get location action.
+
+    :param type: Type of the action.
+    :type type: str
+    :param parameters: Parameters for the get location action.
+    :type parameters: GetLocationActionParameters
+    """
+
+    _attribute_map = {
+        "parameters": {"key": "parameters", "type": "GetLocationActionParameters"},
+    }
+
+    def __init__(
+        self, *, parameters: GetLocationActionParameters = None, **kwargs
+    ) -> None:
+        super(GetLocationAction, self).__init__(type="VivaAction.GetLocation", **kwargs)
+        self.parameters = parameters

--- a/libraries/botbuilder-schema/botbuilder/schema/sharepoint/actions/focus_parameters.py
+++ b/libraries/botbuilder-schema/botbuilder/schema/sharepoint/actions/focus_parameters.py
@@ -1,0 +1,41 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+from enum import Enum
+from msrest.serialization import Model
+
+
+class AriaLiveOption(str, Enum):
+    """
+    ARIA live region options.
+    """
+
+    Polite = "polite"
+    """ Polite live region """
+    Assertive = "assertive"
+    """ Assertive live region """
+    Off = "off"
+    """ No live region """
+
+
+class FocusParameters(Model):
+    """
+    Parameters for setting focus on an element in a client action.
+
+    :param focus_target: The focus target of type.
+    :type focus_target: str
+    :param aria_live: The ARIA live region option.
+    :type aria_live: AriaLiveOption
+    """
+
+    _attribute_map = {
+        "focus_target": {"focusTarget": "id", "type": "str"},
+        "aria_live": {"key": "ariaLive", "type": "AriaLiveOption"},
+    }
+
+    def __init__(
+        self, *, focus_target: str = None, aria_live: AriaLiveOption = None, **kwargs
+    ) -> None:
+        super(FocusParameters, self).__init__(**kwargs)
+        self.focus_target = focus_target
+        self.aria_live = aria_live

--- a/libraries/botbuilder-schema/botbuilder/schema/sharepoint/card_view/__init__.py
+++ b/libraries/botbuilder-schema/botbuilder/schema/sharepoint/card_view/__init__.py
@@ -1,0 +1,28 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+from .base_card_component import BaseCardComponent, CardComponentName
+from .card_button_base import CardButtonBase
+from .card_image import CardImage
+from .card_bar_component import CardBarComponent
+from .card_button_component import CardButtonComponent
+from .card_search_box_component import CardSearchBoxComponent
+from .card_search_footer_component import CardSearchFooterComponent
+from .card_text_component import CardTextComponent
+from .card_text_input_component import CardTextInputComponent
+from .card_view_parameters import CardViewParameters
+
+
+__all__ = [
+    "BaseCardComponent",
+    "CardComponentName",
+    "CardBarComponent",
+    "CardButtonComponent",
+    "CardImage",
+    "CardSearchBoxComponent",
+    "CardSearchFooterComponent",
+    "CardTextComponent",
+    "CardTextInputComponent",
+    "CardButtonBase",
+    "CardViewParameters",
+]

--- a/libraries/botbuilder-schema/botbuilder/schema/sharepoint/card_view/base_card_component.py
+++ b/libraries/botbuilder-schema/botbuilder/schema/sharepoint/card_view/base_card_component.py
@@ -1,0 +1,47 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+from enum import Enum
+from msrest.serialization import Model
+
+
+class CardComponentName(str, Enum):
+    """
+    Names of the components allowed in a card view.
+    """
+
+    Text = "Text"
+    """ Text component """
+    CardButton = "CardButton"
+    """ Card button component """
+    CardBar = "CardBar"
+    """ Card bar component """
+    TextInput = "TextInput"
+    """ Text input component """
+    SearchBox = "SearchBox"
+    """ Search box component """
+    SearchFooter = "SearchFooter"
+    """ Search footer component """
+
+
+class BaseCardComponent(Model):
+    """
+    Base class for all card components.
+
+    :param id: The ID of the component.
+    :type id: str
+    :param component_name: The name of the component.
+    :type component_name: CardComponentName
+    """
+
+    _attribute_map = {
+        "id": {"key": "id", "type": "str"},
+        "component_name": {"key": "componentName", "type": "CardComponentName"},
+    }
+
+    def __init__(
+        self, *, id: str = None, component_name: CardComponentName = None, **kwargs
+    ) -> None:
+        super(BaseCardComponent, self).__init__(**kwargs)
+        self.id = id
+        self.component_name = component_name

--- a/libraries/botbuilder-schema/botbuilder/schema/sharepoint/card_view/card_bar_component.py
+++ b/libraries/botbuilder-schema/botbuilder/schema/sharepoint/card_view/card_bar_component.py
@@ -1,0 +1,35 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+from botbuilder.schema.sharepoint.card_view import (
+    BaseCardComponent,
+    CardComponentName,
+    CardImage,
+)
+
+
+class CardBarComponent(BaseCardComponent):
+    """
+    Adaptive Card Extension Card view title area (card bar) component.
+
+    :param component_name: The name of the component.
+    :type component_name: CardComponentName
+    :param title: The title to display.
+    :type title: str
+    :param icon: The icon to display.
+    :type icon: CardImage
+    """
+
+    _attribute_map = {
+        "title": {"key": "title", "type": "str"},
+        "icon": {"key": "icon", "type": "CardImage"},
+    }
+
+    def __init__(
+        self, *, title: str = None, icon: "CardImage" = None, **kwargs
+    ) -> None:
+        super(CardBarComponent, self).__init__(
+            component_name=CardComponentName.CardBar, **kwargs
+        )
+        self.title = title
+        self.icon = icon

--- a/libraries/botbuilder-schema/botbuilder/schema/sharepoint/card_view/card_button_base.py
+++ b/libraries/botbuilder-schema/botbuilder/schema/sharepoint/card_view/card_button_base.py
@@ -1,0 +1,27 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+from msrest.serialization import Model
+from botbuilder.schema.sharepoint.actions.card_action import CardAction
+
+
+class CardButtonBase(Model):
+    """
+    Base properties for the buttons used in different Adaptive Card Extension card view components,
+    such as Text Input, Search Box and Card Button.
+
+    :param action: The action to perform when the button is clicked.
+    :type action: CardAction
+    :param id: The Unique Id of the button.
+    :type id: str
+    """
+
+    _attribute_map = {
+        "action": {"key": "action", "type": "CardAction"},
+        "id": {"key": "id", "type": "str"},
+    }
+
+    def __init__(self, *, action: CardAction = None, id: str = None, **kwargs) -> None:
+        super(CardButtonBase, self).__init__(**kwargs)
+        self.action = action
+        self.id = id

--- a/libraries/botbuilder-schema/botbuilder/schema/sharepoint/card_view/card_button_component.py
+++ b/libraries/botbuilder-schema/botbuilder/schema/sharepoint/card_view/card_button_component.py
@@ -1,0 +1,57 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+from enum import Enum
+from botbuilder.schema.sharepoint.actions.card_action import CardAction
+from botbuilder.schema.sharepoint.card_view import (
+    BaseCardComponent,
+    CardComponentName,
+    CardButtonBase,
+)
+
+
+class CardButtonStyle(str, Enum):
+    """
+    The style of the button.
+    """
+
+    Default = "Default"
+    """ Default style """
+    Positive = "Positive"
+    """ Positive (primary) style. """
+
+
+class CardButtonComponent(BaseCardComponent, CardButtonBase):
+    """
+    Adaptive Card Extension Card view button component.
+
+    :param component_name: The name of the component.
+    :type component_name: CardComponentName
+    :param action: The action to perform when the button is clicked.
+    :type action: CardAction
+    :param title: Text displayed on the button.
+    :type title: str
+    :param style: The style of the button.
+    :type style: CardButtonStyle
+    """
+
+    _attribute_map = {
+        "action": {"key": "action", "type": "CardAction"},
+        "title": {"key": "title", "type": "str"},
+        "style": {"key": "style", "type": "CardButtonStyle"},
+    }
+
+    def __init__(
+        self,
+        *,
+        action: CardAction = None,
+        title: str = None,
+        style: CardButtonStyle = None,
+        **kwargs
+    ) -> None:
+        super(CardButtonComponent, self).__init__(
+            component_name=CardComponentName.CardButton, **kwargs
+        )
+        self.action = action
+        self.title = title
+        self.style = style

--- a/libraries/botbuilder-schema/botbuilder/schema/sharepoint/card_view/card_image.py
+++ b/libraries/botbuilder-schema/botbuilder/schema/sharepoint/card_view/card_image.py
@@ -1,0 +1,27 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+from msrest.serialization import Model
+
+
+class CardImage(Model):
+    """
+    Properties for the image rendered in a card view.
+
+    :param image_url: The URL to display as image or icon.
+    :type image_url: str
+    :param alt_text: The alternate text for the image.
+    :type alt_text: str
+    """
+
+    _attribute_map = {
+        "image_url": {"key": "imageUrl", "type": "str"},
+        "alt_text": {"key": "altText", "type": "str"},
+    }
+
+    def __init__(
+        self, *, alt_text: str = None, image_url: str = None, **kwargs
+    ) -> None:
+        super(CardImage, self).__init__(**kwargs)
+        self.image_url = image_url
+        self.alt_text = alt_text

--- a/libraries/botbuilder-schema/botbuilder/schema/sharepoint/card_view/card_search_box_component.py
+++ b/libraries/botbuilder-schema/botbuilder/schema/sharepoint/card_view/card_search_box_component.py
@@ -1,0 +1,61 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+from botbuilder.schema.sharepoint.card_view import (
+    BaseCardComponent,
+    CardComponentName,
+    CardButtonBase,
+)
+from botbuilder.schema.sharepoint.actions.card_action import CardAction
+
+
+class CardSearchBoxButton(CardButtonBase):
+    """
+    Card Search box button.
+
+    :param action: The action to perform when the button is clicked.
+    :type action: CardAction
+    :param id: The Unique Id of the button.
+    :type id: str
+    """
+
+    _attribute_map = {}
+
+    def __init__(self, *, action: CardAction = None, id: str = None, **kwargs) -> None:
+        super(CardSearchBoxButton, self).__init__(action=action, id=id, **kwargs)
+
+
+class CardSearchBoxComponent(BaseCardComponent):
+    """
+    Adaptive Card Extension Search box component. Represents a search box rendered in the card view.
+
+    :param component_name: The name of the component.
+    :type component_name: CardComponentName
+    :param placeholder: The placeholder text to display in the search box.
+    :type placeholder: str
+    :param default_value: The default value to display in the search box.
+    :type default_value: str
+    :param button: The button to display next to the search box.
+    :type button: CardSearchBoxButton
+    """
+
+    _attribute_map = {
+        "placeholder": {"key": "placeholder", "type": "str"},
+        "default_value": {"key": "defaultValue", "type": "str"},
+        "button": {"key": "button", "type": "CardSearchBoxButton"},
+    }
+
+    def __init__(
+        self,
+        *,
+        placeholder: str = None,
+        default_value: str = None,
+        button: "CardSearchBoxButton" = None,
+        **kwargs
+    ) -> None:
+        super(CardSearchBoxComponent, self).__init__(
+            component_name=CardComponentName.SearchBox, **kwargs
+        )
+        self.placeholder = placeholder
+        self.default_value = default_value
+        self.button = button

--- a/libraries/botbuilder-schema/botbuilder/schema/sharepoint/card_view/card_search_footer_component.py
+++ b/libraries/botbuilder-schema/botbuilder/schema/sharepoint/card_view/card_search_footer_component.py
@@ -1,0 +1,51 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+from botbuilder.schema.sharepoint.card_view import BaseCardComponent, CardComponentName
+from botbuilder.schema.sharepoint.actions import CardAction
+
+
+class CardSearchFooterComponent(BaseCardComponent):
+    """
+    Adaptive Card Extension Search footer component. Represents a footer rendered in the card view.
+
+    :param component_name: The name of the component.
+    :type component_name: CardComponentName
+    :param title: The title to display.
+    :type title: str
+    :param image_url: The URL of the image to display.
+    :type image_url: str
+    :param image_initials: The initials to display on the image.
+    :type image_initials: str
+    :param text: The text to display.
+    :type text: str
+    :param on_selection: The action to perform when the footer is selected.
+    :type on_selection: CardAction
+    """
+
+    _attribute_map = {
+        "title": {"key": "title", "type": "str"},
+        "image_url": {"key": "imageUrl", "type": "str"},
+        "image_initials": {"key": "imageInitials", "type": "str"},
+        "text": {"key": "text", "type": "str"},
+        "on_selection": {"key": "onSelection", "type": "CardAction"},
+    }
+
+    def __init__(
+        self,
+        *,
+        title: str = None,
+        image_url: str = None,
+        image_initials: str = None,
+        text: str = None,
+        on_selection: CardAction = None,
+        **kwargs
+    ) -> None:
+        super(CardSearchFooterComponent, self).__init__(
+            component_name=CardComponentName.SearchFooter, **kwargs
+        )
+        self.title = title
+        self.image_url = image_url
+        self.image_initials = image_initials
+        self.text = text
+        self.on_selection = on_selection

--- a/libraries/botbuilder-schema/botbuilder/schema/sharepoint/card_view/card_text_component.py
+++ b/libraries/botbuilder-schema/botbuilder/schema/sharepoint/card_view/card_text_component.py
@@ -1,0 +1,25 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+from botbuilder.schema.sharepoint.card_view import BaseCardComponent, CardComponentName
+
+
+class CardTextComponent(BaseCardComponent):
+    """
+    Adaptive Card Extension Text component. Represents a text block rendered in the card view.
+
+    :param component_name: The name of the component.
+    :type component_name: CardComponentName
+    :param text: The text to display.
+    :type text: str
+    """
+
+    _attribute_map = {
+        "text": {"key": "text", "type": "str"},
+    }
+
+    def __init__(self, *, text: str = None, **kwargs) -> None:
+        super(CardTextComponent, self).__init__(
+            component_name=CardComponentName.Text, **kwargs
+        )
+        self.text = text

--- a/libraries/botbuilder-schema/botbuilder/schema/sharepoint/card_view/card_text_input_component.py
+++ b/libraries/botbuilder-schema/botbuilder/schema/sharepoint/card_view/card_text_input_component.py
@@ -1,0 +1,93 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+from typing import Union
+from botbuilder.schema.sharepoint.card_view import (
+    BaseCardComponent,
+    CardComponentName,
+    CardImage,
+    CardButtonBase,
+)
+
+
+class CardTextInputIconButton(CardButtonBase):
+    """
+    Card Text Input Icon Button.
+
+    :param icon: The icon to display on the button.
+    :type icon: CardImage
+    """
+
+    _attribute_map = {
+        "icon": {"key": "icon", "type": "CardImage"},
+    }
+
+    def __init__(self, *, icon: "CardImage" = None, **kwargs) -> None:
+        super(CardTextInputIconButton, self).__init__(**kwargs)
+        self.icon = icon
+
+
+class CardTextInputTitleButton(CardButtonBase):
+    """
+    Card Text Input Title Button.
+
+    :param title: The title to display on the button.
+    :type title: str
+    """
+
+    _attribute_map = {
+        "title": {"key": "title", "type": "str"},
+    }
+
+    def __init__(self, *, title: str = None, **kwargs) -> None:
+        super(CardTextInputTitleButton, self).__init__(**kwargs)
+        self.title = title
+
+
+class CardTextInputComponent(BaseCardComponent):
+    """
+    Adaptive Card Extension Text input component. Represents a text input field rendered in the card view.
+
+    :param component_name: The name of the component.
+    :type component_name: CardComponentName
+    :param placeholder: The placeholder text to display in the text input field.
+    :type placeholder: str
+    :param default_value: The default value to display in the text input field.
+    :type default_value: str
+    :param button: The button to display next to the text input field.
+    :type button: CardTextInputIconButton or CardTextInputTitleButton
+    :param icon_before: The icon to display before the text input field.
+    :type icon_before: CardImage
+    :param icon_after: The icon to display after the text input field.
+    :type icon_after: CardImage
+    """
+
+    _attribute_map = {
+        "placeholder": {"key": "placeholder", "type": "str"},
+        "default_value": {"key": "defaultValue", "type": "str"},
+        "button": {
+            "key": "button",
+            "type": "CardTextInputIconButton or CardTextInputTitleButton",
+        },
+        "icon_before": {"key": "iconBefore", "type": "CardImage"},
+        "icon_after": {"key": "iconAfter", "type": "CardImage"},
+    }
+
+    def __init__(
+        self,
+        *,
+        placeholder: str = None,
+        default_value: str = None,
+        button: Union["CardTextInputIconButton", "CardTextInputTitleButton"] = None,
+        icon_before: "CardImage" = None,
+        icon_after: "CardImage" = None,
+        **kwargs
+    ) -> None:
+        super(CardTextInputComponent, self).__init__(
+            component_name=CardComponentName.TextInput, **kwargs
+        )
+        self.placeholder = placeholder
+        self.default_value = default_value
+        self.button = button
+        self.icon_before = icon_before
+        self.icon_after = icon_after

--- a/libraries/botbuilder-schema/botbuilder/schema/sharepoint/card_view/card_view_parameters.py
+++ b/libraries/botbuilder-schema/botbuilder/schema/sharepoint/card_view/card_view_parameters.py
@@ -1,0 +1,224 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+from typing import List
+from msrest.serialization import Model
+from botbuilder.schema.sharepoint.card_view import (
+    BaseCardComponent,
+    CardBarComponent,
+    CardButtonComponent,
+    CardImage,
+    CardSearchBoxComponent,
+    CardSearchFooterComponent,
+    CardTextComponent,
+    CardTextInputComponent,
+)
+
+
+class CardViewParameters(Model):
+    """
+    Adaptive Card Extension Card View Parameters.
+
+    :param card_view_type: The type of card view.
+    :type card_view_type: str
+    :param image: The image to display on the card view.
+    :type image: CardImage
+    :param card_bar: The card bar to display on the card view.
+    :type card_bar: list[CardBarComponent]
+    :param header: The header to display on the card view.
+    :type header: list[BaseCardComponent]
+    :param body: The body to display on the card view.
+    :type body: list[BaseCardComponent]
+    :param footer: The footer to display on the card view.
+    :type footer: list[BaseCardComponent]
+    """
+
+    _attribute_map = {
+        "card_view_type": {"key": "cardViewType", "type": "str"},
+        "image": {"key": "image", "type": "CardImage"},
+        "card_bar": {"key": "cardBar", "type": "[CardBarComponent]"},
+        "header": {"key": "header", "type": "[BaseCardComponent]"},
+        "body": {"key": "body", "type": "[BaseCardComponent]"},
+        "footer": {"key": "footer", "type": "[BaseCardComponent]"},
+    }
+
+    def __init__(
+        self,
+        *,
+        card_view_type: str = None,
+        image: CardImage = None,
+        card_bar: List[CardBarComponent] = None,
+        header: List[BaseCardComponent] = None,
+        body: List[BaseCardComponent] = None,
+        footer: List[BaseCardComponent] = None,
+        **kwargs
+    ) -> None:
+        super(CardViewParameters, self).__init__(**kwargs)
+        self.card_view_type = card_view_type
+        self.image = image
+        self.card_bar = card_bar
+        self.header = header
+        self.body = body
+        self.footer = footer
+
+    @staticmethod
+    def basic_card_view_parameters(
+        card_bar: "CardBarComponent",
+        header: "CardTextComponent",
+        footer: List["BaseCardComponent"],
+    ) -> "CardViewParameters":
+        if card_bar is None:
+            raise ValueError("card_bar cannot be None")
+        if header is None:
+            raise ValueError("header cannot be None")
+        CardViewParameters.validate_generic_card_view_footer_configuration(footer)
+
+        return CardViewParameters(
+            card_view_type="text", card_bar=[card_bar], header=[header], footer=footer
+        )
+
+    @staticmethod
+    def primary_text_card_view_parameters(
+        card_bar: "CardBarComponent",
+        header: "CardTextComponent",
+        body: "CardTextComponent",
+        footer: List["BaseCardComponent"],
+    ) -> "CardViewParameters":
+        if card_bar is None:
+            raise ValueError("card_bar cannot be None")
+        if header is None:
+            raise ValueError("header cannot be None")
+        if body is None:
+            raise ValueError("body cannot be None")
+        CardViewParameters.validate_generic_card_view_footer_configuration(footer)
+
+        return CardViewParameters(
+            card_view_type="text",
+            card_bar=[card_bar],
+            header=[header],
+            body=[body],
+            footer=footer,
+        )
+
+    @staticmethod
+    def image_card_view_parameters(
+        card_bar: "CardBarComponent",
+        header: "CardTextComponent",
+        footer: List["BaseCardComponent"],
+        image: "CardImage",
+    ) -> "CardViewParameters":
+        if card_bar is None:
+            raise ValueError("card_bar cannot be None")
+        if header is None:
+            raise ValueError("header cannot be None")
+        if image is None:
+            raise ValueError("image cannot be None")
+        CardViewParameters.validate_generic_card_view_footer_configuration(footer)
+
+        return CardViewParameters(
+            card_view_type="text",
+            card_bar=[card_bar],
+            header=[header],
+            image=image,
+            footer=footer,
+        )
+
+    @staticmethod
+    def text_input_card_view_parameters(
+        card_bar: "CardBarComponent",
+        header: "CardTextComponent",
+        body: "CardTextInputComponent",
+        footer: List["CardButtonComponent"],
+        image: "CardImage" = None,
+    ) -> "CardViewParameters":
+        if card_bar is None:
+            raise ValueError("card_bar cannot be None")
+        if header is None:
+            raise ValueError("header cannot be None")
+        if body is None:
+            raise ValueError("body cannot be None")
+        if len(footer) > 2:
+            raise ValueError("Card view footer must contain up to two buttons.")
+
+        return CardViewParameters(
+            card_view_type="textInput",
+            card_bar=[card_bar],
+            header=[header],
+            body=[body],
+            image=image,
+            footer=footer,
+        )
+
+    @staticmethod
+    def search_card_view_parameters(
+        card_bar: "CardBarComponent",
+        header: "CardTextComponent",
+        body: "CardSearchBoxComponent",
+        footer: "CardSearchFooterComponent",
+    ) -> "CardViewParameters":
+        if card_bar is None:
+            raise ValueError("card_bar cannot be None")
+        if header is None:
+            raise ValueError("header cannot be None")
+        if body is None:
+            raise ValueError("body cannot be None")
+        if footer is None:
+            raise ValueError("footer cannot be None")
+
+        return CardViewParameters(
+            card_view_type="search",
+            card_bar=[card_bar],
+            header=[header],
+            body=[body],
+            footer=[footer],
+        )
+
+    @staticmethod
+    def sign_in_card_view_parameters(
+        card_bar: "CardBarComponent",
+        header: "CardTextComponent",
+        body: "CardTextComponent",
+        footer: "CardButtonComponent",
+    ) -> "CardViewParameters":
+        if card_bar is None:
+            raise ValueError("card_bar cannot be None")
+        if header is None:
+            raise ValueError("header cannot be None")
+        if body is None:
+            raise ValueError("body cannot be None")
+        if footer is None:
+            raise ValueError("footer cannot be None")
+
+        return CardViewParameters(
+            card_view_type="signIn",
+            card_bar=[card_bar],
+            header=[header],
+            body=[body],
+            footer=[footer],
+        )
+
+    @staticmethod
+    def validate_generic_card_view_footer_configuration(
+        footer: List[BaseCardComponent],
+    ) -> None:
+        """
+        Validates the generic card view footer configuration.
+
+        :param footer: The footer to validate.
+        :type footer: list[BaseCardComponent]
+        :raises ValueError: The footer is invalid.
+        """
+        if footer is None or len(footer) == 0:
+            return
+        if len(footer) > 2:
+            raise ValueError(
+                "Card view footer must contain up to two buttons or text input."
+            )
+        if len(footer) == 2 and not all(
+            isinstance(comp, CardButtonComponent) for comp in footer
+        ):
+            raise ValueError("Both footer components must be buttons if there are two.")
+        if len(footer) == 1 and not isinstance(
+            footer[0], (CardButtonComponent, CardTextInputComponent)
+        ):
+            raise ValueError("Single footer component must be a button or text input.")

--- a/libraries/botbuilder-schema/botbuilder/schema/sharepoint/card_view_response.py
+++ b/libraries/botbuilder-schema/botbuilder/schema/sharepoint/card_view_response.py
@@ -1,0 +1,50 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+from msrest.serialization import Model
+from botbuilder.schema.sharepoint import AceData
+from botbuilder.schema.sharepoint.actions import OnCardSelectionAction
+from botbuilder.schema.sharepoint.card_view import CardViewParameters
+
+
+class CardViewResponse(Model):
+    """
+    SharePoint Card View Data object.
+
+    :param ace_date: AceData for the card view of type.
+    :type ace_date: AceData
+    :param card_view_parameters: Card view configuration.
+    :type card_view_parameters: CardViewParameters
+    :param on_card_selection: Action to invoke when the card is selected.
+    :type on_card_selection: OnCardSelectionAction
+    :param view_id: The ID of the view.
+    :type view_id: str
+    """
+
+    _attribute_map = {
+        "ace_date": {"key": "aceDate", "type": "AceData"},
+        "card_view_parameters": {
+            "key": "cardViewParameters",
+            "type": "CardViewParameters",
+        },
+        "on_card_selection": {
+            "key": "onCardSelection",
+            "type": "OnCardSelectionAction",
+        },
+        "view_id": {"key": "viewId", "type": "str"},
+    }
+
+    def __init__(
+        self,
+        *,
+        ace_date: AceData = None,
+        card_view_parameters: CardViewParameters = None,
+        on_card_selection: OnCardSelectionAction = None,
+        view_id: str = None,
+        **kwargs
+    ) -> None:
+        super(CardViewResponse, self).__init__(**kwargs)
+        self.ace_date = ace_date
+        self.card_view_parameters = card_view_parameters
+        self.on_card_selection = on_card_selection
+        self.view_id = view_id

--- a/libraries/botbuilder-schema/botbuilder/schema/sharepoint/get_property_pane_configuration_response.py
+++ b/libraries/botbuilder-schema/botbuilder/schema/sharepoint/get_property_pane_configuration_response.py
@@ -1,0 +1,41 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+from typing import List
+from msrest.serialization import Model
+
+from botbuilder.schema.sharepoint.property_pane_page import PropertyPanePage
+
+
+class GetPropertyPaneConfigurationResponse(Model):
+    """
+    SharePoint ACE get property pane configuration response.
+
+    :param pages: The pages of the property pane configuration.
+    :type pages: list[PropertyPanePage]
+    """
+
+    _attribute_map = {
+        "pages": {"key": "pages", "type": "[PropertyPanePage]"},
+        "current_page": {"key": "currentPage", "type": "int"},
+        "loading_indicator_delay_time": {
+            "key": "loadingIndicatorDelayTime",
+            "type": "int",
+        },
+        "show_loading_indicator": {"key": "showLoadingIndicator", "type": "bool"},
+    }
+
+    def __init__(
+        self,
+        *,
+        pages: List[PropertyPanePage] = None,
+        current_page: int = None,
+        loading_indicator_delay_time: int = None,
+        show_loading_indicator: bool = None,
+        **kwargs
+    ) -> None:
+        super(GetPropertyPaneConfigurationResponse, self).__init__(**kwargs)
+        self.pages = pages if pages is not None else []
+        self.current_page = current_page
+        self.loading_indicator_delay_time = loading_indicator_delay_time
+        self.show_loading_indicator = show_loading_indicator

--- a/libraries/botbuilder-schema/botbuilder/schema/sharepoint/handle_action_response.py
+++ b/libraries/botbuilder-schema/botbuilder/schema/sharepoint/handle_action_response.py
@@ -1,0 +1,108 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+from enum import Enum
+from msrest.serialization import Model
+
+from botbuilder.schema.sharepoint import CardViewResponse, QuickViewResponse
+
+
+class ViewResponseType(str, Enum):
+    """
+    Adaptive Card Extension View response type.
+    """
+
+    Card = "Card"
+    """ Render card view """
+
+    QuickView = "QuickView"
+    """ Render quick view """
+
+    NoOp = "NoOp"
+    """ No operation """
+
+
+class BaseHandleActionResponse(Model):
+    """
+    Response returned when handling a client-side action on an Adaptive Card Extension.
+
+    :param response_type: The type of view response.
+    :type response_type: ViewResponseType
+    :param render_arguments: Arguments to render the view.
+    :type render_arguments: object
+    """
+
+    _attribute_map = {
+        "response_type": {"key": "responseType", "type": "ViewResponseType"},
+        "render_arguments": {"key": "renderArguments", "type": "object"},
+    }
+
+    def __init__(
+        self,
+        *,
+        response_type: ViewResponseType = None,
+        render_arguments: object = None,
+        **kwargs
+    ) -> None:
+        super(BaseHandleActionResponse, self).__init__(**kwargs)
+        self.response_type = response_type
+        self.render_arguments = render_arguments
+
+
+class CardViewHandleActionResponse(BaseHandleActionResponse):
+    """
+    Adaptive Card Extension Client-side action response to render card view..
+
+    :param render_arguments: Arguments to render the view.
+    :type render_arguments: CardViewResponse
+    """
+
+    _attribute_map = {
+        "render_arguments": {"key": "renderArguments", "type": "CardViewResponse"},
+    }
+
+    def __init__(self, *, render_arguments: CardViewResponse = None, **kwargs) -> None:
+        super(CardViewHandleActionResponse, self).__init__(
+            response_type=ViewResponseType.Card, **kwargs
+        )
+        self.render_arguments = render_arguments
+
+
+class QuickViewHandleActionResponse(BaseHandleActionResponse):
+    """
+    Adaptive Card Extension Client-side action response to render quick view.
+
+    :param response_type: The type of view response.
+    :type type: ViewResponseType
+    :param render_arguments: Arguments to render the view.
+    :type render_arguments: QuickViewResponse
+    """
+
+    _attribute_map = {
+        "render_arguments": {"key": "renderArguments", "type": "QuickViewResponse"},
+    }
+
+    def __init__(self, *, render_arguments: QuickViewResponse = None, **kwargs) -> None:
+        super(QuickViewHandleActionResponse, self).__init__(
+            response_type=ViewResponseType.QuickView, **kwargs
+        )
+        self.render_arguments = render_arguments
+
+
+class NoOpHandleActionResponse(BaseHandleActionResponse):
+    """
+    The handle action response for no op.
+
+    :param response_type: The type of view response.
+    :type response_type: ViewResponseType
+    :param render_arguments: Arguments to render the view.
+    :type render_arguments: object
+    """
+
+    _attribute_map = {}
+
+    def __init__(self, **kwargs) -> None:
+        super(NoOpHandleActionResponse, self).__init__(
+            response_type=ViewResponseType.NoOp, **kwargs
+        )
+        self.render_arguments = None

--- a/libraries/botbuilder-schema/botbuilder/schema/sharepoint/property_pane_checkbox_properties.py
+++ b/libraries/botbuilder-schema/botbuilder/schema/sharepoint/property_pane_checkbox_properties.py
@@ -1,0 +1,38 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+from botbuilder.schema.sharepoint.property_pane_field_properties import (
+    PropertyPaneFieldProperties,
+)
+
+
+class PropertyPaneCheckboxProperties(PropertyPaneFieldProperties):
+    """
+    SharePoint property pane checkbox field properties.
+
+    :param text: The text to display next to the checkbox.
+    :type text: str
+    :param disabled: Whether or not the checkbox is disabled.
+    :type disabled: bool
+    :param checked: Whether or not the checkbox is checked.
+    :type checked: bool
+    """
+
+    _attribute_map = {
+        "text": {"key": "text", "type": "str"},
+        "disabled": {"key": "disabled", "type": "bool"},
+        "checked": {"key": "checked", "type": "bool"},
+    }
+
+    def __init__(
+        self,
+        *,
+        text: str = None,
+        disabled: bool = False,
+        checked: bool = None,
+        **kwargs
+    ) -> None:
+        super(PropertyPaneCheckboxProperties, self).__init__(**kwargs)
+        self.text = text
+        self.disabled = disabled
+        self.checked = checked

--- a/libraries/botbuilder-schema/botbuilder/schema/sharepoint/property_pane_choice_group_option.py
+++ b/libraries/botbuilder-schema/botbuilder/schema/sharepoint/property_pane_choice_group_option.py
@@ -1,0 +1,142 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+from typing import List
+from msrest.serialization import Model
+
+from botbuilder.schema.sharepoint.property_pane_field_properties import (
+    PropertyPaneFieldProperties,
+)
+
+
+class PropertyPaneChoiceGroupIconProperties(Model):
+    """
+    SharePoint property pane choice group icon properties.
+
+    :param office_fabric_icon_font_name: The Office Fabric icon font name.
+    :type office_fabric_icon_font_name: str
+    """
+
+    _attribute_map = {
+        "office_fabric_icon_font_name": {
+            "key": "officeFabricIconFontName",
+            "type": "str",
+        },
+    }
+
+    def __init__(self, *, office_fabric_icon_font_name: str = None, **kwargs) -> None:
+        super(PropertyPaneChoiceGroupIconProperties, self).__init__(**kwargs)
+        self.office_fabric_icon_font_name = office_fabric_icon_font_name
+
+
+class PropertyPaneChoiceGroupImageSize(Model):
+    """
+    SharePoint property pane choice group option.
+
+    :param width: The width of the image.
+    :type width: int
+    :param height: The height of the image.
+    :type height: int
+
+    """
+
+    _attribute_map = {
+        "width": {"key": "width", "type": "int"},
+        "height": {"key": "height", "type": "int"},
+    }
+
+    def __init__(self, *, width: int = None, height: int = None, **kwargs) -> None:
+        super(PropertyPaneChoiceGroupImageSize, self).__init__(**kwargs)
+        self.width = width
+        self.height = height
+
+
+class PropertyPaneChoiceGroupOption(Model):
+    """
+    SharePoint property pane choice group option.
+
+    :param aria_label: The aria label of the choice group option.
+    :type aria_label: str
+    :param checked: The checked state of the choice group option.
+    :type checked: bool
+    :param disabled: The disabled state of the choice group option.
+    :type disabled: bool
+    :param icon_props: The icon properties of the choice group option.
+    :type icon_props: PropertyPaneChoiceGroupIconProperties
+    :param image_size: The image size of the choice group option.
+    :type image_size: PropertyPaneChoiceGroupImageSize
+    :param image_src: The image source of the choice group option.
+    :type image_src: str
+    :param key: The key of the choice group option.
+    :type key: str
+    :param text: The text of the choice group option.
+    :type text: str
+    """
+
+    _attribute_map = {
+        "aria_label": {"key": "ariaLabel", "type": "str"},
+        "checked": {"key": "checked", "type": "bool"},
+        "disabled": {"key": "disabled", "type": "bool"},
+        "icon_props": {
+            "key": "iconProps",
+            "type": "PropertyPaneChoiceGroupIconProperties",
+        },
+        "image_size": {"key": "imageSize", "type": "PropertyPaneChoiceGroupImageSize"},
+        "image_src": {"key": "imageSrc", "type": "str"},
+        "key": {"key": "key", "type": "str"},
+        "text": {"key": "text", "type": "str"},
+    }
+
+    def __init__(
+        self,
+        *,
+        aria_label: str = None,
+        checked: bool = False,
+        disabled: bool = False,
+        icon_props: PropertyPaneChoiceGroupIconProperties = None,
+        image_size: PropertyPaneChoiceGroupImageSize = None,
+        image_src: str = None,
+        key: str = None,
+        text: str = None,
+        **kwargs
+    ) -> None:
+        super(PropertyPaneChoiceGroupOption, self).__init__(**kwargs)
+        self.aria_label = aria_label
+        self.checked = checked
+        self.disabled = disabled
+        self.icon_props = icon_props or PropertyPaneChoiceGroupIconProperties()
+        self.image_size = image_size or PropertyPaneChoiceGroupImageSize()
+        self.image_src = image_src
+        self.key = key
+        self.text = text
+
+
+class PropertyPaneChoiceGroupProperties(PropertyPaneFieldProperties):
+    """
+    SharePoint property pane choice group field properties.
+
+    :param aria_label: The aria label of the choice group.
+    :type aria_label: str
+    :param disabled: Indicates whether the choice group is disabled.
+    :type disabled: bool
+    :param options: The options of the choice group.
+    :type options: list[PropertyPaneChoiceGroupOption]
+    :param selected_key: The selected key of the choice group.
+    :type selected_key: str
+    """
+
+    _attribute_map = {
+        "label": {"key": "label", "type": "str"},
+        "options": {"key": "options", "type": "[PropertyPaneChoiceGroupOption]"},
+    }
+
+    def __init__(
+        self,
+        *,
+        label: str = None,
+        options: List[PropertyPaneChoiceGroupOption] = None,
+        **kwargs
+    ) -> None:
+        super(PropertyPaneChoiceGroupProperties, self).__init__(**kwargs)
+        self.label = label
+        self.options = options or []

--- a/libraries/botbuilder-schema/botbuilder/schema/sharepoint/property_pane_dropdown_option.py
+++ b/libraries/botbuilder-schema/botbuilder/schema/sharepoint/property_pane_dropdown_option.py
@@ -1,0 +1,55 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+from enum import IntEnum
+from msrest.serialization import Model
+
+
+class DropDownOptionType(IntEnum):
+    """
+    SharePoint property pane dropdown option type
+    """
+
+    Normal = 0
+    """ The dropdown option is normal. """
+    Divider = 1
+    """ The dropdown option is a divider. """
+    Header = 2
+    """ The dropdown option is a header. """
+
+
+class PropertyPaneDropDownOption(Model):
+    """
+    harePoint property pane drop down option.
+
+    :param index: The index of the drop down option.
+    :type index: int
+    :param key: The key of the drop down option.
+    :type key: str
+    :param text: The text of the drop down option.
+    :type text: str
+    :param type: The type of the drop down option.
+    :type type: DropDownOptionType
+    """
+
+    _attribute_map = {
+        "index": {"key": "index", "type": "int"},
+        "key": {"key": "key", "type": "str"},
+        "text": {"key": "text", "type": "str"},
+        "type": {"key": "type", "type": "DropDownOptionType"},
+    }
+
+    def __init__(
+        self,
+        *,
+        index: int = 0,
+        key: str = "",
+        text: str = "",
+        type: DropDownOptionType = None,
+        **kwargs
+    ) -> None:
+        super(PropertyPaneDropDownOption, self).__init__(**kwargs)
+        self.index = index
+        self.key = key
+        self.text = text
+        self.type = type

--- a/libraries/botbuilder-schema/botbuilder/schema/sharepoint/property_pane_dropdown_properties.py
+++ b/libraries/botbuilder-schema/botbuilder/schema/sharepoint/property_pane_dropdown_properties.py
@@ -1,0 +1,68 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+from typing import List
+
+from botbuilder.schema.sharepoint.property_pane_dropdown_option import (
+    PropertyPaneDropDownOption,
+)
+from botbuilder.schema.sharepoint.property_pane_field_properties import (
+    PropertyPaneFieldProperties,
+)
+
+
+class PropertyPaneDropDownProperties(PropertyPaneFieldProperties):
+    """
+    SharePoint property pane dropdown field properties.
+
+    :param aria_label: The aria label of the dropdown.
+    :type aria_label: str
+    :param aria_position_in_set: The position in the set of the dropdown.
+    :type aria_position_in_set: int
+    :param aria_set_size: The size of the set of the dropdown.
+    :type aria_set_size: int
+    :param label: The label of the dropdown.
+    :type label: str
+    :param disabled: Indicates whether the dropdown is disabled.
+    :type disabled: bool
+    :param error_message: The error message of the dropdown.
+    :type error_message: str
+    :param selected_key: The selected key of the dropdown.
+    :type selected_key: str
+    :param options: The options of the dropdown.
+    :type options: list[PropertyPaneDropDownOption]
+    """
+
+    # Mapping of class attributes to their serialized keys
+    _attribute_map = {
+        "aria_label": {"key": "ariaLabel", "type": "str"},
+        "aria_position_in_set": {"key": "ariaPositionInSet", "type": "int"},
+        "aria_set_size": {"key": "ariaSetSize", "type": "int"},
+        "label": {"key": "label", "type": "str"},
+        "disabled": {"key": "disabled", "type": "bool"},
+        "error_message": {"key": "errorMessage", "type": "str"},
+        "selected_key": {"key": "selectedKey", "type": "str"},
+        "options": {"key": "options", "type": "[PropertyPaneDropDownOption]"},
+    }
+
+    def __init__(
+        self,
+        aria_label: str = "",
+        aria_position_in_set: int = 1,
+        aria_set_size: int = 0,
+        label: str = "",
+        disabled: bool = False,
+        error_message: str = "",
+        selected_key: str = "",
+        options: List[PropertyPaneDropDownOption] = None,
+        **kwargs
+    ) -> None:
+        super(PropertyPaneDropDownProperties, self).__init__(**kwargs)
+        self.aria_label = aria_label
+        self.aria_position_in_set = aria_position_in_set
+        self.aria_set_size = aria_set_size
+        self.label = label
+        self.disabled = disabled
+        self.error_message = error_message
+        self.selected_key = selected_key
+        self.options = options or []

--- a/libraries/botbuilder-schema/botbuilder/schema/sharepoint/property_pane_field_properties.py
+++ b/libraries/botbuilder-schema/botbuilder/schema/sharepoint/property_pane_field_properties.py
@@ -1,0 +1,11 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+from msrest.serialization import Model
+
+
+class PropertyPaneFieldProperties(Model):
+    """
+    SharePoint base property pane field properties
+    keep this empty - used as base type in property group definition
+    """

--- a/libraries/botbuilder-schema/botbuilder/schema/sharepoint/property_pane_group.py
+++ b/libraries/botbuilder-schema/botbuilder/schema/sharepoint/property_pane_group.py
@@ -1,0 +1,43 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+from typing import List
+from botbuilder.schema.sharepoint.property_pane_group_field import (
+    PropertyPaneGroupField,
+)
+from botbuilder.schema.sharepoint.property_pane_group_or_conditional_group import (
+    PropertyPaneGroupOrConditionalGroup,
+)
+
+
+class PropertyPaneGroup(PropertyPaneGroupOrConditionalGroup):
+    """
+    SharePoint property pane group object.
+
+    :param is_expanded: Indicates whether the group is expanded.
+    :type is_expanded: bool
+    :param group_fields: The fields of the group.
+    :type group_fields: list[PropertyPaneFieldProperties]
+    """
+
+    _attribute_map = {
+        "group_fields": {"key": "groupFields", "type": "[PropertyPaneFieldProperties]"},
+        "group_name": {"key": "groupName", "type": "str"},
+        "is_collapsed": {"key": "isCollapsed", "type": "bool"},
+        "is_group_name_hidden": {"key": "isGroupNameHidden", "type": "bool"},
+    }
+
+    def __init__(
+        self,
+        *,
+        group_fields: List["PropertyPaneGroupField"] = None,
+        group_name: str = "",
+        is_collapsed: bool = False,
+        is_group_name_hidden: bool = False,
+        **kwargs
+    ) -> None:
+        super(PropertyPaneGroup, self).__init__(**kwargs)
+        self.group_fields = group_fields
+        self.group_name = group_name
+        self.is_collapsed = is_collapsed
+        self.is_group_name_hidden = is_group_name_hidden

--- a/libraries/botbuilder-schema/botbuilder/schema/sharepoint/property_pane_group_field.py
+++ b/libraries/botbuilder-schema/botbuilder/schema/sharepoint/property_pane_group_field.py
@@ -1,0 +1,62 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+from enum import IntEnum
+from msrest.serialization import Model
+
+from botbuilder.schema.sharepoint.property_pane_field_properties import (
+    PropertyPaneFieldProperties,
+)
+
+
+class FieldType(IntEnum):
+    """
+    SharePoint property pane group field type.
+    """
+
+    CheckBox = 2
+    TextField = 3
+    Toggle = 5
+    Dropdown = 6
+    Label = 7
+    Slider = 8
+    ChoiceGroup = 10
+    HorizontalRule = 12
+    Link = 13
+
+
+class PropertyPaneGroupField(Model):
+    """
+    SharePoint property pane group field.
+
+    :param type: The type of the field.
+    :type type: FieldType
+    :param properties: The properties of the field.
+    :type properties: PropertyPaneFieldProperties
+    :param should_focus: Indicates whether the field should be focused.
+    :type should_focus: bool
+    :param target_property: The target property of the field.
+    :type target_property: str
+    """
+
+    _attribute_map = {
+        "type": {"key": "type", "type": "FieldType"},
+        "properties": {"key": "properties", "type": "PropertyPaneFieldProperties"},
+        "should_focus": {"key": "shouldFocus", "type": "bool"},
+        "target_property": {"key": "targetProperty", "type": "str"},
+    }
+
+    def __init__(
+        self,
+        *,
+        type: FieldType = None,
+        properties: PropertyPaneFieldProperties = None,
+        should_focus: bool = False,
+        target_property: str = None,
+        **kwargs
+    ) -> None:
+        super(PropertyPaneGroupField, self).__init__(**kwargs)
+        self.type = type
+        self.properties = properties
+        self.should_focus = should_focus
+        self.target_property = target_property

--- a/libraries/botbuilder-schema/botbuilder/schema/sharepoint/property_pane_group_or_conditional_group.py
+++ b/libraries/botbuilder-schema/botbuilder/schema/sharepoint/property_pane_group_or_conditional_group.py
@@ -1,0 +1,11 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+from msrest.serialization import Model
+
+
+class PropertyPaneGroupOrConditionalGroup(Model):
+    """
+    SharePoint property pane group or conditional group
+    keep this empty - used as base type in property page definition
+    """

--- a/libraries/botbuilder-schema/botbuilder/schema/sharepoint/property_pane_label_properties.py
+++ b/libraries/botbuilder-schema/botbuilder/schema/sharepoint/property_pane_label_properties.py
@@ -1,0 +1,28 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+from botbuilder.schema.sharepoint.property_pane_field_properties import (
+    PropertyPaneFieldProperties,
+)
+
+
+class PropertyPaneLinkProperties(PropertyPaneFieldProperties):
+    """
+    SharePoint property pane label properties.
+
+    :param text: The text of the link.
+    :type text: str
+    :param required: Indicates whether the link is required.
+    :type required: bool
+    """
+
+    # Mapping of class attributes to their serialized keys
+    _attribute_map = {
+        "text": {"key": "text", "type": "str"},
+        "required": {"key": "required", "type": "bool"},
+    }
+
+    def __init__(self, text: str = None, required: bool = False, **kwargs) -> None:
+        super(PropertyPaneLinkProperties, self).__init__(**kwargs)
+        self.text = text
+        self.required = required

--- a/libraries/botbuilder-schema/botbuilder/schema/sharepoint/property_pane_link_popup_window_properties.py
+++ b/libraries/botbuilder-schema/botbuilder/schema/sharepoint/property_pane_link_popup_window_properties.py
@@ -1,0 +1,62 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+from msrest.serialization import Model
+from enum import IntEnum
+
+
+class PopupWindowPosition(IntEnum):
+    """
+    SharePoint property pane link popup window position
+    """
+
+    Center = 0
+    """ The popup window is displayed at the top. """
+    RightTop = 1
+    """ The popup window is displayed at the right. """
+    LeftTop = 2
+    """ The popup window is displayed at the left. """
+    RightBottom = 3
+    """ The popup window is displayed at the right. """
+    LeftBottom = 4
+    """ The popup window is displayed at the center. """
+
+
+class PropertyPaneLinkPopupWindowProperties(Model):
+    """
+    SharePoint property pane link popup window properties.
+
+    :param height: The height of the popup window.
+    :type height: int
+    :param position_window_position: The position of the popup window.
+    :type position_window_position: PopupWindowPosition
+    :param title: The title of the popup window.
+    :type title: str
+    :param width: The width of the popup window.
+    :type width: int
+    """
+
+    _attribute_map = {
+        "height": {"key": "height", "type": "int"},
+        "position_window_position": {
+            "key": "positionWindowPosition",
+            "type": "PopupWindowPosition",
+        },
+        "title": {"key": "title", "type": "str"},
+        "width": {"key": "width", "type": "int"},
+    }
+
+    def __init__(
+        self,
+        *,
+        height: int = None,
+        position_window_position: PopupWindowPosition = None,
+        title: str = "",
+        width: int = None,
+        **kwargs
+    ) -> None:
+        super(PropertyPaneLinkPopupWindowProperties, self).__init__(**kwargs)
+        self.height = height
+        self.position_window_position = position_window_position
+        self.title = title
+        self.width = width

--- a/libraries/botbuilder-schema/botbuilder/schema/sharepoint/property_pane_link_properties.py
+++ b/libraries/botbuilder-schema/botbuilder/schema/sharepoint/property_pane_link_properties.py
@@ -1,0 +1,63 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+from botbuilder.schema.sharepoint.property_pane_field_properties import (
+    PropertyPaneFieldProperties,
+)
+from botbuilder.schema.sharepoint.property_pane_link_popup_window_properties import (
+    PropertyPaneLinkPopupWindowProperties,
+)
+
+
+class PropertyPaneLinkProperties(PropertyPaneFieldProperties):
+    """
+    SharePoint property pane link field properties.
+
+    :param aria_label: The aria label of the link.
+    :type aria_label: str
+    :param disabled: Indicates whether the link is disabled.
+    :type disabled: bool
+    :param href: The href of the link.
+    :type href: str
+    :param popup_window_props: The popup window properties of the link.
+    :type popup_window_props: PropertyPaneLinkPopupWindowProperties
+    :param target: The target of the link.
+    :type target: str
+    :param text: The text of the link.
+    :type text: str
+    """
+
+    # Mapping of class attributes to their serialized keys
+    _attribute_map = {
+        "aria_label": {"key": "ariaLabel", "type": "str"},
+        "disabled": {"key": "disabled", "type": "bool"},
+        "href": {"key": "href", "type": "str"},
+        "popup_window_props": {
+            "key": "popupWindowProps",
+            "type": "PropertyPaneLinkPopupWindowProperties",
+        },
+        "target": {"key": "target", "type": "str"},
+        "text": {"key": "text", "type": "str"},
+    }
+
+    def __init__(
+        self,
+        aria_label: str = None,
+        disabled: bool = False,
+        href: str = None,
+        popup_window_props: PropertyPaneLinkPopupWindowProperties = None,
+        target: str = None,
+        text: str = None,
+        **kwargs
+    ) -> None:
+        super(PropertyPaneLinkProperties, self).__init__(**kwargs)
+        self.aria_label = aria_label
+        self.disabled = disabled
+        self.href = href
+        self.popup_window_props = (
+            popup_window_props
+            if popup_window_props
+            else PropertyPaneLinkPopupWindowProperties()
+        )
+        self.target = target
+        self.text = text

--- a/libraries/botbuilder-schema/botbuilder/schema/sharepoint/property_pane_page.py
+++ b/libraries/botbuilder-schema/botbuilder/schema/sharepoint/property_pane_page.py
@@ -1,0 +1,47 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+from typing import List
+from msrest.serialization import Model
+
+from botbuilder.schema.sharepoint.property_pane_page_header import (
+    PropertyPanePageHeader,
+)
+from botbuilder.schema.sharepoint.property_pane_group_or_conditional_group import (
+    PropertyPaneGroupOrConditionalGroup,
+)
+
+
+class PropertyPanePage(Model):
+    """
+    SharePoint property pane page.
+
+    :param groups: The groups of the page.
+    :type groups: list[PropertyPaneGroupOrConditionalGroup]
+    :param display_groups_as_accordion: Whether to display the groups as an accordion.
+    :type display_groups_as_accordion: bool
+    :param header: The header of the page.
+    :type header: PropertyPanePageHeader
+    """
+
+    _attribute_map = {
+        "groups": {"key": "groups", "type": "[PropertyPaneGroupOrConditionalGroup]"},
+        "display_groups_as_accordion": {
+            "key": "displayGroupsAsAccordion",
+            "type": "bool",
+        },
+        "header": {"key": "header", "type": "PropertyPanePageHeader"},
+    }
+
+    def __init__(
+        self,
+        *,
+        groups: List[PropertyPaneGroupOrConditionalGroup] = None,
+        display_groups_as_accordion: bool = None,
+        header: PropertyPanePageHeader = None,
+        **kwargs
+    ) -> None:
+        super(PropertyPanePage, self).__init__(**kwargs)
+        self.groups = groups
+        self.display_groups_as_accordion = display_groups_as_accordion
+        self.header = header

--- a/libraries/botbuilder-schema/botbuilder/schema/sharepoint/property_pane_page_header.py
+++ b/libraries/botbuilder-schema/botbuilder/schema/sharepoint/property_pane_page_header.py
@@ -1,0 +1,21 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+from msrest.serialization import Model
+
+
+class PropertyPanePageHeader(Model):
+    """
+    SharePoint property pane page header object.
+
+    :param description: The description of the page header.
+    :type description: str
+    """
+
+    _attribute_map = {
+        "description": {"key": "description", "type": "str"},
+    }
+
+    def __init__(self, *, description: str = None, **kwargs) -> None:
+        super(PropertyPanePageHeader, self).__init__(**kwargs)
+        self.description = description

--- a/libraries/botbuilder-schema/botbuilder/schema/sharepoint/property_pane_slider_properties.py
+++ b/libraries/botbuilder-schema/botbuilder/schema/sharepoint/property_pane_slider_properties.py
@@ -1,0 +1,63 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+from botbuilder.schema.sharepoint.property_pane_field_properties import (
+    PropertyPaneFieldProperties,
+)
+
+
+class PropertyPaneSliderProperties(PropertyPaneFieldProperties):
+    """
+    SharePoint property pane slider properties object.
+
+    :param label: The label of the slider.
+    :type label: str
+    :param value: The value of the slider.
+    :type value: str
+    :param aria_label: Text for screen readers to announce regardless of toggle state.
+    :type aria_label: str
+    :param disabled: Indicates whether the slider is disabled.
+    :type disabled: bool
+    :param max: The maximum value of the slider.
+    :type max: int
+    :param min: The minimum value of the slider.
+    :type min: int
+    :param show_value: Indicates whether to show the value on the right of the slider.
+    :type show_value: bool
+    :param step: The step amount between two adjacent values (defaults to 1).
+    :type step: int
+    """
+
+    # Mapping of class attributes to their serialized keys
+    _attribute_map = {
+        "label": {"key": "label", "type": "str"},
+        "value": {"key": "value", "type": "str"},
+        "aria_label": {"key": "ariaLabel", "type": "str"},
+        "disabled": {"key": "disabled", "type": "bool"},
+        "max": {"key": "max", "type": "int"},
+        "min": {"key": "min", "type": "int"},
+        "show_value": {"key": "showValue", "type": "bool"},
+        "step": {"key": "step", "type": "int"},
+    }
+
+    def __init__(
+        self,
+        label: str = None,
+        value: str = None,
+        aria_label: str = None,
+        disabled: bool = False,
+        max: int = None,
+        min: int = None,
+        show_value: bool = False,
+        step: int = 1,
+        **kwargs
+    ) -> None:
+        super(PropertyPaneSliderProperties, self).__init__(**kwargs)
+        self.label = label
+        self.value = value
+        self.aria_label = aria_label
+        self.disabled = disabled
+        self.max = max
+        self.min = min
+        self.show_value = show_value
+        self.step = step

--- a/libraries/botbuilder-schema/botbuilder/schema/sharepoint/property_pane_text_field_properties.py
+++ b/libraries/botbuilder-schema/botbuilder/schema/sharepoint/property_pane_text_field_properties.py
@@ -1,0 +1,88 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+from botbuilder.schema.sharepoint.property_pane_field_properties import (
+    PropertyPaneFieldProperties,
+)
+
+
+class PropertyPaneTextFieldProperties(PropertyPaneFieldProperties):
+    """
+    SharePoint property pane text field properties.
+
+        :param label: The label of the text field.
+        :type label: str
+        :param value: The value of the text field.
+        :type value: str
+        :param aria_label: Text for screen readers to announce regardless of toggle state.
+        :type aria_label: str
+        :param description: The description of the text field.
+        :type description: str
+        :param disabled: Indicates whether the text field is disabled.
+        :type disabled: bool
+        :param error_message: The error message for the text field.
+        :type error_message: str
+        :param log_name: The name used for logging value changes.
+        :type log_name: str
+        :param max_length: The maximum number of characters allowed in the text field.
+        :type max_length: int
+        :param multiline: Indicates whether the text field is multiline.
+        :type multiline: bool
+        :param placeholder: The placeholder text displayed in the text field.
+        :type placeholder: str
+        :param resizable: Indicates whether the multiline text field is resizable.
+        :type resizable: bool
+        :param rows: The number of rows for a multiline text field.
+        :type rows: int
+        :param underlined: Indicates whether the text field is underlined.
+        :type underlined: bool
+    """
+
+    _attribute_map = {
+        "label": {"key": "label", "type": "str"},
+        "value": {"key": "value", "type": "str"},
+        "aria_label": {"key": "ariaLabel", "type": "str"},
+        "description": {"key": "description", "type": "str"},
+        "disabled": {"key": "disabled", "type": "bool"},
+        "error_message": {"key": "errorMessage", "type": "str"},
+        "log_name": {"key": "logName", "type": "str"},
+        "max_length": {"key": "maxLength", "type": "int"},
+        "multiline": {"key": "multiline", "type": "bool"},
+        "placeholder": {"key": "placeholder", "type": "str"},
+        "resizable": {"key": "resizable", "type": "bool"},
+        "rows": {"key": "rows", "type": "int"},
+        "underlined": {"key": "underlined", "type": "bool"},
+    }
+
+    def __init__(
+        self,
+        *,
+        label: str = None,
+        value: str = None,
+        aria_label: str = None,
+        description: str = None,
+        disabled: bool = False,
+        error_message: str = None,
+        log_name: str = None,
+        max_length: int = None,
+        multiline: bool = False,
+        placeholder: str = None,
+        resizable: bool = False,
+        rows: int = None,
+        underlined: bool = False,
+        **kwargs
+    ) -> None:
+        super(PropertyPaneTextFieldProperties, self).__init__(**kwargs)
+        self.label = label
+        self.value = value
+        self.aria_label = aria_label
+        self.description = description
+        self.disabled = disabled
+        self.error_message = error_message
+        self.log_name = log_name
+        self.max_length = max_length
+        self.multiline = multiline
+        self.placeholder = placeholder
+        self.resizable = resizable
+        self.rows = rows
+        self.underlined = underlined

--- a/libraries/botbuilder-schema/botbuilder/schema/sharepoint/property_pane_toggle_properties.py
+++ b/libraries/botbuilder-schema/botbuilder/schema/sharepoint/property_pane_toggle_properties.py
@@ -1,0 +1,68 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+from botbuilder.schema.sharepoint.property_pane_field_properties import (
+    PropertyPaneFieldProperties,
+)
+
+
+class PropertyPaneToggleProperties(PropertyPaneFieldProperties):
+    """
+    SharePoint property pane toggle properties.
+
+    :param aria_label: The aria label of the toggle.
+    :type aria_label: str
+    :param label: The label of the toggle.
+    :type label: str
+    :param disabled: Indicates whether the toggle is disabled.
+    :type disabled: bool
+    :param checked: Indicates whether the toggle is checked.
+    :type checked: bool
+    :param key: The key of the toggle.
+    :type key: str
+    :param off_text: The text to display when the toggle is off.
+    :type off_text: str
+    :param on_text: The text to display when the toggle is on.
+    :type on_text: str
+    :param off_aria_label: The aria label of the toggle when it is off.
+    :type off_aria_label: str
+    :param on_aria_label: The aria label of the toggle when it is on.
+    :type on_aria_label: str
+    """
+
+    _attribute_map = {
+        "area_label": {"key": "areaLabel", "type": "str"},
+        "label": {"key": "label", "type": "str"},
+        "disabled": {"key": "disabled", "type": "bool"},
+        "checked": {"key": "checked", "type": "bool"},
+        "key": {"key": "key", "type": "str"},
+        "off_text": {"key": "offText", "type": "str"},
+        "on_text": {"key": "onText", "type": "str"},
+        "off_aria_label": {"key": "offAriaLabel", "type": "str"},
+        "on_aria_label": {"key": "onAriaLabel", "type": "str"},
+    }
+
+    def __init__(
+        self,
+        *,
+        aria_label: str = None,
+        label: str = None,
+        disabled: bool = False,
+        checked: bool = False,
+        key: str = None,
+        off_text: str = None,
+        on_text: str = None,
+        off_aria_label: str = None,
+        on_aria_label: str = None,
+        **kwargs
+    ) -> None:
+        super(PropertyPaneToggleProperties, self).__init__(**kwargs)
+        self.aria_label = aria_label
+        self.label = label
+        self.disabled = disabled
+        self.checked = checked
+        self.key = key
+        self.off_text = off_text
+        self.on_text = on_text
+        self.off_aria_label = off_aria_label
+        self.on_aria_label = on_aria_label

--- a/libraries/botbuilder-schema/botbuilder/schema/sharepoint/quick_view_data.py
+++ b/libraries/botbuilder-schema/botbuilder/schema/sharepoint/quick_view_data.py
@@ -1,0 +1,25 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+from msrest.serialization import Model
+
+
+class QuickViewData(Model):
+    """
+    SharePoint Quick View Data.
+
+    :param title: The title of the quick view data.
+    :type title: str
+    :param description: The description of the quick view data.
+    :type description: str
+    """
+
+    _attribute_map = {
+        "title": {"key": "title", "type": "str"},
+        "description": {"key": "description", "type": "str"},
+    }
+
+    def __init__(self, *, title: str = None, description: str = None, **kwargs) -> None:
+        super(QuickViewData, self).__init__(**kwargs)
+        self.title = title
+        self.description = description

--- a/libraries/botbuilder-schema/botbuilder/schema/sharepoint/quick_view_response.py
+++ b/libraries/botbuilder-schema/botbuilder/schema/sharepoint/quick_view_response.py
@@ -1,0 +1,70 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+from msrest.serialization import Model
+
+from botbuilder.schema.sharepoint.actions.card_action import (
+    ExternalLinkActionParameters,
+)
+from botbuilder.schema.sharepoint.actions.focus_parameters import FocusParameters
+from adaptivecards.adaptivecard import AdaptiveCard
+
+
+class QuickViewResponse(Model):
+    """
+    SharePoint Quick View Response object.
+
+    :param data: The data of the quick view.
+    :type data: object
+    :param template: The template of the quick view.
+    :type template: AdaptiveCard
+    :param view_id: The ID of the view.
+    :type view_id: str
+    :param title: The title of the quick view.
+    :type title: str
+    :param external_link: The external link of the quick view.
+    :type external_link: ExternalLinkActionParameters
+    :param focus_parameters: The focus parameters of the quick view.
+    :type focus_parameters: FocusParameters
+    :param requires_sso: The flag to determine if SSO is required.
+    :type requires_sso: bool
+    :param post_sso_view_id: The view ID after SSO.
+    :type post_sso_view_id: str
+    """
+
+    _attribute_map = {
+        "data": {"key": "data", "type": "object"},
+        "template": {"key": "template", "type": "AdaptiveCard"},
+        "view_id": {"key": "viewId", "type": "str"},
+        "title": {"key": "title", "type": "str"},
+        "external_link": {
+            "key": "externalLink",
+            "type": "ExternalLinkActionParameters",
+        },
+        "focus_parameters": {"key": "focusParameters", "type": "FocusParameters"},
+        "requires_sso": {"key": "requiresSso", "type": "bool"},
+        "post_sso_view_id": {"key": "postSsoViewId", "type": "str"},
+    }
+
+    def __init__(
+        self,
+        *,
+        data: object = None,
+        template: "AdaptiveCard" = None,
+        view_id: str = None,
+        title: str = None,
+        external_link: "ExternalLinkActionParameters" = None,
+        focus_parameters: "FocusParameters" = None,
+        requires_sso: bool = False,
+        post_sso_view_id: str = None,
+        **kwargs
+    ) -> None:
+        super(QuickViewResponse, self).__init__(**kwargs)
+        self.data = data
+        self.template = template
+        self.view_id = view_id
+        self.title = title
+        self.external_link = external_link
+        self.focus_parameters = focus_parameters
+        self.requires_sso = requires_sso
+        self.post_sso_view_id = post_sso_view_id

--- a/libraries/botbuilder-schema/requirements.txt
+++ b/libraries/botbuilder-schema/requirements.txt
@@ -1,2 +1,3 @@
 aiounittest==1.3.0
 msrest== 0.7.*
+adaptivecards==0.4.1

--- a/libraries/botbuilder-schema/setup.py
+++ b/libraries/botbuilder-schema/setup.py
@@ -6,10 +6,7 @@ from setuptools import setup
 
 NAME = "botbuilder-schema"
 VERSION = os.environ["packageVersion"] if "packageVersion" in os.environ else "4.17.0"
-REQUIRES = [
-    "msrest== 0.7.*",
-    "urllib3",
-]
+REQUIRES = ["msrest== 0.7.*", "urllib3", "adaptivecards==0.4.1"]
 
 root = os.path.abspath(os.path.dirname(__file__))
 
@@ -30,6 +27,7 @@ setup(
     packages=[
         "botbuilder.schema",
         "botbuilder.schema.teams",
+        "botbuilder.schema.sharepoint",
     ],
     include_package_data=True,
     classifiers=[


### PR DESCRIPTION
Fixes #minor

## Description
Porting changes from [feat: Support for SharePoint (Viva) Adaptive Card Extension  #6695](https://github.com/microsoft/botbuilder-dotnet/pull/6695)

SharePoint Framework is adding a new adaptive card experience (ACE) where it is powered by a Bot. In order to be able to implement the bot we are updating the BotBuilder Framework to natively support these API's to make it easier for end users to add a bot powered ACE.

## Specific Changes
We support 5 new BotInvoke activities:
**`cardExtension/getCardView`**
**`cardExtension/getQuickView`**
**`cardExtension/getPropertyPaneConfiguration`**
**`cardExtension/setPropertyPaneConfiguration`**
**`cardExtension/handleAction`**

The SharePointActivityHandler in **`botbuilder.core`** is the base class for developing a bot powered ACE. Users of this base class will need to implement the following 5 methods:
**`on_sharepoint_task_get_card_view`**
**`on_sharepoint_task_get_quick_view`**
**`on_sharepoint_task_get_property_pane_configuration`**
**`on_sharepoint_task_set_property_pane_configuration`**
**`on_sharepoint_task_handle_action`**

## Testing
Below image shows the new unit tests are passing.
![Tests_SharePoint adaptive card experience](https://github.com/user-attachments/assets/a89bc1a4-451e-4c10-abff-4aaa62bbbec0)
