### PR TITLE
Update remoteDebuggingVersion from VS2017 to VS2022

### DIFF
--- a/generators/app/templates/echo/{{cookiecutter.bot_name}}/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/generators/app/templates/echo/{{cookiecutter.bot_name}}/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -239,7 +239,7 @@
                 "linuxFxVersion": "PYTHON|3.9",
                 "requestTracingEnabled": false,
                 "remoteDebuggingEnabled": false,
-                "remoteDebuggingVersion": "VS2017",
+                "remoteDebuggingVersion": "VS2022",
                 "httpLoggingEnabled": true,
                 "logsDirectorySizeLimit": 35,
                 "detailedErrorLoggingEnabled": false,


### PR DESCRIPTION
Azure App Service now only supports remote debugging using VS2022, and using VS2017 was causing deployment failures. This update changes the remoteDebuggingVersion in the configuration to VS2022, resolving the error:
`"The parameter 'remoteDebuggingVersion' has an invalid value. Details: Supported Versions: VS2022."`