### PR TITLE
Fix Middleware Chain to Allow Awaiting Final Logic Result

### DIFF
--- a/libraries/botbuilder-core/botbuilder/core/turn_context.py
+++ b/libraries/botbuilder-core/botbuilder/core/turn_context.py
@@ -288,20 +288,15 @@ class TurnContext:
 
         async def emit_next(i: int):
             context = self
-            try:
-                if i < len(handlers):
+            if i < len(handlers):
+                try:
+                    return await handlers[i](context, arg, lambda: emit_next(i + 1))
+                except Exception as error:
+                    raise error
+            else:
+                return await logic
 
-                    async def next_handler():
-                        await emit_next(i + 1)
-
-                    await handlers[i](context, arg, next_handler)
-
-            except Exception as error:
-                raise error
-
-        await emit_next(0)
-        # logic does not use parentheses because it's a coroutine
-        return await logic
+        return await emit_next(0)
 
     async def send_trace_activity(
         self, name: str, value: object = None, value_type: str = None, label: str = None

--- a/libraries/botbuilder-core/tests/test_turn_context.py
+++ b/libraries/botbuilder-core/tests/test_turn_context.py
@@ -241,7 +241,7 @@ class TestBotContext(aiounittest.AsyncTestCase):
             assert context is not None
             assert activity.id == activity_id
             assert activity.conversation.id == ACTIVITY.conversation.id
-            await next_handler_coroutine()
+            return await next_handler_coroutine()
 
         context.on_update_activity(update_handler)
         new_activity = MessageFactory.text("test text")


### PR DESCRIPTION
Fixes #2197

## Description
Previously, the middleware chain executed each handler sequentially, but none could await the final logic result. This prevented middlewares from processing the response of the last middleware (which runs the actual logic).

This PR updates the `TurnContext` class in the `botbuilder-core` library to modify the middleware chain handling. The changes ensure that middleware can await the result of the "next" middleware, including the final logic.
This allows for more flexible and powerful middleware handling.

## Specific Changes

### 1. TurnContext Class:
- Modified the `_emit` method to ensure that each middleware can await the result of the next middleware in the chain, including the final logic.
- Updated the `_emit` method to return the result of the logic coroutine correctly.

### 2. Test Cases:
- Updated the `test_update_activity_should_apply_conversation_reference` test case to handle the `ResourceResponse` correctly and ensure the `update_activity` method returns the correct `ResourceResponse`.