### PR TITLE
MentionRemoved fix

### DIFF
--- a/libraries/botbuilder-core/botbuilder/core/turn_context.py
+++ b/libraries/botbuilder-core/botbuilder/core/turn_context.py
@@ -396,9 +396,13 @@ class TurnContext:
         mentions = TurnContext.get_mentions(activity)
         for mention in mentions:
             if mention.additional_properties["mentioned"]["id"] == identifier:
+                replace_text = (
+                    mention.additional_properties.get("text")
+                    or mention.additional_properties.get("mentioned")["name"]
+                )
                 mention_name_match = re.match(
                     r"<at(.*)>(.*?)<\/at>",
-                    escape(mention.additional_properties["text"]),
+                    escape(replace_text),
                     re.IGNORECASE,
                 )
                 if mention_name_match:

--- a/libraries/botbuilder-core/tests/test_turn_context.py
+++ b/libraries/botbuilder-core/tests/test_turn_context.py
@@ -350,6 +350,48 @@ class TestBotContext(aiounittest.AsyncTestCase):
         assert text == " test activity"
         assert activity.text == " test activity"
 
+    def test_should_remove_custom_mention_from_activity(self):
+        activity = Activity(
+            text="Hallo",
+            text_format="plain",
+            type="message",
+            timestamp="2025-03-11T14:16:47.0093935Z",
+            id="1741702606984",
+            channel_id="msteams",
+            service_url="https://smba.trafficmanager.net/emea/REDACTED/",
+            from_property=ChannelAccount(
+                id="29:1J-K4xVh-sLpdwQ-R5GkOZ_TB0W3ec_37p710aH8qe8bITA0zxdgIGc9l-MdDdkdE_jasSfNOeWXyyL1nsrHtBQ",
+                name="",
+                aad_object_id="REDACTED",
+            ),
+            conversation=ConversationAccount(
+                is_group=True,
+                conversation_type="groupChat",
+                tenant_id="REDACTED",
+                id="19:Ql86tXNM2lTBXNKJdqKdwIF9ltGZwpvluLvnJdA0tmg1@thread.v2",
+            ),
+            recipient=ChannelAccount(
+                id="28:c5d5fb56-a1a4-4467-a7a3-1b37905498a0", name="Azure AI Agent"
+            ),
+            entities=[
+                Entity().deserialize(
+                    Mention(
+                        type="mention",
+                        mentioned=ChannelAccount(
+                            id="28:c5d5fb56-a1a4-4467-a7a3-1b37905498a0",
+                            name="Custom Agent",
+                        ),
+                    ).serialize()
+                )
+            ],
+            channel_data={"tenant": {"id": "REDACTED"}, "productContext": "COPILOT"},
+        )
+
+        text = TurnContext.remove_mention_text(activity, activity.recipient.id)
+
+        assert text == "Hallo"
+        assert activity.text == "Hallo"
+
     async def test_should_send_a_trace_activity(self):
         context = TurnContext(SimpleAdapter(), ACTIVITY)
         called = False


### PR DESCRIPTION
Fixes #2210 
This pull request includes changes to the `remove_mention_text` method in `turn_context.py` and adds a new test case in `test_turn_context.py` to ensure the method works correctly with custom mentions.

Improvements to `remove_mention_text` method:

* [`libraries/botbuilder-core/botbuilder/core/turn_context.py`](diffhunk://#diff-e80e0302ba9095fcef94e0004e727e78057cffb08bce12ef4339f05ed6d43e5cR399-R405): Modified the `remove_mention_text` method to handle cases where the mention text is not directly available by using either the `text` or `name` property from `additional_properties`.

Additions to test cases:

* [`libraries/botbuilder-core/tests/test_turn_context.py`](diffhunk://#diff-0aebc3cd5165e7e1ee742045c212d5a38e59a19a6fe57e9726e0d5964f01d530R353-R394): Added a new test case `test_should_remove_custom_mention_from_activity` to verify that the `remove_mention_text` method correctly removes custom mentions from the activity text.