### PR TITLE
Show typing middleware bugfix

### DIFF
--- a/libraries/botbuilder-core/botbuilder/core/adapters/test_adapter.py
+++ b/libraries/botbuilder-core/botbuilder/core/adapters/test_adapter.py
@@ -699,6 +699,7 @@ class TestFlow:
                     reply = adapter.activity_buffer.pop(0)
                     raise RuntimeError(
                         f"TestAdapter.assert_no_reply(): '{reply.text}' is responded when waiting for no reply."
+                        f"(Activity type: {reply.type})"
                     )
 
                 await asyncio.sleep(0.05)

--- a/libraries/botbuilder-core/botbuilder/core/show_typing_middleware.py
+++ b/libraries/botbuilder-core/botbuilder/core/show_typing_middleware.py
@@ -93,12 +93,10 @@ class ShowTypingMiddleware(Middleware):
         ):
             start_interval(context, self._delay, self._period)
 
-        # call the bot logic
-        result = await logic()
-
-        stop_interval()
-
-        return result
+        try:
+            return await logic()
+        finally:
+            stop_interval()
 
     @staticmethod
     def _is_skill_bot(context: TurnContext) -> bool:


### PR DESCRIPTION
Fixes #1980

## Description

The typing middleware creates a long running task that is not cleared 

## Specific Changes

  - The first commit shows a reproducible test of this bug
  - The second commit fixes the bug

## Testing

The tests are added on the first commit.